### PR TITLE
Add page size to advanced_search

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -364,6 +364,7 @@ class MarklogicApiClient:
         date_from=None,
         date_to=None,
         page=1,
+        page_size=RESULTS_PER_PAGE,
         show_unpublished=False,
         only_unpublished=False
     ) -> requests.Response:
@@ -380,6 +381,7 @@ class MarklogicApiClient:
         :param date_from:
         :param date_to:
         :param page:
+        :param page_size:
         :param show_unpublished: If True, both published and unpublished documents will be returned
         :param only_unpublished: If True, will only return published documents. Ignores the value of show_unpublished
         :return:
@@ -389,7 +391,7 @@ class MarklogicApiClient:
             "court": str(court or ""),
             "judge": str(judge or ""),
             "page": page,
-            "page-size": RESULTS_PER_PAGE,
+            "page-size": int(page_size),
             "q": str(q or ""),
             "party": str(party or ""),
             "neutral_citation": str(neutral_citation or ""),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,13 +41,14 @@ class ApiClientTest(unittest.TestCase):
                 judge="a. judge",
                 party="a party",
                 page=2,
+                page_size=20
             )
 
             expected_vars = {
                 "court": "ewhc",
                 "judge": "a. judge",
                 "page": 2,
-                "page-size": RESULTS_PER_PAGE,
+                "page-size": 20,
                 "q": "my-query",
                 "party": "a party",
                 "neutral_citation": "",


### PR DESCRIPTION
Update the advanced search function to accept a flexible page_size parameter that defaults to the RESULTS_PER_PAGE constant, rather than using the constant explicitly. This allows for us to provide more content on a single page should a user require it.