### PR TITLE
Respect & maintain the `FRBRdate` attribute `name` in `FRBRWork`

### DIFF
--- a/src/caselawclient/xquery/set_metadata_date.xqy
+++ b/src/caselawclient/xquery/set_metadata_date.xqy
@@ -4,13 +4,20 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
+(: If at least one FRBRWork/FRBRdate element exists then...:)
 if (fn:boolean(
-cts:search(doc($uri),
+cts:search(doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork,
 cts:element-query(xs:QName('akn:FRBRdate'),cts:and-query(()))))) then
-    xdmp:node-replace(
-    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
-    <akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
+    (: ...iterate over the FRBRdate element(s) :)
+    for $frbr_date in doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate
+        (: Store the existing @name attribute value :)
+        let $attribute_name := $frbr_date/@name
+        (: Replace the exisitng FRBRdate element with a new one, using the same @name attribute :)
+        return xdmp:node-replace(
+        document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate[@name = $attribute_name],
+        <akn:FRBRdate date="{$content}" name="{$attribute_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
 else
+    (: No FRBRdate exists in FRBRWork, so create a new one and use the 'judgment' attribute name as default  :)
     xdmp:node-insert-child(
     document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork,
     <akn:FRBRdate date="{$content}" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:

Related to https://github.com/nationalarchives/ds-caselaw-public-ui/pull/316

This XQuery sets or updates the node at `/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate`

However, it does not respect the value of the `@name` attribute. It is being
set to `judgment`, which is true in many cases, but may also be `hearing` in
some cases.

In the referred PR above, we changed the way we get a judgment's date, from
looking for an `FRBRdate` with an attribute of `judgment`, we instead
look for any `FRBRdate` inside the `FRBRWork` element. So the attribute `name`
value is redundant.

When updating a judgement's date, we do not want to obliterate the existing
`name` attribute value, and replace it with `judgment`, as we were previously
doing. Instead we want to preserve it in the new/updated `FRBRWork/FRBRdate`
element.

However, if a judgment does not have an `FRBRWork/FRBRdate` element, create
a new one and give it the `@name` attribute `judgment` by default.

## Trello card / Rollbar error (etc)

https://trello.com/c/lTTnAqpz/847-date-editor-ui

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
