### PR TITLE
Correct error with `checkout_judgment` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Add optional annotation parameter to `checkout_judgment` method
 
 ## [Release 4.8.0]
 - Gracefully handle a null, empty or unexpected error response from Marklogic 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -300,13 +300,14 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
-    def checkout_judgment(self, judgment_uri: str) -> requests.Response:
+    def checkout_judgment(self, judgment_uri: str, annotation="") -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(
             ROOT_DIR, "xquery", "checkout_judgment.xqy"
         )
         vars = {
-            "uri": uri
+            "uri": uri,
+            "annotation": annotation,
         }
 
         return self.eval(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -596,8 +596,8 @@ class MarklogicApiClient:
 
 
 api_client = MarklogicApiClient(
-    host=env("MARKLOGIC_HOST"),
-    username=env("MARKLOGIC_USER"),
-    password=env("MARKLOGIC_PASSWORD"),
+    host=env("MARKLOGIC_HOST", default=None),
+    username=env("MARKLOGIC_USER", default=None),
+    password=env("MARKLOGIC_PASSWORD", default=None),
     use_https=env("MARKLOGIC_USE_HTTPS", default=False),
 )

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -37,9 +37,16 @@ class MarklogicNotPermittedError(MarklogicAPIError):
 class MarklogicResourceNotFoundError(MarklogicAPIError):
     pass
 
+class MarklogicResourceLockedError(MarklogicAPIError):
+    pass
+
+class MarklogicResourceUnmanagedError(MarklogicAPIError):
+    """Note: this exception may be raised if a document doesn't exist"""
+    pass
 
 class MarklogicCommunicationError(MarklogicAPIError):
     pass
+
 
 
 class MarklogicApiClient:
@@ -51,7 +58,9 @@ class MarklogicApiClient:
         404: MarklogicResourceNotFoundError,
     }
     error_code_classes = {
-        'XDMP-DOCNOTFOUND': MarklogicResourceNotFoundError
+        'XDMP-DOCNOTFOUND': MarklogicResourceNotFoundError,
+        'XDMP-LOCKCONFLICT': MarklogicResourceLockedError,
+        'DLS-UNMANAGED': MarklogicResourceUnmanagedError,
     }
 
     default_http_error_class = MarklogicCommunicationError

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -272,10 +272,12 @@ class ApiClientTest(unittest.TestCase):
 
         with patch.object(client, 'eval'):
             uri = '/ewca/civ/2004/632'
+            annotation = "locked by A KITTEN"
             expected_vars = {
-                'uri':'/ewca/civ/2004/632.xml'
+                'uri':'/ewca/civ/2004/632.xml',
+                'annotation': 'locked by A KITTEN'
             }
-            client.checkout_judgment(uri)
+            client.checkout_judgment(uri, annotation)
 
             client.eval.assert_called_with(
                 os.path.join(ROOT_DIR, 'xquery', 'checkout_judgment.xqy'),


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

`checkout_judgment` method requires an annotation parameter in its associated XQuery (`checkout_judgment.xqy`) but we weren't passing it in, and because we don't have any XQuery automated testing, and we're not yet using the `checkout_judgment` method, we didn't catch this error.

Additionally, add some new Marklogic error statuses associated with checking out a judgment. 

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
