### PR TITLE
Allow editing of metadata if elements do not exist

### DIFF
--- a/src/caselawclient/xquery/set_metadata_citation.xqy
+++ b/src/caselawclient/xquery/set_metadata_citation.xqy
@@ -5,6 +5,14 @@ declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-xdmp:node-replace(
-document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite,
-<uk:cite>{$content}</uk:cite>)
+if (fn:boolean(
+cts:search(doc($uri),
+cts:element-query(xs:QName('uk:cite'),cts:and-query(()))))) then
+    xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite,
+    <uk:cite>{$content}</uk:cite>)
+else
+    xdmp:node-insert-child(
+      document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary,
+      <uk:cite>{$content}</uk:cite>
+    )

--- a/src/caselawclient/xquery/set_metadata_court.xqy
+++ b/src/caselawclient/xquery/set_metadata_court.xqy
@@ -5,6 +5,14 @@ declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-xdmp:node-replace(
-document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
-<uk:court>{$content}</uk:court>)
+if (fn:boolean(
+cts:search(doc($uri),
+cts:element-query(xs:QName('uk:court'),cts:and-query(()))))) then
+    xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
+    <uk:court>{$content}</uk:court>)
+else
+    xdmp:node-insert-child(
+      document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary,
+      <uk:court>{$content}</uk:court>
+    )

--- a/src/caselawclient/xquery/set_metadata_date.xqy
+++ b/src/caselawclient/xquery/set_metadata_date.xqy
@@ -4,6 +4,14 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-xdmp:node-replace(
-document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
-<akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
+if (fn:boolean(
+cts:search(doc($uri),
+cts:element-query(xs:QName('akn:FRBRdate'),cts:and-query(()))))) then
+    xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
+    <akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
+else
+    xdmp:node-insert-child(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork,
+    <akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    )


### PR DESCRIPTION
Trello: https://trello.com/c/wqpbKBxw

In some judgments, the `<uk:court>` metadata element was entirely missing, instead of being present and incorrect. In these cases, we were not able to amend the court data as the XQuery to do this relies on the existence of a `uk:court` element to edit. The updated XQuery checks for the presence of the element, updates it if it exists, and creates it if it does not. 

Additionally, do the same amendments for the `uk:cite` and `akn:FRBRdate` elements. 