### PR TITLE
Fix: If metadata name element does not exist, insert a new one as a child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Create a new `akn:FRBRname` node for the judgment metadata name, if one does not exist
 
 ## [Release 4.5.1]
 - Patch release to update `setup.cfg`, which was missed from v4.5.0

--- a/src/caselawclient/xquery/set_metadata_name.xqy
+++ b/src/caselawclient/xquery/set_metadata_name.xqy
@@ -4,6 +4,15 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-xdmp:node-replace(
-document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname,
-<akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
+if (fn:boolean(
+cts:search(doc($uri),
+cts:element-query(xs:QName('akn:FRBRname'),cts:and-query(()))))) then
+    xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname,
+    <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    )
+else
+    xdmp:node-insert-child(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork,
+    <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    )


### PR DESCRIPTION
We were assuming that the `akn:FRBRname` node would exist and could be edited,
but in some cases this node does not exist if the parser was unable to find a
case name in the judgment.

Check to see if a `akn:FRBRname` node exists in the document, and if it does
replace it, otherwise create a new one.