### PR TITLE
Add Changelog and Release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
           python -m
           build
       - name: Publish distribution to PyPI
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog 1.0.0].
+
+## [Unreleased]
+
+## [Release 1.0.5]
+- Initial tagged release
+
+[unreleased]: TODO
+[release 1.0.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/release-1.0.5
+[keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Caselaw Marklogic API Client
+
+This is an API Client for connecting to Marklogic for The National Archive's Caselaw site.
+
+This package is published on PyPI: https://pypi.org/project/ds-caselaw-marklogic-api-client/
+
+## Making changes
+
+When making a change, update the [changelog](CHANGELOG.md) using the
+[Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) format. Pull
+requests should not be merged before any relevant updates are made.
+
+## Releasing changes
+
+When making a new release, update the [changelog](CHANGELOG.md) in the release
+pull request.
+
+The package will **only** be released to PyPI if the branch is tagged. A merge 
+to main alone will **not** trigger a release to PyPI.
+
+To create a release:
+
+0. Update the version number in `setup.cfg`
+1. Create a branch release/xxx
+2. Update changelog for the release
+3. Commit and push
+4. Open a PR from that branch to main
+5. Get approval on the PR
+6. Tag the HEAD of the PR release-xxx and push the tag
+7. Merge the PR to main and push
+


### PR DESCRIPTION
This package should only be published to PyPI if it is tagged.

Document the release process. Add a changelog.

Amend the github action to only release to PyPI if the branch is tagged.