### PR TITLE
Pass the name of the database the client uses in an env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 - Parameterize the location of images in the XSLT transformation
+- Parameterize the database name
 
 ## [Release 3.2.0]
 - Add flag to advanced_search to enable filtering out published documents from the search

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -253,8 +253,10 @@ class MarklogicApiClient:
         )
 
     def eval(
-        self, xquery_path, vars, database="Judgments", accept_header="multipart/mixed"
+        self, xquery_path, vars, database=None, accept_header="multipart/mixed"
     ):
+        if not database:
+            database = os.getenv('DATABASE_NAME')
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
             "Accept": accept_header,


### PR DESCRIPTION
Note that the implementing application will have to add DATABASE_NAME to its
environment variables.