### PR TITLE
Add methods to get the lock/checkout status of a judgment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 - Add optional annotation parameter to `checkout_judgment` method
+- Add method to get the lock/checkout status of a judgment
 
 ## [Release 4.8.0]
 - Gracefully handle a null, empty or unexpected error response from Marklogic 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -333,6 +333,29 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def get_judgment_checkout_status(self, judgment_uri: str) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "get_judgment_checkout_status.xqy"
+        )
+        vars = {
+            "uri": uri
+        }
+
+        return self.eval(
+            xquery_path,
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
+    def get_judgment_checkout_status_message(self, judgment_uri: str) -> str:
+        response = self.get_judgment_checkout_status(judgment_uri)
+        if response.text == "":
+            return "Not locked"
+        response_xml = ElementTree.fromstring(response.text)
+        return response_xml.find("dls:annotation", namespaces={"dls": "http://marklogic.com/xdmp/dls"}).text
+
+
     def get_judgment_version(self, judgment_uri: str, version: int) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -37,16 +37,18 @@ class MarklogicNotPermittedError(MarklogicAPIError):
 class MarklogicResourceNotFoundError(MarklogicAPIError):
     pass
 
+
 class MarklogicResourceLockedError(MarklogicAPIError):
     pass
+
 
 class MarklogicResourceUnmanagedError(MarklogicAPIError):
     """Note: this exception may be raised if a document doesn't exist"""
     pass
 
+
 class MarklogicCommunicationError(MarklogicAPIError):
     pass
-
 
 
 class MarklogicApiClient:

--- a/src/caselawclient/xquery/get_judgment_checkout_status.xqy
+++ b/src/caselawclient/xquery/get_judgment_checkout_status.xqy
@@ -1,0 +1,6 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string;
+
+dls:document-checkout-status($uri)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

In the privileged API, we want to be able to see the checkout/lock status of a
judgment.

`get_judgment_checkout_status.xqy` checks the checkout status of a judgment using
`dls:document-checkout-status($uri)`

The result will either be empty, if the judgment is not locked, or an XML
fragment containing the URI and annotation message, if the judgment is locked.

The method `get_judgment_checkout_status` can be called on the Client, and will
return a response with either an XML fragment describing who has locked the
judgment, or empty if it is not locked.

The method `get_judgment_checkout_status_message` can also be called on the
Client, and will return either the lock annotation, if the judgment is locked,
or "not locked" if the judgment is not locked.

## Trello card / Rollbar error (etc)

https://trello.com/c/l60TQkpe/261-implement-checkout-endpoint
https://trello.com/c/nXl9N4Iz/840-add-checkout-status-function-to-ml-client

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
