### PR TITLE
Change XQuery method for deleting documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Change the XQuery delete method from xdmp:document-delete to dls:document-delete
 
 ## [Release 4.6.0]
 - Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -

--- a/src/caselawclient/xquery/delete_judgment.xqy
+++ b/src/caselawclient/xquery/delete_judgment.xqy
@@ -1,5 +1,10 @@
 xquery version "1.0-ml";
 
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
 declare variable $uri as xs:string external;
 
-xdmp:document-delete($uri)
+let $keep_old_versions := fn:false()
+let $retain_history := fn:false()
+
+return dls:document-delete($uri, $keep_old_versions, $retain_history)


### PR DESCRIPTION


https://docs.marklogic.com/dls:document-delete

<!-- Amend as appropriate -->

## Changes in this PR:

We were previously using xdmp:document-delete, which only deleted the document
itself.

As all our documents are managed under dls, it makes more sense to use
dls:document-delete, which will also delete the document's property history and
old versions. This way we do not end up with property fragments and versions of
old documents lying around.

## Trello card / Rollbar error (etc)

https://trello.com/c/ZGmLoDby

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
