### PR TITLE
Check if user can view unpublished documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 - Add user_has_privilege method & XQuery to check if a user has a privilege
+- Use `user_has_privilege` to check if a user can see unpublished documents
 
 ## [Release 4.9.1]
 - Fix: add external declaration to XQuery parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+- Add user_has_privilege method & XQuery to check if a user has a privilege
 
 ## [Release 4.9.1]
 - Fix: add external declaration to XQuery parameter

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -64,6 +64,7 @@ class MarklogicApiClient:
         'XDMP-DOCNOTFOUND': MarklogicResourceNotFoundError,
         'XDMP-LOCKCONFLICT': MarklogicResourceLockedError,
         'DLS-UNMANAGED': MarklogicResourceUnmanagedError,
+        'SEC-PRIVDNE': MarklogicNotPermittedError,
     }
 
     default_http_error_class = MarklogicCommunicationError
@@ -624,6 +625,21 @@ class MarklogicApiClient:
         vars = json.dumps({
             "old_uri": old_uri,
             "new_uri": new_uri,
+        })
+        return self.eval(
+            xquery_path,
+            vars=vars,
+            accept_header="application/xml",
+        )
+
+    def user_has_privilege(self, username, privilege_uri, privilege_action):
+        xquery_path = os.path.join(
+            ROOT_DIR, "xquery", "user_has_privilege.xqy"
+        )
+        vars = json.dumps({
+            "user": username,
+            "privilege_uri": privilege_uri,
+            "privilege_action": privilege_action
         })
         return self.eval(
             xquery_path,

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -647,6 +647,14 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def user_can_view_unpublished_judgments(self, username):
+        check_privilege = self.user_has_privilege(
+            username,
+            "https://caselaw.nationalarchives.gov.uk/custom/privileges/can-view-unpublished-documents",
+            "execute"
+        )
+        return check_privilege.text.lower() == "true"
+
     def calculate_seconds_until_midnight(self, now=None):
         """
         Get timedelta until end of day on the datetime passed, or current time.

--- a/src/caselawclient/xquery/user_has_privilege.xqy
+++ b/src/caselawclient/xquery/user_has_privilege.xqy
@@ -1,0 +1,10 @@
+xquery version "1.0-ml";
+
+declare variable $privilege_uri as xs:string external;
+declare variable $privilege_action as xs:string external;
+declare variable $user as xs:string external;
+
+let $privilege_id := xdmp:privilege($privilege_uri, $privilege_action)
+let $user_privileges := xdmp:user-privileges($user)
+
+return fn:boolean(index-of($privilege_id, $user_privileges))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -534,3 +534,23 @@ class ApiClientTest(unittest.TestCase):
         result = client.calculate_seconds_until_midnight(dt)
         expected_result = 3600 # 1 hour in seconds
         self.assertEqual(result, expected_result)
+
+    def test_user_has_privilege(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            user = "laura"
+            privilege_uri = "https://caselaw.nationalarchives.gov.uk/custom/uri"
+            privilege_action = "execute"
+            expected_vars = {
+                "user": "laura",
+                "privilege_uri": "https://caselaw.nationalarchives.gov.uk/custom/uri",
+                "privilege_action": "execute"
+            }
+            client.user_has_privilege(user, privilege_uri, privilege_action)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "user_has_privilege.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -554,3 +554,21 @@ class ApiClientTest(unittest.TestCase):
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )
+
+    def test_user_can_view_unpublished_judgments_true(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval') as _mock_method:
+            client.eval.return_value.text = 'true'
+
+            result = client.user_can_view_unpublished_judgments("laura")
+            self.assertEqual(result, True)
+
+    def test_user_can_view_unpublished_judgments_false(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval') as _mock_method:
+            client.eval.return_value.text = 'false'
+
+            result = client.user_can_view_unpublished_judgments("laura")
+            self.assertEqual(result, False)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

A user has "privileges" in Marklogic, which are represented by names & IDs.
When we want to check to see if a user has a certain privilege, we can get the
ID of the privilege we want to check, then a sequence of the privileges a user
has, and see if the former is in the latter.

The XQuery `user_has_privilege` returns `true` or `false` depending on whether a requested privilege, which is found via its URI and action, is in the user's list of privileges. The method `user_has_privilege()`
returns a response object with a `text` value of `true` or `false`.

In https://github.com/nationalarchives/ds-caselaw-public-access-service/pull/65
we propose to add a custom privilege which indicates a user is allowed to view
unpublished judgments.

The second commit in this PR creates a method `user_can_view_unpublished_judgments` which uses `user_has_privilege()` to check that a user has this privilege
(which is found via its unique URI and action). The method returns `True` or
`False`.


## Trello card / Rollbar error (etc)

https://trello.com/c/o3Wbto2N/263-implement-preview-permissions

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
