### PR TITLE
Changes for privileged client

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,0 +1,1 @@
+python -m unittest discover -s tests

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -20,42 +20,52 @@ ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 class MarklogicAPIError(requests.HTTPError):
-    pass
+    status_code = 500
+    default_message = "An error occurred, and we didn't recognise it."
 
 
 class MarklogicBadRequestError(MarklogicAPIError):
-    pass
+    status_code = 400
+    default_message = "Marklogic did not understand the request that was made."
 
 
 class MarklogicUnauthorizedError(MarklogicAPIError):
-    pass
+    status_code = 401
+    default_message = "Your credentials are not valid, or you did not provide any by basic authentication"
 
 
 class MarklogicNotPermittedError(MarklogicAPIError):
-    pass
+    status_code = 403
+    default_message = "Your credentials are valid, but you are not allowed to do that."
 
 
 class MarklogicResourceNotFoundError(MarklogicAPIError):
-    pass
+    status_code = 404
+    default_message = "No resource with that name could be found."
 
 
 class MarklogicResourceLockedError(MarklogicAPIError):
-    pass
+    status_code = 409
+    default_message = "The resource is locked by another user, so you cannot change it."
 
 
 class MarklogicResourceUnmanagedError(MarklogicAPIError):
-    """Note: this exception may be raised if a document doesn't exist"""
-    pass
+    """Note: this exception may be raised if a document doesn't exist,
+    since all documents should be managed."""
+    status_code = 404
+    default_message = "The resource isn't managed. It probably doesn't exist, and if it does, that's a problem. Please report it."
 
 class MarklogicResourceNotCheckedOutError(MarklogicAPIError):
-    pass
+    status_code = 409
+    default_message = "The resource is not checked out by anyone, but that request needed a checkout first."
 
 class MarklogicCheckoutConflictError(MarklogicAPIError):
-    pass
+    status_code = 409
+    default_message = "The resource is checked out by another user."
 
 class MarklogicCommunicationError(MarklogicAPIError):
-    pass
-
+    status_code = 500
+    default_message = "Something unexpected happened when communicating with the Marklogic server."
 
 class MarklogicApiClient:
 

--- a/src/caselawclient/xquery/update_locked_judgment.xqy
+++ b/src/caselawclient/xquery/update_locked_judgment.xqy
@@ -1,0 +1,17 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls"
+      at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $judgment as xs:string external;
+declare variable $annotation as xs:string external;
+
+let $judgment_xml := xdmp:unquote($judgment)
+
+return dls:document-update(
+   $uri,
+   $judgment_xml,
+   $annotation,
+   fn:true() (: retain history :)
+)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -204,12 +204,32 @@ class ApiClientTest(unittest.TestCase):
             expected_vars = {
                 'uri': '/ewca/civ/2004/632.xml',
                 'judgment': judgment_str,
-                'annotation':''
+                'annotation': 'my annotation',
             }
-            client.save_judgment_xml(uri, judgment_xml)
+            client.save_judgment_xml(uri, judgment_xml, "my annotation")
 
             client.eval.assert_called_with(
                 os.path.join(ROOT_DIR, 'xquery', 'update_judgment.xqy'),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml"
+            )
+
+    def test_save_locked_judgment_xml(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, 'eval'):
+            uri = '/ewca/civ/2004/632'
+            judgment_str = '<root>My updated judgment</root>'
+            judgment_xml = judgment_str.encode('utf-8')
+            expected_vars = {
+                'uri': '/ewca/civ/2004/632.xml',
+                'judgment': judgment_str,
+                'annotation': 'my annotation',
+            }
+            client.save_locked_judgment_xml(uri, judgment_xml, "my annotation")
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, 'xquery', 'update_locked_judgment.xqy'),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml"
             )


### PR DESCRIPTION
Supports matching work in privileged api.

## Changes in this PR:

Two new errors for Checkout issues - not checkout out or checkout conflict
New function/xquery - save locked document

Work to move information about errors into the error subclasses to simplify downstream
(recommended error messages, status codes)

Little script for running the tests

