### PR TITLE
Release v4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+
+## [Release 4.6.0]
 - Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -
   `judgment2` (the accessible version) and `judgment0` (the "as handed down" version). Add two helper methods
   `accessible_judgment_transformation()` and `original_judgment_transformation()` to call these transformations without
   specifying the xsl filename.
+- Copy judgment from URI to URI
 
 ## [Release 4.5.4]
 - Adds a new `delete_judgment` endpoint, for deleting a judgment from marklogic
@@ -82,7 +85,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.5.4...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.6.0...HEAD
+[Release 4.6.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.6.0...4.5.4
 [Release 4.5.4]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.5.4...4.5.3
 [Release 4.5.3]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.5.3...4.5.2
 [Release 4.5.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/release-4.5.2...4.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ds-caselaw-marklogic-api-client
-version = 4.5.4
+version = 4.6.0
 author = The National Archives
 description = An API client for interacting with the Caselaw Marklogic instance
 long_description = file: README.md


### PR DESCRIPTION
- Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -
  `judgment2` (the accessible version) and `judgment0` (the "as handed down" version). Add two helper methods
  `accessible_judgment_transformation()` and `original_judgment_transformation()` to call these transformations without
  specifying the xsl filename.
- Copy judgment from URI to URI

