### PR TITLE
Correct various issues with the API Client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi==2021.10.8
 charset-normalizer==2.0.12
 django-environ==0.8.1
 idna==3.3
-requests==2.27.1
-requests==2.27.1
+requests==2.28.1
 requests-toolbelt==0.9.1
 urllib3==1.26.8

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -317,6 +317,8 @@ class MarklogicApiClient:
         if expires_at_midnight:
             timeout = self.calculate_seconds_until_midnight()
             vars["timeout"] = timeout
+        else:
+            vars["timeout"] = -1
 
         return self.eval(
             xquery_path,

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -356,11 +356,15 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
-    def get_judgment_checkout_status_message(self, judgment_uri: str) -> str:
+    def get_judgment_checkout_status_message(self, judgment_uri: str):
+        """Return the annotation of the lock or `None` if there is no lock."""
         response = self.get_judgment_checkout_status(judgment_uri)
-        if response.text == "":
-            return "Not locked"
-        response_xml = ElementTree.fromstring(response.text)
+        if not response.content:
+            return None
+        content = decoder.MultipartDecoder.from_response(response).parts[0].text
+        if content == "":
+            return None
+        response_xml = ElementTree.fromstring(content)
         return response_xml.find("dls:annotation", namespaces={"dls": "http://marklogic.com/xdmp/dls"}).text
 
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -165,8 +165,9 @@ class MarklogicApiClient:
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
+
         if not response.text:
-            return ''
+            raise MarklogicNotPermittedError("The document is not published and show_unpublished was not set")
 
         multipart_data = decoder.MultipartDecoder.from_response(response)
         return multipart_data.parts[0].text

--- a/src/caselawclient/xquery/checkout_judgment.xqy
+++ b/src/caselawclient/xquery/checkout_judgment.xqy
@@ -4,8 +4,8 @@ import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls
 
 declare variable $uri as xs:string external;
 declare variable $annotation as xs:string external;
-declare variable $timeout as xs:unsignedInt* external;
+declare variable $timeout as xs:int external;
 
-let $expires := if (fn:empty($timeout)) then () else $timeout
+let $expires := if ($timeout = -1) then () else $timeout
 
 return dls:document-checkout($uri, fn:true(), $annotation, $expires)

--- a/src/caselawclient/xquery/get_judgment_checkout_status.xqy
+++ b/src/caselawclient/xquery/get_judgment_checkout_status.xqy
@@ -1,6 +1,6 @@
 xquery version "1.0-ml";
 import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
 
-declare variable $uri as xs:string;
+declare variable $uri as xs:string external;
 
 dls:document-checkout-status($uri)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -276,7 +276,8 @@ class ApiClientTest(unittest.TestCase):
             annotation = "locked by A KITTEN"
             expected_vars = {
                 'uri':'/ewca/civ/2004/632.xml',
-                'annotation': 'locked by A KITTEN'
+                'annotation': 'locked by A KITTEN',
+                'timeout': -1
             }
             client.checkout_judgment(uri, annotation)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -494,28 +494,39 @@ class ApiClientTest(unittest.TestCase):
             )
 
     def test_get_checkout_status_message(self):
-        response_text = """
-        <dls:checkout xmlns:dls="http://marklogic.com/xdmp/dls">
-            <dls:document-uri>/ukpc/2022/17.xml</dls:document-uri>
-            <dls:annotation>locked by a kitten</dls:annotation>
-            <dls:timeout>0</dls:timeout>
-            <dls:timestamp>1660210484</dls:timestamp>
-            <sec:user-id xmlns:sec="http://marklogic.com/xdmp/security">10853946559473170020</sec:user-id>
-        </dls:checkout>
-        """
+        client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(MarklogicApiClient, 'eval', return_value=MagicMock(text=response_text)) as mock_method:
-            client = MarklogicApiClient("","","",False)
+        with patch.object(MarklogicApiClient, 'eval') as mock_method:
+            client.eval.return_value.text = 'true'
+            client.eval.return_value.headers = {'content-type': 'multipart/mixed; boundary=595658fa1db1aa98'}
+            client.eval.return_value.content = b'\r\n--595658fa1db1aa98\r\n' \
+                                               b'Content-Type: application/xml\r\n' \
+                                               b'X-Primitive: element()\r\n' \
+                                               b'X-Path: /*\r\n\r\n' \
+                                               b'<dls:checkout xmlns:dls="http://marklogic.com/xdmp/dls">'\
+                                               b'<dls:document-uri>/ukpc/2022/17.xml</dls:document-uri>'\
+                                               b'<dls:annotation>locked by a kitten</dls:annotation>'\
+                                               b'<dls:timeout>0</dls:timeout>'\
+                                               b'<dls:timestamp>1660210484</dls:timestamp>'\
+                                               b'<sec:user-id xmlns:sec="http://marklogic.com/xdmp/security">10853946559473170020</sec:user-id>'\
+                                               b'</dls:checkout>\r\n' \
+                                               b'--595658fa1db1aa98--\r\n'
             result = client.get_judgment_checkout_status_message("/ewca/2002/2")
             assert result == "locked by a kitten"
 
     def test_get_checkout_status_message_empty(self):
-        response_text = ""
-
-        with patch.object(MarklogicApiClient, 'eval', return_value=MagicMock(text=response_text)) as mock_method:
-            client = MarklogicApiClient("", "", "", False)
+        client = MarklogicApiClient("", "", "", False)
+        with patch.object(MarklogicApiClient, 'eval') as mock_method:
+            client.eval.return_value.text = 'true'
+            client.eval.return_value.headers = {'content-type': 'multipart/mixed; boundary=595658fa1db1aa98'}
+            client.eval.return_value.content = b'\r\n--595658fa1db1aa98\r\n' \
+                                               b'Content-Type: application/xml\r\n' \
+                                               b'X-Primitive: element()\r\n' \
+                                               b'X-Path: /*\r\n\r\n' \
+                                               b'\r\n' \
+                                               b'--595658fa1db1aa98--\r\n'
             result = client.get_judgment_checkout_status_message("/ewca/2002/2")
-            assert result == "Not locked"
+            assert result is None
 
     def test_calculate_seconds_until_midnight(self):
         client = MarklogicApiClient("", "", "", False)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

While building the privileged API we encountered a few errors and issues with the API client:

- Error in checkout_judgment.xqy
- New version of requests required
- `get_judgment_checkout_status` returns a multipart response, which `get_judgment_checkout_status_message` needs to handle
- The `timeout` parameter must be passed to `checkout_judgment.xqy`, the parameter must be passed even if it is empty

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
