### PR TITLE
Revert get_last_modified

### DIFF
--- a/src/caselawclient/xquery/get_last_modified.xqy
+++ b/src/caselawclient/xquery/get_last_modified.xqy
@@ -2,7 +2,6 @@ xquery version "1.0-ml";
 
 declare variable $uri as xs:string external;
 
-return xdmp:parse-dateTime(
-         "[Y0001]-[M01]-[D01]T[h01]:[m01]:[s01][Z]",
-         xdmp:document-properties($uri)//prop:last-modified/text()
-)
+let $timestamp := xdmp:document-timestamp( $uri )
+
+return xdmp:timestamp-to-wallclock( $timestamp )


### PR DESCRIPTION
The approach taken was incorrect and the get_last_modified needed to not have a return as it did not have a let statement.