### PR TITLE
Update API client to use Marklogic Library Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 dist
 venv
 *.egg-info
+.env
+tests/__pycache__/
+src/caselawclient/__pycache__/
+/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Refactor save_judgment_xml to use the eval endpoint, so that we can introduce versioning via na XQuery.
+- List all versions of a managed judgment
+- Get a version of a managed judgment
+- Restrict search to managed judgments only
+- Set properties on a judgment using the dls namespace, not xdmp
+- Insert & manage a new document
+- Check in and check out a document for editing
+- Use document properties on the "original" version of the judgment, not its version, to see if a judgment is published
 
 ## [Release 2.0.1]
 - Minor bugfixes
@@ -16,6 +24,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[unreleased]: TODO
+[unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-2.0.1...HEAD
+[release 2.0.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-2.0.0...release-2.0.1
+[release 2.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-1.0.5...release-2.0.0
 [release 1.0.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/release-1.0.5
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -164,6 +164,21 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "list_judgment_versions.xqy"
+        )
+        vars = {
+            "uri": uri
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
     def eval(
         self, xquery_path, vars, database="Judgments", accept_header="multipart/mixed"
     ):

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -164,6 +164,25 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def insert_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
+        xml = etree.tostring(judgment_xml)
+
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "insert_judgment.xqy"
+        )
+        vars = {
+            "uri": uri,
+            "judgment": xml.decode("utf-8") ,
+            "annotation": ""
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
     def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -198,6 +198,36 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def checkout_judgment(self, judgment_uri: str) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "checkout_judgment.xqy"
+        )
+        vars = {
+            "uri": uri
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
+    def checkin_judgment(self, judgment_uri: str) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "checkin_judgment.xqy"
+        )
+        vars = {
+            "uri": uri
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
     def get_judgment_version(self, judgment_uri: str, version: int) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -145,14 +145,23 @@ class MarklogicApiClient:
         multipart_data = decoder.MultipartDecoder.from_response(response)
         return multipart_data.parts[0].text
 
-    def save_judgment_xml(self, uri: str, judgment_xml: Element) -> requests.Response:
+    def save_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
         xml = etree.tostring(judgment_xml)
-        headers = {"Accept": "text/xml", "Content-type": "application/xml"}
-        return self.make_request(
-            "PUT",
-            f"LATEST/documents?uri=/{uri.lstrip('/')}.xml",
-            headers=headers,
-            body=xml,
+
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "update_judgment.xqy"
+        )
+        vars = {
+            "uri": uri,
+            "judgment": xml.decode("utf-8") ,
+            "annotation": ""
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
         )
 
     def eval(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -116,15 +116,22 @@ class MarklogicApiClient:
     ) -> requests.Response:
         return self.make_request("POST", path, headers, data)
 
-    def get_judgment_xml(self, judgment_uri, show_unpublished=False) -> str:
+    def get_judgment_xml(self, judgment_uri, version_uri=None, show_unpublished=False) -> str:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
+        if version_uri:
+            version_uri = f"/{version_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(
             ROOT_DIR, "xquery", "get_judgment.xqy"
         )
+        vars = {
+            "uri": uri,
+            "version_uri": version_uri,
+            "show_unpublished": str(show_unpublished).lower()
+        }
 
         response = self.eval(
             xquery_path,
-            vars=f'{{"uri":"{uri}", "show_unpublished":{str(show_unpublished).lower()}}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         if not response.text:
@@ -293,12 +300,15 @@ class MarklogicApiClient:
 
         return self.eval(xquery_path, vars)
 
-    def eval_xslt(self, judgment_uri, show_unpublished=False) -> requests.Response:
+    def eval_xslt(self, judgment_uri, version_uri=None, show_unpublished=False) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
+        if version_uri:
+            version_uri = f"/{version_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
 
         vars = json.dumps({
             "uri": uri,
+            "version_uri": version_uri,
             "show_unpublished": str(show_unpublished).lower()
         })
         return self.eval(xquery_path, vars=vars, accept_header="application/xml")

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -179,6 +179,22 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def get_judgment_version(self, judgment_uri: str, version: int) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "get_judgment_version.xqy"
+        )
+        vars = {
+            "uri": uri,
+            "version": str(version)
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
     def eval(
         self, xquery_path, vars, database="Judgments", accept_header="multipart/mixed"
     ):

--- a/src/caselawclient/xquery/checkin_judgment.xqy
+++ b/src/caselawclient/xquery/checkin_judgment.xqy
@@ -1,0 +1,7 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+
+dls:document-checkin($uri, fn:true())

--- a/src/caselawclient/xquery/checkout_judgment.xqy
+++ b/src/caselawclient/xquery/checkout_judgment.xqy
@@ -1,0 +1,8 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $annotation as xs:string external;
+
+dls:document-checkout($uri, fn:true(), $annotation)

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -2,15 +2,19 @@ xquery version "1.0-ml";
 
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
+declare variable $version_uri as xs:string? external;
 
 let $judgment := fn:document($uri)
+let $version := if ($version_uri) then fn:document($version_uri) else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
 
+let $document_to_return := if ($version_uri) then $version else $judgment
+
 let $return_value := if ($show_unpublished) then
-        $judgment
+        $document_to_return
     else if (xs:boolean($is_published)) then
-        $judgment
+        $document_to_return
     else
         ()
 

--- a/src/caselawclient/xquery/get_judgment_version.xqy
+++ b/src/caselawclient/xquery/get_judgment_version.xqy
@@ -1,0 +1,10 @@
+xquery version "1.0-ml";
+
+import module namespace dls="http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $version as xs:string external;
+
+let $version_int := xs:int($version)
+
+return dls:document-version($uri, $version_int)

--- a/src/caselawclient/xquery/insert_judgment.xqy
+++ b/src/caselawclient/xquery/insert_judgment.xqy
@@ -1,0 +1,10 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $judgment as xs:string external;
+
+let $judgment_xml := xdmp:unquote($judgment)
+
+return dls:insert-and-manage($uri, fn:true(), $judgment_xml)

--- a/src/caselawclient/xquery/list_judgment_versions.xqy
+++ b/src/caselawclient/xquery/list_judgment_versions.xqy
@@ -1,0 +1,7 @@
+xquery version "1.0-ml";
+
+import module namespace dls="http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+
+dls:document-version-uris($uri)

--- a/src/caselawclient/xquery/search.xqy
+++ b/src/caselawclient/xquery/search.xqy
@@ -44,7 +44,7 @@ let $query2 := if ($party) then
     ))
 else ()
 let $query4 := if ($court) then cts:or-query((
-    cts:element-value-query(fn:QName('https:/judgments.gov.uk/', 'court'), $court, ('case-insensitive')),
+    cts:element-value-query(fn:QName('https://judgments.gov.uk/', 'court'), $court, ('case-insensitive')),
     cts:element-value-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'court'), $court, ('case-insensitive')),
     cts:element-attribute-word-query(
     fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRuri'), xs:QName('value'), $court, ('case-insensitive')

--- a/src/caselawclient/xquery/search.xqy
+++ b/src/caselawclient/xquery/search.xqy
@@ -1,6 +1,7 @@
 xquery version "1.0-ml";
 
 import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk";
 
@@ -55,7 +56,7 @@ let $query6 := if (empty($from_date)) then () else cts:path-range-query('akn:FRB
 let $query7 := if (empty($to_date)) then () else cts:path-range-query('akn:FRBRWork/akn:FRBRdate/@date', '<=', $to_date)
 let $query8 := if ($show_unpublished) then () else cts:properties-fragment-query(cts:element-value-query(fn:QName("", "published"), "true"))
 
-let $queries := ( $query1, $query2, $query4, $query5, $query6, $query7, $query8 )
+let $queries := ( $query1, $query2, $query4, $query5, $query6, $query7, $query8, dls:documents-query() )
 let $query := cts:and-query($queries)
 
 let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))

--- a/src/caselawclient/xquery/set_property.xqy
+++ b/src/caselawclient/xquery/set_property.xqy
@@ -1,9 +1,11 @@
 xquery version "1.0-ml";
 
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
 declare variable $uri as xs:string external;
 declare variable $value as xs:string external;
 declare variable $name as xs:string external;
 
 let $props := ( element {$name}{xs:boolean($value)} )
 
-return xdmp:document-set-properties($uri, $props)
+return dls:document-set-property($uri, $props)

--- a/src/caselawclient/xquery/update_judgment.xqy
+++ b/src/caselawclient/xquery/update_judgment.xqy
@@ -1,0 +1,17 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls"
+      at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $judgment as xs:string external;
+declare variable $annotation as xs:string external;
+
+let $judgment_xml := xdmp:unquote($judgment)
+
+return dls:document-checkout-update-checkin(
+    $uri,
+    $judgment_xml,
+    $annotation,
+    fn:true()
+)

--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -2,14 +2,18 @@ xquery version "1.0-ml";
 
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
+declare variable $version_uri as xs:string? external;
 
 let $judgment_xml := fn:doc($uri)/element()
+let $version_xml := if ($version_uri) then fn:document($version_uri)/element() else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
 
+let $document_to_transform := if ($version_xml) then $version_xml else $judgment_xml
+
 let $return_value := if (xs:boolean($is_published) or $show_unpublished) then
         xdmp:xslt-invoke('judgments/xslts/judgment2.xsl',
-          $judgment_xml
+          $document_to_transform
         )/element()
     else
         ()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -186,3 +186,37 @@ class ApiClientTest(unittest.TestCase):
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
+
+    def test_get_judgment_version(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            version = '3'
+            expected_vars = {
+                'uri':'/ewca/civ/2004/632.xml',
+                'version':'3'
+            }
+            client.get_judgment_version(uri, version)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'get_judgment_version.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
+    def test_list_judgment_versions(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            expected_vars = {
+                'uri':'/ewca/civ/2004/632.xml'
+            }
+            client.list_judgment_versions(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'list_judgment_versions.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -187,6 +187,26 @@ class ApiClientTest(unittest.TestCase):
                 accept_header="application/xml"
             )
 
+    def test_insert_judgment_xml(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            judgment_str = '<root>My new judgment</root>'
+            judgment_xml = etree.fromstring(judgment_str)
+            expected_vars = {
+                'uri': '/ewca/civ/2004/632.xml',
+                'judgment': judgment_str,
+                'annotation':''
+            }
+            client.insert_judgment_xml(uri, judgment_xml)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'insert_judgment.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
     def test_get_judgment_version(self):
         client = MarklogicApiClient("", "", "", False)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -240,3 +240,35 @@ class ApiClientTest(unittest.TestCase):
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
+
+    def test_checkout_judgment(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            expected_vars = {
+                'uri':'/ewca/civ/2004/632.xml'
+            }
+            client.checkout_judgment(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'checkout_judgment.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
+    def test_checkin_judgment(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            expected_vars = {
+                'uri':'/ewca/civ/2004/632.xml'
+            }
+            client.checkin_judgment(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'checkin_judgment.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -70,6 +70,7 @@ class ApiClientTest(unittest.TestCase):
             uri = "/judgment/uri"
             expected_vars = {
                 "uri": "/judgment/uri.xml",
+                "version_uri": None,
                 "show_unpublished": "true",
             }
             client.eval_xslt(uri, show_unpublished=True)


### PR DESCRIPTION
In order to use document versioning in Marklogic, we need to use the `dls` Marklogic Library Services to manage judgments. 

This PR consists of multiple commits amending & adding new functionality.

- Refactor `save_judgment_xml` to use the `eval` endpoint, so that we can introduce versioning via na XQuery.
- List all versions of a managed judgment
- Get a version of a managed judgment
- Restrict search to managed judgments only
- Set properties on a judgment using the `dls` namespace, not `xdmp`
- Insert & manage a new document
- Check in and check out a document for editing

I propose we update this version to 2.1.0