### PR TITLE
Change XQuery getter/setter methods for document properties to use dl…

### DIFF
--- a/src/caselawclient/xquery/get_property.xqy
+++ b/src/caselawclient/xquery/get_property.xqy
@@ -1,9 +1,12 @@
 xquery version "1.0-ml";
 
+import module namespace dls = "http://marklogic.com/xdmp/dls"
+      at "/MarkLogic/dls.xqy";
+
 declare variable $uri as xs:string external;
 
 declare variable $name as xs:string external;
 
 let $prop := fn:QName("", $name)
 
-return xdmp:document-get-properties($uri, $prop)/text()
+return dls:document-get-properties($uri, $prop)/text()

--- a/src/caselawclient/xquery/set_property.xqy
+++ b/src/caselawclient/xquery/set_property.xqy
@@ -1,9 +1,12 @@
 xquery version "1.0-ml";
 
+import module namespace dls = "http://marklogic.com/xdmp/dls"
+      at "/MarkLogic/dls.xqy";
+
 declare variable $uri as xs:string external;
 declare variable $value as xs:string external;
 declare variable $name as xs:string external;
 
 let $props := ( element {$name}{xs:boolean($value)} )
 
-return xdmp:document-set-properties($uri, $props)
+return dls:document-set-properties($uri, $props)


### PR DESCRIPTION
…s namespace

We are now using the Library Services to manage documents, and their document
properties should be namespaces to `dls`