### PR TITLE
Release v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
-- Change the XQuery delete method from xdmp:document-delete to dls:document-delete
 
+## [Release 4.7.0]
+- Change the XQuery delete method from xdmp:document-delete to dls:document-delete
 - Change the behaviour of 'last-modified' dates to use prop:last-modified rather than xdmp:document-timestamp
+- Set the judgment's internal URI (`FRBRthis` and `FRBRuri` nodes)
 
 ## [Release 4.6.0]
 - Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ds-caselaw-marklogic-api-client
-version = 4.6.0
+version = 4.7.0
 author = The National Archives
 description = An API client for interacting with the Caselaw Marklogic instance
 long_description = file: README.md


### PR DESCRIPTION
- Change the XQuery delete method from xdmp:document-delete to dls:document-delete
- Set the judgment's internal URI (`FRBRthis` and `FRBRuri` nodes)

