### PR TITLE
Set judgment metadata in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Allow metadata elements (name, date, court and citation) to be edited in the XML via XQuery, not by deserialising and
+  serialising the XML in the implementing client code.
 
 ## [Release 4.4.0]
 - If an element doesn't exist in a document, `xml_tools.get_element` tries to return an empty element with the same

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -173,6 +173,17 @@ class MarklogicApiClient:
         multipart_data = decoder.MultipartDecoder.from_response(response)
         return multipart_data.parts[0].text
 
+    def set_judgment_name(self, judgment_uri, content):
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "set_metadata_name.xqy"
+        )
+
+        response = self.eval(
+            xquery_path, vars=f'{{"uri":"{uri}", "content":"{content}"}}', accept_header="application/xml"
+        )
+        return response
+
     def save_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -195,6 +195,28 @@ class MarklogicApiClient:
         )
         return response
 
+    def set_judgment_citation(self, judgment_uri, content):
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "set_metadata_citation.xqy"
+        )
+
+        response = self.eval(
+            xquery_path, vars=f'{{"uri":"{uri}", "content":"{content}"}}', accept_header="application/xml"
+        )
+        return response
+
+    def set_judgment_court(self, judgment_uri, content):
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "set_metadata_court.xqy"
+        )
+
+        response = self.eval(
+            xquery_path, vars=f'{{"uri":"{uri}", "content":"{content}"}}', accept_header="application/xml"
+        )
+        return response
+
     def save_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -184,6 +184,17 @@ class MarklogicApiClient:
         )
         return response
 
+    def set_judgment_date(self, judgment_uri, content):
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "set_metadata_date.xqy"
+        )
+
+        response = self.eval(
+            xquery_path, vars=f'{{"uri":"{uri}", "content":"{content}"}}', accept_header="application/xml"
+        )
+        return response
+
     def save_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 

--- a/src/caselawclient/xquery/set_metadata_citation.xqy
+++ b/src/caselawclient/xquery/set_metadata_citation.xqy
@@ -1,0 +1,10 @@
+xquery version "1.0-ml";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare variable $uri as xs:string external;
+declare variable $content as xs:string external;
+
+xdmp:node-replace(
+document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite,
+<uk:cite>{$content}</uk:cite>)

--- a/src/caselawclient/xquery/set_metadata_court.xqy
+++ b/src/caselawclient/xquery/set_metadata_court.xqy
@@ -1,0 +1,10 @@
+xquery version "1.0-ml";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare variable $uri as xs:string external;
+declare variable $content as xs:string external;
+
+xdmp:node-replace(
+document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
+<uk:court>{$content}</uk:court>)

--- a/src/caselawclient/xquery/set_metadata_date.xqy
+++ b/src/caselawclient/xquery/set_metadata_date.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+declare variable $content as xs:string external;
+
+xdmp:node-replace(
+document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
+<akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)

--- a/src/caselawclient/xquery/set_metadata_name.xqy
+++ b/src/caselawclient/xquery/set_metadata_name.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+declare variable $content as xs:string external;
+
+xdmp:node-replace(
+document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname,
+<akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)


### PR DESCRIPTION
Previously, we have been updating the judgment metadata in the Editor UI project, by retrieving the XML, editing it and re-serialising it. A side effect of this is that the namespaces in the judgment XML are stripped out and lost. 

By doing all the editing in the client, and only editing the exact nodes we wish to update, we are able to avoid losing the namespaces.

TODO: All these XQueries could be refactored into one, if we can figure out how to turn a string representation of an XPath (e.g. `/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court`) into a `node()*`, which is what `xdmp:node-replace` expects. 