### PR TITLE
Fix intermittently broken transforms

### DIFF
--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -4,8 +4,8 @@ declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
 declare variable $version_uri as xs:string? external;
 
-let $judgment_xml := fn:doc($uri)/element()
-let $version_xml := if ($version_uri) then fn:document($version_uri)/element() else ()
+let $judgment_xml := fn:doc($uri)
+let $version_xml := if ($version_uri) then fn:document($version_uri) else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
 


### PR DESCRIPTION
We were gettting this error in the public & editor UIs when transforming some
documents:

```
 500 Server Error: Internal Server Error for url: http://marklogic:8011/LATEST/eval?database=Judgments. Response body:
b'<error-response xmlns="http://marklogic.com/xdmp/error">\n  <status-code>500</status-code>\n  <status>Internal Server Error</status>\n  <message-code>XSLT-VARAS</message-code>\n  <message>XSLT-VARAS: (err:XTTE0570) /*:transform/*:template[2] &lt;xsl:element name="article"&gt; &lt;xsl:apply-templates select="node()"/&gt;&lt;xsl:apply-templates select="attachments/attachment/doc[@name = "annex"]"/&gt;&lt;xsl:call-template name="footnotes"/&gt;&lt;xsl:for-each select="attachments/attachment/doc[@name = "annex"]"&gt; &lt;xsl:call-template name="footnotes"/&gt;&lt;/xsl:for-each&gt;&lt;/xsl:element&gt;, &lt;xsl:apply-templates select="attachments/attachment/doc[fn:not(@name = "annex")]"/&gt; -- Invalid variable coercion: () as xs:string</message>\n  <message-detail>\n    <message-title>Invalid variable coercion</message-title>\n  </message-detail>\n</error-response>'
```

Investigation revealed that the XQuery `xslt_transform.xqy` was trying to run
the XSLT transform against an empty node (`()`) and this was causing the error.

Removing the calls to `element()` at the end of these variable declarations
seems to have fixed it.