### PR TITLE
Add setter and getter for properties

### DIFF
--- a/src/caselawclient/xml_tools.py
+++ b/src/caselawclient/xml_tools.py
@@ -1,7 +1,8 @@
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-akn_uk_namespaces = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0", "uk": "https://caselaw.nationalarchives.gov.uk/akn"}
+akn_uk_namespaces = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+                     "uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 search_namespace = {"search": "http://marklogic.com/appservices/search"}
 
 
@@ -12,6 +13,7 @@ class JudgmentMissingMetadataError(IndexError):
 def get_metadata_name_value(xml: ElementTree) -> str:
     name = get_metadata_name_element(xml)
     return name.attrib["value"]
+
 
 def get_element(xml: ElementTree, xpath) -> Element:
     name = xml.find(
@@ -24,26 +26,34 @@ def get_element(xml: ElementTree, xpath) -> Element:
 
     return name
 
+
 def get_neutral_citation_name_value(xml) -> str:
     return get_neutral_citation_element(xml).text
+
 
 def get_judgment_date_value(xml) -> str:
     return get_judgment_date_element(xml).attrib["date"]
 
+
 def get_court_value(xml) -> str:
     return get_court_element(xml).text
+
 
 def get_metadata_name_element(xml) -> Element:
     return get_element(xml, ".//akn:FRBRname")
 
+
 def get_neutral_citation_element(xml) -> Element:
     return get_element(xml, ".//uk:cite")
+
 
 def get_judgment_date_element(xml) -> Element:
     return get_element(xml, ".//akn:FRBRWork/akn:FRBRdate")
 
+
 def get_court_element(xml) -> Element:
     return get_element(xml, ".//uk:court")
+
 
 def get_search_matches(element: ElementTree) -> [str]:
     nodes = element.findall(".//search:match", namespaces=search_namespace)

--- a/src/caselawclient/xquery/set_boolean_property.xqy
+++ b/src/caselawclient/xquery/set_boolean_property.xqy
@@ -6,6 +6,6 @@ declare variable $uri as xs:string external;
 declare variable $value as xs:string external;
 declare variable $name as xs:string external;
 
-let $props := ( element {$name}{$value} )
+let $props := ( element {$name}{xs:boolean($value)} )
 
 return dls:document-set-property($uri, $props)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,7 +92,7 @@ class ApiClientTest(unittest.TestCase):
             client.set_boolean_property(uri, name="my-property", value="true")
 
             client.eval.assert_called_with(
-                os.path.join(ROOT_DIR, "xquery", "set_property.xqy"),
+                os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
@@ -110,7 +110,7 @@ class ApiClientTest(unittest.TestCase):
             client.set_boolean_property(uri, name="my-property", value=False)
 
             client.eval.assert_called_with(
-                os.path.join(ROOT_DIR, "xquery", "set_property.xqy"),
+                os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
@@ -268,6 +268,50 @@ class ApiClientTest(unittest.TestCase):
 
             client.eval.assert_called_with(
                 os.path.join(ROOT_DIR, 'xquery', 'checkin_judgment.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
+    def test_get_property(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            client.eval.return_value.text = 'my-content'
+            client.eval.return_value.headers = {'content-type': 'multipart/mixed; boundary=595658fa1db1aa98'}
+            client.eval.return_value.content = b'\r\n--595658fa1db1aa98\r\n' \
+                                               b'Content-Type: text/plain\r\n' \
+                                               b'X-Primitive: text()\r\n' \
+                                               b'X-URI: /ewca/civ/2004/632.xml\r\n' \
+                                               b'X-Path: /prop:properties/published/text()\r\n' \
+                                               b'\r\nmy-content\r\n' \
+                                               b'--595658fa1db1aa98--\r\n'
+            result = client.get_property("/judgment/uri", "my-property")
+
+            self.assertEqual("my-content", result)
+
+    def test_get_unset_property(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            client.eval.return_value.text = ''
+            result = client.get_property("/judgment/uri", "my-property")
+
+            self.assertEqual("", result)
+
+    def test_set_property(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = "/judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+                "value": "my-value",
+                "name": "my-property"
+            }
+            client.set_property(uri, name="my-property", value="my-value")
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "set_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )


### PR DESCRIPTION
Adds abstracted endpoint for getting and setting a property, regardless of data type. Slightly refactors the get_boolean_property function to extend the new get_property function to reduce duplication without changing the interface.