### PR TITLE
Pass image location to XSLT transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Parameterize the location of images in the XSLT transformation
 
 ## [Release 3.2.0]
 - Add flag to advanced_search to enable filtering out published documents from the search

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -323,11 +323,16 @@ class MarklogicApiClient:
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
+        if os.getenv('XSLT_IMAGE_LOCATION'):
+            image_location = os.getenv('XSLT_IMAGE_LOCATION')
+        else:
+            image_location = ""
 
         vars = json.dumps({
             "uri": uri,
             "version_uri": version_uri,
-            "show_unpublished": str(show_unpublished).lower()
+            "show_unpublished": str(show_unpublished).lower(),
+            "img_location": image_location
         })
         return self.eval(xquery_path, vars=vars, accept_header="application/xml")
 

--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -3,17 +3,26 @@ xquery version "1.0-ml";
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
 declare variable $version_uri as xs:string? external;
+declare variable $img_location as xs:string? external;
 
 let $judgment_xml := fn:doc($uri)
 let $version_xml := if ($version_uri) then fn:document($version_uri) else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
+let $image_base := if ($img_location) then $img_location else ""
 
 let $document_to_transform := if ($version_xml) then $version_xml else $judgment_xml
 
+let $params := map:map()
+let $_put := map:put(
+                    $params,
+                    "image-base",
+                    $image_base)
+
 let $return_value := if (xs:boolean($is_published) or $show_unpublished) then
         xdmp:xslt-invoke('judgments/xslts/judgment2.xsl',
-          $document_to_transform
+          $document_to_transform,
+          $params
         )/element()
     else
         ()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,6 +71,7 @@ class ApiClientTest(unittest.TestCase):
                 "uri": "/judgment/uri.xml",
                 "version_uri": None,
                 "show_unpublished": "true",
+                "img_location": ""
             }
             client.eval_xslt(uri, show_unpublished=True)
 


### PR DESCRIPTION
The location of the images in the transformed Judgments will vary according to
environment. We need to pass the `image-base` to the XSLT to tell it where to
find the images.

This change relies on the implementing application having `XSLT_IMAGE_LOCATION`
set in its env.