### PR TITLE
Fix/send default elements if they are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- If an element doesn't exist in a document, `xml_tools.get_element` tries to return an empty element with the same
+  name as the desired element.
 
 ## [Release 4.3.0]
 - Add function to retrieve the last time a document or it's properties was updated

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ There is also a small set of xml helper tools that provide some common functiona
 from caselawclient import xml_tools
 
 xml_tools.get_metadata_name_value(xml)
-xml_toosl.get_metadata_name_element(xml)
+xml_tools.get_metadata_name_element(xml)
 xml_tools.get_search_matches(element)
 ```
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -167,6 +167,9 @@ class MarklogicApiClient:
         response = self.eval(
             xquery_path, vars=f'{{"uri":"{uri}"}}', accept_header="application/xml"
         )
+        if not response.text:
+            return ''
+
         multipart_data = decoder.MultipartDecoder.from_response(response)
         return multipart_data.parts[0].text
 

--- a/tests/test_xml_tools.py
+++ b/tests/test_xml_tools.py
@@ -2,8 +2,6 @@ import unittest
 import xml.etree.ElementTree as ET
 
 import src.caselawclient.xml_tools as xml_tools
-from src.caselawclient.xml_tools import JudgmentMissingMetadataError
-
 
 class XmlToolsTests(unittest.TestCase):
     def test_metadata_name_value_success(self):
@@ -48,9 +46,8 @@ class XmlToolsTests(unittest.TestCase):
             </proprietary>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_neutral_citation_name_value, xml
-        )
+        result = xml_tools.get_neutral_citation_name_value(xml)
+        self.assertEqual(result, None)
 
     def test_neutral_citation_element_success(self):
         xml_string = """
@@ -81,9 +78,8 @@ class XmlToolsTests(unittest.TestCase):
             </proprietary>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_neutral_citation_element, xml
-        )
+        result = xml_tools.get_neutral_citation_element(xml)
+        self.assertEqual(result.text, None)
 
     def test_metadata_name_value_failure(self):
         xml_string = """
@@ -96,9 +92,8 @@ class XmlToolsTests(unittest.TestCase):
             </akomaNtoso>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_metadata_name_value, xml
-        )
+        result = xml_tools.get_metadata_name_value(xml)
+        self.assertEqual(result, "")
 
     def test_metadata_name_element_success(self):
         xml_string = """
@@ -130,9 +125,11 @@ class XmlToolsTests(unittest.TestCase):
             </akomaNtoso>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_metadata_name_element, xml
+        result = xml_tools.get_metadata_name_element(xml)
+        self.assertEqual(
+            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRname"
         )
+        self.assertEqual(result.attrib, {"value": ""})
 
     def test_judgment_date_value_success(self):
         xml_string = """
@@ -166,9 +163,8 @@ class XmlToolsTests(unittest.TestCase):
             </akomaNtoso>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_metadata_name_value, xml
-        )
+        result = xml_tools.get_judgment_date_value(xml)
+        self.assertEqual(result, "")
 
     def test_judgment_date_element_success(self):
         xml_string = """
@@ -205,9 +201,11 @@ class XmlToolsTests(unittest.TestCase):
             </akomaNtoso>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_judgment_date_element, xml
+        result = xml_tools.get_judgment_date_element(xml)
+        self.assertEqual(
+            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRdate"
         )
+        self.assertEqual(result.attrib, {"date": "", "name": "judgment"})
 
     def test_court_value_success(self):
         xml_string = """
@@ -235,9 +233,8 @@ class XmlToolsTests(unittest.TestCase):
             </proprietary>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_court_value, xml
-        )
+        result = xml_tools.get_court_value(xml)
+        self.assertEqual(result, None)
 
     def test_court_element_success(self):
         xml_string = """
@@ -268,9 +265,11 @@ class XmlToolsTests(unittest.TestCase):
             </proprietary>
         """
         xml = ET.ElementTree(ET.fromstring(xml_string))
-        self.assertRaises(
-            JudgmentMissingMetadataError, xml_tools.get_court_element, xml
+        result = xml_tools.get_court_element(xml)
+        self.assertEqual(
+            result.tag, "{https://caselaw.nationalarchives.gov.uk/akn}court"
         )
+        self.assertEqual(result.text, None)
 
     def test_search_matches(self):
         xml_string = """


### PR DESCRIPTION
If Elements are missing from the XML which we need to edit (e.g
if we are attempting to edit the metadata name of a judgment but its
`akn:FRBRWork` element is completely missing) then send an empty Element
in its place instead of sending an error.

This will allow editors to correct the missing metadata in the editor UI.

Rollbar: https://rollbar.com/dxw/tna-caselaw-editor-ui/items/14/
