### PR TITLE
Last modified use document timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- Change the behaviour of 'last-modified' dates to use prop:last-modified rather than xdmp:document-timestamp
+
 ## [Release 4.6.0]
 - Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -
   `judgment2` (the accessible version) and `judgment0` (the "as handed down" version). Add two helper methods

--- a/src/caselawclient/xquery/get_last_modified.xqy
+++ b/src/caselawclient/xquery/get_last_modified.xqy
@@ -2,6 +2,7 @@ xquery version "1.0-ml";
 
 declare variable $uri as xs:string external;
 
-let $timestamp := xdmp:document-timestamp( $uri )
-
-return xdmp:timestamp-to-wallclock( $timestamp )
+return xdmp:parse-dateTime(
+         "[Y0001]-[M01]-[D01]T[h01]:[m01]:[s01][Z]",
+         xdmp:document-properties($uri)//prop:last-modified/text()
+)


### PR DESCRIPTION
Change the behaviour of 'last-modified' dates to use prop:last-modified rather than xdmp:document-timestamp

Thomson Reuters reported an issue where on May 24th a great many documents started reporting their date in the
atom feed as being the 24th of May. From trawling through slack, it was discovered that this was co-incident
with a reindexing of the documents.

This implies that the xdmp:document-timestamp we are currently using is not fit for this purpose, so we have
changed the behaviour of the get_last_modified function to no-longer return this value.

prop:last-modified is a text string like 2022-07-04T11:05:45Z, but consumers expect a datetime;
documentation for the query string is at https://docs.marklogic.com/xdmp:parse-dateTime

The example gives an example of a 24h time being converted via the 'h' operator but the documentation
suggests it only does half day ranges, and "H" should be used instead; both seem to have the same behaviour.