### PR TITLE
Ensure only people who are allowed to view unpublished judgments can view them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           python-version: 3.9
       - run: pip install -r requirements.txt
-      - run: python -m unittest discover -s tests
+      - run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To run the test suite:
 
 ```bash
 pip install -r requirements.txt
-python -m unittest discover -s tests
+python -m pytest
 ```
 
 ## Making changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ idna==3.3
 requests==2.28.1
 requests-toolbelt==0.9.1
 urllib3==1.26.8
+pytest==7.1.2

--- a/script/test
+++ b/script/test
@@ -1,1 +1,1 @@
-python -m unittest discover -s tests
+python -m pytest

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -183,6 +183,8 @@ class MarklogicApiClient:
         self, judgment_uri, version_uri=None, show_unpublished=False
     ) -> str:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
+        if not self.user_can_view_unpublished_judgments(self.username):
+            show_unpublished = False
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
         xquery_path = os.path.join(ROOT_DIR, "xquery", "get_judgment.xqy")
@@ -500,7 +502,10 @@ class MarklogicApiClient:
         :param only_unpublished: If True, will only return published documents. Ignores the value of show_unpublished
         :return:
         """
+
         module = "/judgments/search/search.xqy"  # as stored on Marklogic
+        if not self.user_can_view_unpublished_judgments(self.username):
+            show_unpublished = False
         vars = json.dumps(
             {
                 "court": str(court or ""),
@@ -536,6 +541,9 @@ class MarklogicApiClient:
             image_location = os.getenv("XSLT_IMAGE_LOCATION")
         else:
             image_location = ""
+
+        if not self.user_can_view_unpublished_judgments(self.username):
+            show_unpublished = False
 
         vars = json.dumps(
             {

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -729,15 +729,18 @@ class MarklogicApiClient:
 
         return difference.seconds
 
-
     def verify_show_unpublished(self, show_unpublished):
-        if not self.user_can_view_unpublished_judgments(self.username) and show_unpublished:
+        if (
+            not self.user_can_view_unpublished_judgments(self.username)
+            and show_unpublished
+        ):
             # The user cannot view unpublished judgments but is requesting to see them
             logging.warning(
                 f"User {self.username} is attempting to view unpublished judgments but does not have that privilege."
             )
             return False
         return show_unpublished
+
 
 api_client = MarklogicApiClient(
     host=env("MARKLOGIC_HOST", default=None),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -146,7 +146,7 @@ class ApiClientTest(unittest.TestCase):
                     )
                     mock_logging.assert_called()
 
-    def test_eval_xslt_with_default_and_user_can_view_unpublished(self):
+    def test_eval_xslt_user_can_view_unpublished(self):
         client = MarklogicApiClient("", "", "", False)
 
         with patch.object(client, 'eval'):
@@ -167,7 +167,7 @@ class ApiClientTest(unittest.TestCase):
                     accept_header='application/xml'
                 )
 
-    def test_eval_xslt_with_default_and_user_cannot_view_unpublished(self):
+    def test_eval_xslt_user_cannot_view_unpublished(self):
         """The user is not permitted to see unpublished judgments but is attempting to view them
         Set `show_unpublished` to false and log a warning"""
         client = MarklogicApiClient("", "", "", False)
@@ -712,7 +712,10 @@ class ApiClientTest(unittest.TestCase):
             result = client.user_can_view_unpublished_judgments("laura")
             assert result == False
 
-    def test_verify_show_unpublished_user_cannot_view_unpublished_and_show_unpublished_true(self):
+class TestVerifyShowUnpublished(unittest.TestCase):
+    # Test `verify_show_unpublished` with users who can/cannot see unpublished judgments
+    # and with them asking for unpublished judgments or not
+    def test_hide_published_if_unauthorised_and_user_asks_for_unpublished(self):
         # User cannot view unpublished but is asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=False):
@@ -722,21 +725,21 @@ class ApiClientTest(unittest.TestCase):
                 # Check the logger was called
                 mock_logger.assert_called()
 
-    def test_verify_show_unpublished_user_cannot_view_unpublished_and_show_unpublished_false(self):
+    def test_hide_unpublished_if_unauthorised_and_does_not_ask_for_unpublished(self):
         # User cannot view unpublished and is not asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=False):
             result = client.verify_show_unpublished(False)
             self.assertEqual(result, False)
 
-    def test_verify_show_unpublished_user_can_view_unpublished_and_show_unpublished_true(self):
+    def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):
             result = client.verify_show_unpublished(True)
             assert result == True
 
-    def test_verify_show_unpublished_user_can_view_unpublished_and_show_unpublished_false(self):
+    def test_hide_unpublished_if_authorised_and_does_not_ask_for_unpublished(self):
         # User can view unpublished but is NOT asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from xml.etree import ElementTree
 
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
-import pytest as pytest
 
 
 class ApiClientTest(unittest.TestCase):
@@ -32,13 +31,17 @@ class ApiClientTest(unittest.TestCase):
             data={"xquery": "mock-query", "vars": '{{"testvar":"test"}}'},
         )
 
-    def test_advanced_search_user_can_view_unpublished_but_show_unpublished_is_false(self):
+    def test_advanced_search_user_can_view_unpublished_but_show_unpublished_is_false(
+        self,
+    ):
         """If a user who is allowed to view unpublished judgments wishes to specifically see only published
-           judgments, do not change the value of `show_unpublished`"""
+        judgments, do not change the value of `show_unpublished`"""
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'invoke'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=True):
+        with patch.object(client, "invoke"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=True
+            ):
                 client.advanced_search(
                     q="my-query",
                     court="ewhc",
@@ -46,7 +49,7 @@ class ApiClientTest(unittest.TestCase):
                     party="a party",
                     page=2,
                     page_size=20,
-                    show_unpublished=False
+                    show_unpublished=False,
                 )
 
                 expected_vars = {
@@ -62,19 +65,22 @@ class ApiClientTest(unittest.TestCase):
                     "from": "",
                     "to": "",
                     "show_unpublished": "false",
-                    "only_unpublished": "false"
+                    "only_unpublished": "false",
                 }
 
                 client.invoke.assert_called_with(
-                    '/judgments/search/search.xqy',
-                    json.dumps(expected_vars)
+                    "/judgments/search/search.xqy", json.dumps(expected_vars)
                 )
 
-    def test_advanced_search_user_can_view_unpublished_and_show_unpublished_is_true(self):
+    def test_advanced_search_user_can_view_unpublished_and_show_unpublished_is_true(
+        self,
+    ):
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'invoke'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=True):
+        with patch.object(client, "invoke"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=True
+            ):
                 client.advanced_search(
                     q="my-query",
                     court="ewhc",
@@ -82,7 +88,7 @@ class ApiClientTest(unittest.TestCase):
                     party="a party",
                     page=2,
                     page_size=20,
-                    show_unpublished=True
+                    show_unpublished=True,
                 )
 
                 expected_vars = {
@@ -98,21 +104,24 @@ class ApiClientTest(unittest.TestCase):
                     "from": "",
                     "to": "",
                     "show_unpublished": "true",
-                    "only_unpublished": "false"
+                    "only_unpublished": "false",
                 }
 
                 client.invoke.assert_called_with(
-                    '/judgments/search/search.xqy',
-                    json.dumps(expected_vars)
+                    "/judgments/search/search.xqy", json.dumps(expected_vars)
                 )
 
-    def test_advanced_search_user_cannot_view_unpublished_but_show_unpublished_is_true(self):
+    def test_advanced_search_user_cannot_view_unpublished_but_show_unpublished_is_true(
+        self,
+    ):
         """The user is not permitted to see unpublished judgments but is attempting to view them
         Set `show_unpublished` to false and log a warning"""
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'invoke'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=False):
+        with patch.object(client, "invoke"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=False
+            ):
                 with patch.object(logging, "warning") as mock_logging:
                     client.advanced_search(
                         q="my-query",
@@ -121,7 +130,7 @@ class ApiClientTest(unittest.TestCase):
                         party="a party",
                         page=2,
                         page_size=20,
-                        show_unpublished=True
+                        show_unpublished=True,
                     )
 
                     expected_vars = {
@@ -137,34 +146,35 @@ class ApiClientTest(unittest.TestCase):
                         "from": "",
                         "to": "",
                         "show_unpublished": "false",
-                        "only_unpublished": "false"
+                        "only_unpublished": "false",
                     }
 
                     client.invoke.assert_called_with(
-                        '/judgments/search/search.xqy',
-                        json.dumps(expected_vars)
+                        "/judgments/search/search.xqy", json.dumps(expected_vars)
                     )
                     mock_logging.assert_called()
 
     def test_eval_xslt_user_can_view_unpublished(self):
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'eval'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=True):
+        with patch.object(client, "eval"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=True
+            ):
                 uri = "/judgment/uri"
                 expected_vars = {
                     "uri": "/judgment/uri.xml",
                     "version_uri": None,
                     "show_unpublished": "true",
                     "img_location": "",
-                    "xsl_filename": "judgment2.xsl"
+                    "xsl_filename": "judgment2.xsl",
                 }
                 client.eval_xslt(uri, show_unpublished=True)
 
                 client.eval.assert_called_with(
                     os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"),
                     vars=json.dumps(expected_vars),
-                    accept_header='application/xml'
+                    accept_header="application/xml",
                 )
 
     def test_eval_xslt_user_cannot_view_unpublished(self):
@@ -172,8 +182,10 @@ class ApiClientTest(unittest.TestCase):
         Set `show_unpublished` to false and log a warning"""
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'eval'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=False):
+        with patch.object(client, "eval"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=False
+            ):
                 with patch.object(logging, "warning") as mock_logging:
                     uri = "/judgment/uri"
                     expected_vars = {
@@ -181,36 +193,40 @@ class ApiClientTest(unittest.TestCase):
                         "version_uri": None,
                         "show_unpublished": "false",
                         "img_location": "",
-                        "xsl_filename": "judgment2.xsl"
+                        "xsl_filename": "judgment2.xsl",
                     }
                     client.eval_xslt(uri, show_unpublished=True)
 
                     client.eval.assert_called_with(
                         os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"),
                         vars=json.dumps(expected_vars),
-                        accept_header='application/xml'
+                        accept_header="application/xml",
                     )
                     mock_logging.assert_called()
 
     def test_eval_xslt_with_filename(self):
         client = MarklogicApiClient("", "", "", False)
 
-        with patch.object(client, 'eval'):
-            with patch.object(client, 'user_can_view_unpublished_judgments', return_value=True):
+        with patch.object(client, "eval"):
+            with patch.object(
+                client, "user_can_view_unpublished_judgments", return_value=True
+            ):
                 uri = "/judgment/uri"
                 expected_vars = {
                     "uri": "/judgment/uri.xml",
                     "version_uri": None,
                     "show_unpublished": "true",
                     "img_location": "",
-                    "xsl_filename": "judgment0.xsl"
+                    "xsl_filename": "judgment0.xsl",
                 }
-                client.eval_xslt(uri, show_unpublished=True, xsl_filename="judgment0.xsl")
+                client.eval_xslt(
+                    uri, show_unpublished=True, xsl_filename="judgment0.xsl"
+                )
 
                 client.eval.assert_called_with(
                     os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"),
                     vars=json.dumps(expected_vars),
-                    accept_header='application/xml'
+                    accept_header="application/xml",
                 )
 
     def test_set_boolean_property_true(self):
@@ -301,11 +317,13 @@ class ApiClientTest(unittest.TestCase):
 
             result = client.get_judgment_xml("/judgment/uri")
 
-            expected = '<?xml version="1.0" encoding="UTF-8"?>\n' \
-                        '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n' \
-                        '<judgment name="judgment" contains="originalVersion">\n' \
-                        '</judgment>\n' \
-                        '</akomaNtoso>'
+            expected = (
+                '<?xml version="1.0" encoding="UTF-8"?>\n'
+                '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n'
+                '<judgment name="judgment" contains="originalVersion">\n'
+                "</judgment>\n"
+                "</akomaNtoso>"
+            )
             assert result == expected
 
     def test_save_judgment_xml(self):
@@ -671,7 +689,7 @@ class ApiClientTest(unittest.TestCase):
             "2020-01-01 23:00", "%Y-%m-%d %H:%M"
         )  # 1 hour until midnight
         result = client.calculate_seconds_until_midnight(dt)
-        expected_result = 3600 # 1 hour in seconds
+        expected_result = 3600  # 1 hour in seconds
         assert result == expected_result
 
     def test_user_has_privilege(self):
@@ -712,13 +730,16 @@ class ApiClientTest(unittest.TestCase):
             result = client.user_can_view_unpublished_judgments("laura")
             assert result == False
 
+
 class TestVerifyShowUnpublished(unittest.TestCase):
     # Test `verify_show_unpublished` with users who can/cannot see unpublished judgments
     # and with them asking for unpublished judgments or not
     def test_hide_published_if_unauthorised_and_user_asks_for_unpublished(self):
         # User cannot view unpublished but is asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
-        with patch.object(client, "user_can_view_unpublished_judgments", return_value=False):
+        with patch.object(
+            client, "user_can_view_unpublished_judgments", return_value=False
+        ):
             with patch.object(logging, "warning") as mock_logger:
                 result = client.verify_show_unpublished(True)
                 assert result == False
@@ -728,20 +749,26 @@ class TestVerifyShowUnpublished(unittest.TestCase):
     def test_hide_unpublished_if_unauthorised_and_does_not_ask_for_unpublished(self):
         # User cannot view unpublished and is not asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
-        with patch.object(client, "user_can_view_unpublished_judgments", return_value=False):
+        with patch.object(
+            client, "user_can_view_unpublished_judgments", return_value=False
+        ):
             result = client.verify_show_unpublished(False)
             self.assertEqual(result, False)
 
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
-        with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):
+        with patch.object(
+            client, "user_can_view_unpublished_judgments", return_value=True
+        ):
             result = client.verify_show_unpublished(True)
             assert result == True
 
     def test_hide_unpublished_if_authorised_and_does_not_ask_for_unpublished(self):
         # User can view unpublished but is NOT asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
-        with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):
+        with patch.object(
+            client, "user_can_view_unpublished_judgments", return_value=True
+        ):
             result = client.verify_show_unpublished(False)
             assert result == False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -272,7 +272,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = ""
             result = client.get_boolean_property("/judgment/uri", "my-property")
 
-            assert result == False
+            assert result is False
 
     def test_get_boolean_property(self):
         client = MarklogicApiClient("", "", "", False)
@@ -293,7 +293,7 @@ class ApiClientTest(unittest.TestCase):
             )
             result = client.get_boolean_property("/judgment/uri", "my-property")
 
-            assert result == True
+            assert result is True
 
     def test_get_judgment_xml(self):
         client = MarklogicApiClient("", "", "", False)
@@ -719,7 +719,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = "true"
 
             result = client.user_can_view_unpublished_judgments("laura")
-            assert result == True
+            assert result is True
 
     def test_user_can_view_unpublished_judgments_false(self):
         client = MarklogicApiClient("", "", "", False)
@@ -728,7 +728,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = "false"
 
             result = client.user_can_view_unpublished_judgments("laura")
-            assert result == False
+            assert result is False
 
 
 class TestVerifyShowUnpublished(unittest.TestCase):
@@ -742,7 +742,7 @@ class TestVerifyShowUnpublished(unittest.TestCase):
         ):
             with patch.object(logging, "warning") as mock_logger:
                 result = client.verify_show_unpublished(True)
-                assert result == False
+                assert result is False
                 # Check the logger was called
                 mock_logger.assert_called()
 
@@ -762,7 +762,7 @@ class TestVerifyShowUnpublished(unittest.TestCase):
             client, "user_can_view_unpublished_judgments", return_value=True
         ):
             result = client.verify_show_unpublished(True)
-            assert result == True
+            assert result is True
 
     def test_hide_unpublished_if_authorised_and_does_not_ask_for_unpublished(self):
         # User can view unpublished but is NOT asking to view unpublished judgments
@@ -771,4 +771,4 @@ class TestVerifyShowUnpublished(unittest.TestCase):
             client, "user_can_view_unpublished_judgments", return_value=True
         ):
             result = client.verify_show_unpublished(False)
-            assert result == False
+            assert result is False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from xml.etree import ElementTree
 
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
+import pytest as pytest
 
 
 class ApiClientTest(unittest.TestCase):
@@ -255,7 +256,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = ""
             result = client.get_boolean_property("/judgment/uri", "my-property")
 
-            self.assertFalse(result)
+            assert result == False
 
     def test_get_boolean_property(self):
         client = MarklogicApiClient("", "", "", False)
@@ -276,7 +277,7 @@ class ApiClientTest(unittest.TestCase):
             )
             result = client.get_boolean_property("/judgment/uri", "my-property")
 
-            self.assertTrue(result)
+            assert result == True
 
     def test_get_judgment_xml(self):
         client = MarklogicApiClient("", "", "", False)
@@ -300,14 +301,12 @@ class ApiClientTest(unittest.TestCase):
 
             result = client.get_judgment_xml("/judgment/uri")
 
-            expected = (
-                '<?xml version="1.0" encoding="UTF-8"?>\n'
-                '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n'
-                '<judgment name="judgment" contains="originalVersion">\n'
-                "</judgment>\n"
-                "</akomaNtoso>"
-            )
-            self.assertEqual(result, expected)
+            expected = '<?xml version="1.0" encoding="UTF-8"?>\n' \
+                        '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n' \
+                        '<judgment name="judgment" contains="originalVersion">\n' \
+                        '</judgment>\n' \
+                        '</akomaNtoso>'
+            assert result == expected
 
     def test_save_judgment_xml(self):
         client = MarklogicApiClient("", "", "", False)
@@ -473,7 +472,7 @@ class ApiClientTest(unittest.TestCase):
             )
             result = client.get_property("/judgment/uri", "my-property")
 
-            self.assertEqual("my-content", result)
+            assert "my-content" == result
 
     def test_get_unset_property(self):
         client = MarklogicApiClient("", "", "", False)
@@ -482,7 +481,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = ""
             result = client.get_property("/judgment/uri", "my-property")
 
-            self.assertEqual("", result)
+            assert "" == result
 
     def test_set_property(self):
         client = MarklogicApiClient("", "", "", False)
@@ -672,8 +671,8 @@ class ApiClientTest(unittest.TestCase):
             "2020-01-01 23:00", "%Y-%m-%d %H:%M"
         )  # 1 hour until midnight
         result = client.calculate_seconds_until_midnight(dt)
-        expected_result = 3600  # 1 hour in seconds
-        self.assertEqual(result, expected_result)
+        expected_result = 3600 # 1 hour in seconds
+        assert result == expected_result
 
     def test_user_has_privilege(self):
         client = MarklogicApiClient("", "", "", False)
@@ -702,7 +701,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = "true"
 
             result = client.user_can_view_unpublished_judgments("laura")
-            self.assertEqual(result, True)
+            assert result == True
 
     def test_user_can_view_unpublished_judgments_false(self):
         client = MarklogicApiClient("", "", "", False)
@@ -711,7 +710,7 @@ class ApiClientTest(unittest.TestCase):
             client.eval.return_value.text = "false"
 
             result = client.user_can_view_unpublished_judgments("laura")
-            self.assertEqual(result, False)
+            assert result == False
 
     def test_verify_show_unpublished_user_cannot_view_unpublished_and_show_unpublished_true(self):
         # User cannot view unpublished but is asking to view unpublished judgments
@@ -719,7 +718,7 @@ class ApiClientTest(unittest.TestCase):
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=False):
             with patch.object(logging, "warning") as mock_logger:
                 result = client.verify_show_unpublished(True)
-                self.assertEqual(result, False)
+                assert result == False
                 # Check the logger was called
                 mock_logger.assert_called()
 
@@ -735,11 +734,11 @@ class ApiClientTest(unittest.TestCase):
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):
             result = client.verify_show_unpublished(True)
-            self.assertEqual(result, True)
+            assert result == True
 
     def test_verify_show_unpublished_user_can_view_unpublished_and_show_unpublished_false(self):
         # User can view unpublished but is NOT asking to view unpublished judgments
         client = MarklogicApiClient("", "", "", False)
         with patch.object(client, "user_can_view_unpublished_judgments", return_value=True):
             result = client.verify_show_unpublished(False)
-            self.assertEqual(result, False)
+            assert result == False


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

We have added `user_can_view_unpublished_judgments(self.username)` to the
client, which allows us to check that the currently logged in user (`username`)
has the appropriate permission to view unpublished judgments.

If a user attempts to access unpublished judgments by (somehow) calling an
endpoint with `show_unpublished=True` BUT they do not have the correct privilege
to view unpublished judgments, they should not be allowed to do that. Instead
`show_unpublished` will be set to False and they will not be able to see
unpublished judgments.

If a user who *is* allowed to view unpublished judgments asks specifically to
view unpublished judgments, by passing in `show_unpublished=False`, the value
of `show_unpublished` will remain False to allow them to view the required
unpublished judgments.

TODO: Refactor these tests!!

## Trello card / Rollbar error (etc)

https://trello.com/c/o3Wbto2N/263-implement-preview-permissions

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
