### PR TITLE
Judgment checkout may optionally expire at midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 - Add optional annotation parameter to `checkout_judgment` method
 - Add method to get the lock/checkout status of a judgment
+- Judgment checkout may optionally expire at midnight
 
 ## [Release 4.8.0]
 - Gracefully handle a null, empty or unexpected error response from Marklogic 

--- a/src/caselawclient/xquery/checkout_judgment.xqy
+++ b/src/caselawclient/xquery/checkout_judgment.xqy
@@ -4,5 +4,8 @@ import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls
 
 declare variable $uri as xs:string external;
 declare variable $annotation as xs:string external;
+declare variable $timeout as xs:unsignedInt* external;
 
-dls:document-checkout($uri, fn:true(), $annotation)
+let $expires := if (fn:empty($timeout)) then () else $timeout
+
+return dls:document-checkout($uri, fn:true(), $annotation, $expires)


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

A comment on https://trello.com/c/l60TQkpe suggests the checkout/lock of
a judgment may expire at midnight, to ensure judgments aren't locked
"forever".

This commit adds a function `calculate_seconds_until_midnight` which calculates
how many seconds there are until midnight.

The Marklogic function `dls:document-checkout` contains an optional third
parameter which lets you pass in the amount of time in seconds a document
should be locked for.

Marrying these two up, we have amended `checkout_judgment` on the client to
take an optional `expires_at_midnight` parameter. Passing True to this param
means that the number of seconds until midnight is calculated, and passed to
`dls:document-checkout`.

If `expires_at_midnight` is not passed, an empty sequence `()` is used in
`dls:document-checkout` and the judgment is locked indefinitely.

## Trello card / Rollbar error (etc)

 https://trello.com/c/l60TQkpe 

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
