### PR TITLE
Gracefully handle a null, empty or unexpected error response from Marklogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Gracefully handle a null, empty or unexpected error response from Marklogic 
 
 ## [Release 4.7.1]
 - Fix a typo in setting the internal URI of a judgment

--- a/src/caselawclient/xml_tools.py
+++ b/src/caselawclient/xml_tools.py
@@ -1,5 +1,5 @@
 from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import Element, ParseError
 
 akn_uk_namespaces = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
                      "uk": "https://caselaw.nationalarchives.gov.uk/akn"}
@@ -85,5 +85,8 @@ def get_search_matches(element: ElementTree) -> [str]:
 
 
 def get_error_code(xml_content: str) -> str:
-    xml = ElementTree.fromstring(xml_content)
-    return xml.find('message-code', namespaces={"": "http://marklogic.com/xdmp/error"}).text
+    try:
+        xml = ElementTree.fromstring(xml_content)
+        return xml.find('message-code', namespaces={"": "http://marklogic.com/xdmp/error"}).text
+    except (ParseError, TypeError, AttributeError):
+        return "Unknown error, Marklogic returned a null or empty response"

--- a/tests/test_xml_tools.py
+++ b/tests/test_xml_tools.py
@@ -305,3 +305,23 @@ class XmlToolsTests(unittest.TestCase):
         """
         result = xml_tools.get_error_code(xml_string)
         self.assertEqual(result, "XDMP-DOCNOTFOUND")
+
+    def test_get_error_code_missing_message(self):
+        xml_string = """
+        <error-response xmlns="http://marklogic.com/xdmp/error">
+            <status-code>500</status-code>
+            <status>Internal Server Error</status>
+        </error-response>
+        """
+        result = xml_tools.get_error_code(xml_string)
+        self.assertEqual(result, "Unknown error, Marklogic returned a null or empty response")
+
+    def test_get_error_code_xml_empty_string(self):
+        xml_string = ""
+        result = xml_tools.get_error_code(xml_string)
+        self.assertEqual(result, "Unknown error, Marklogic returned a null or empty response")
+
+    def test_get_error_code_xml_none(self):
+        xml_string = None
+        result = xml_tools.get_error_code(xml_string)
+        self.assertEqual(result, "Unknown error, Marklogic returned a null or empty response")


### PR DESCRIPTION



<!-- Amend as appropriate -->

## Changes in this PR:

If Marklogic is unavailable or returning an otherwise unexpected response, handle
the error more gracefully that previously. We were seeing AttributeErrors when
Marklogic was temporarily unavailable - this should handle them and return
something a bit more understandable than a 500 error response.

## Trello card / Rollbar error (etc)

Trello: https://trello.com/c/rrdEvcje/731-improve-error-messaging-when-ml-is-unavailable
Rollbar: https://rollbar.com/dxw/tna-caselaw-public-ui/items/67/

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
