### PR TITLE
Allow the XSL filename used in judgment transformation to be varied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -
+  `judgment2` (the accessible version) and `judgment0` (the "as handed down" version). Add two helper methods
+  `accessible_judgment_transformation()` and `original_judgment_transformation()` to call these transformations without
+  specifying the xsl filename.
 
 ## [Release 4.5.4]
 - Adds a new `delete_judgment` endpoint, for deleting a judgment from marklogic

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -403,7 +403,7 @@ class MarklogicApiClient:
 
         return self.invoke(module, vars)
 
-    def eval_xslt(self, judgment_uri, version_uri=None, show_unpublished=False) -> requests.Response:
+    def eval_xslt(self, judgment_uri, version_uri=None, show_unpublished=False, xsl_filename="judgment2.xsl") -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
@@ -417,9 +417,16 @@ class MarklogicApiClient:
             "uri": uri,
             "version_uri": version_uri,
             "show_unpublished": str(show_unpublished).lower(),
-            "img_location": image_location
+            "img_location": image_location,
+            "xsl_filename": xsl_filename
         })
         return self.eval(xquery_path, vars=vars, accept_header="application/xml")
+
+    def accessible_judgment_transformation(self, judgment_uri, version_uri=None, show_unpublished=False):
+        return self.eval_xslt(judgment_uri, version_uri, show_unpublished, xsl_filename="judgment2.xsl")
+
+    def original_judgment_transformation(self, judgment_uri, version_uri=None, show_unpublished=False):
+        return self.eval_xslt(judgment_uri, version_uri, show_unpublished, xsl_filename="judgment0.xsl")
 
     def get_property(self, judgment_uri, name):
         uri = self._format_uri(judgment_uri)

--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -4,14 +4,17 @@ declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
 declare variable $version_uri as xs:string? external;
 declare variable $img_location as xs:string? external;
+declare variable $xsl_filename as xs:string? external;
 
 let $judgment_xml := fn:doc($uri)
 let $version_xml := if ($version_uri) then fn:document($version_uri) else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
 let $image_base := if ($img_location) then $img_location else ""
+let $xsl := if ($xsl_filename) then $xsl_filename else "judgment2.xsl"
 
 let $document_to_transform := if ($version_xml) then $version_xml else $judgment_xml
+let $xsl_path := fn:concat("judgments/xslts/", $xsl)
 
 let $params := map:map()
 let $_put := map:put(
@@ -20,7 +23,7 @@ let $_put := map:put(
                     $image_base)
 
 let $return_value := if (xs:boolean($is_published) or $show_unpublished) then
-        xdmp:xslt-invoke('judgments/xslts/judgment2.xsl',
+        xdmp:xslt-invoke($xsl_path,
           $document_to_transform,
           $params
         )/element()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -64,7 +64,7 @@ class ApiClientTest(unittest.TestCase):
                 json.dumps(expected_vars)
             )
 
-    def test_eval_xslt(self):
+    def test_eval_xslt_with_default(self):
         client = MarklogicApiClient("", "", "", False)
 
         with patch.object(client, 'eval'):
@@ -73,9 +73,30 @@ class ApiClientTest(unittest.TestCase):
                 "uri": "/judgment/uri.xml",
                 "version_uri": None,
                 "show_unpublished": "true",
-                "img_location": ""
+                "img_location": "",
+                "xsl_filename": "judgment2.xsl"
             }
             client.eval_xslt(uri, show_unpublished=True)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header='application/xml'
+            )
+
+    def test_eval_xslt_with_filename(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = "/judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+                "version_uri": None,
+                "show_unpublished": "true",
+                "img_location": "",
+                "xsl_filename": "judgment0.xsl"
+            }
+            client.eval_xslt(uri, show_unpublished=True, xsl_filename="judgment0.xsl")
 
             client.eval.assert_called_with(
                 os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"),


### PR DESCRIPTION
Allow the xsl filename used in the judgment transformation to vary.

We have two xsls available in Marklogic - `judgment2` (the accessible version)
and `judgment0` (the "as handed down" version).

Add two helper methods `accessible_judgment_transformation()` and
`original_judgment_transformation()` to call these transformations without
specifying the xsl filename.