### PR TITLE
Set the judgment's internal URI (`FRBRthis` and `FRBRuri` nodes)

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -217,6 +217,21 @@ class MarklogicApiClient:
         )
         return response
 
+    def set_judgment_this_uri(self, judgment_uri):
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        content_with_id = f"https://caselaw.nationalarchives.gov.uk/id/{judgment_uri.lstrip('/')}"
+        content_without_id = f"https://caselaw.nationalarchives.gov.uk/{judgment_uri.lstrip('/')}"
+        content_with_xml = f"https://caselaw.nationalarchives.gov.uk/{judgment_uri.lstrip('/')}/data.xml"
+
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"
+        )
+
+        response = self.eval(
+            xquery_path, vars=f'{{"uri": "{uri}", "content_with_id": "{content_with_id}", "content_without_id": "{content_without_id}", "content_with_xml": "{content_with_xml}"}}', accept_header="application/xml"
+        )
+        return response
+
     def save_judgment_xml(self, judgment_uri: str, judgment_xml: Element) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 

--- a/src/caselawclient/xquery/set_metadata_this_uri.xqy
+++ b/src/caselawclient/xquery/set_metadata_this_uri.xqy
@@ -1,0 +1,34 @@
+xquery version "1.0-ml";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+declare variable $content_with_id as xs:string external;
+declare variable $content_without_id as xs:string external;
+declare variable $content_with_xml as xs:string external;
+
+(
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRuri,
+    <akn:FRBRuri value="{$content_with_id}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    ),
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRthis,
+    <akn:FRBRthis value="{$content_with_id}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    ),
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRExpression/akn:FRBRuri,
+    <akn:FRBRthis value="{$content_without_id}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    ),
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRExpression/akn:FRBRthis,
+    <akn:FRBRthis value="{$content_without_id}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    ),
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRuri,
+    <akn:FRBRthis value="{$content_with_xml}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    ),
+  xdmp:node-replace(
+    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/akn:FRBRthis,
+    <akn:FRBRthis value="{$content_with_xml}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+    )
+)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -375,3 +375,41 @@ class ApiClientTest(unittest.TestCase):
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
+
+    def test_set_internal_uri_leading_slash(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = "/judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
+                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
+                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
+            }
+            client.set_judgment_this_uri(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
+    def test_set_internal_uri_no_leading_slash(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = "judgment/uri"
+            expected_vars = {
+                "uri":"/judgment/uri.xml",
+                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
+                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
+                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
+            }
+            client.set_judgment_this_uri(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

In https://github.com/nationalarchives/ds-caselaw-public-access-service/blob/main/marklogic/src/main/ml-modules/root/judgments/xslts/judgment2.xsl#L69
we can see that the XSLT uses the node at `/akomaNtoso/judgment/meta/identification/FRBRWork/FRBRthis/https://github.com/value`
to determine the URI of a document, and then uses that URI to build up a URL
for the judgment's images.

In judgments which have failed processing, and have had a Neutral Citation Number
(and therefore a URI) added manually by the editors, this internal URI at
`/FRBRWork/FRBRthis/https://github.com/value` remains blank.

This has the knock on effect of image URLs not resolving correctly in the HTML
version of a judgment (which is generated from the above XSLT).

This commit introduces an XQuery & API endpoint to set the value of
`FRBRWork/FRBRthis/https://github.com/value`

This can then be used in the Editor UI to set the internal URI of a judgment
once a judgment is edited by the editors.

Additionally, the values of FRBRExpression/FRBRthis/https://github.com/value and FRBRExpression/FRBRuri/@value
should be set to the URI (but without the `/id/`), and the values of
FRBRManifestation/FRBRthis/@value and FRBRManifestation/FRBRuri/@value should be set
to the URI, without the `/id/` and with `data.xml` on the end.

E.g.

```
<identification source="#tna">
  <FRBRWork>
    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/ewhc/scco/2022/1148" />
    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/ewhc/scco/2022/1148" />
    <FRBRdate date="2022-05-04" name="judgment" />
    <FRBRauthor href="#ewhc-seniorcourtscosts" />
    <FRBRcountry value="GB-UKM" />
    <FRBRnumber value="1148" />
  </FRBRWork>
  <FRBRExpression>
    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/1148" />
    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/1148" />
    <FRBRdate date="2022-05-04" name="judgment" />
    <FRBRauthor href="#ewhc-seniorcourtscosts" />
    <FRBRlanguage language="eng" />
  </FRBRExpression>
  <FRBRManifestation>
    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/1148/data.xml" />
    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/ewhc/scco/2022/1148/data.xml" />
    <FRBRdate date="2022-06-16T00:40:44" name="transform" />
    <FRBRauthor href="#tna" />
    <FRBRformat value="application/xml" />
  </FRBRManifestation>
</identification>
```

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
