### PR TITLE
Break judgment checkout

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -694,6 +694,20 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def break_checkout(self, judgment_uri):
+        uri = self._format_uri(judgment_uri)
+        xquery_path = os.path.join(ROOT_DIR, "xquery", "break_judgment_checkout.xqy")
+        vars = json.dumps(
+            {
+                "uri": uri,
+            }
+        )
+        return self.eval(
+            xquery_path,
+            vars=vars,
+            accept_header="application/xml",
+        )
+
     def user_has_privilege(self, username, privilege_uri, privilege_action):
         xquery_path = os.path.join(ROOT_DIR, "xquery", "user_has_privilege.xqy")
         vars = json.dumps(

--- a/src/caselawclient/xquery/break_judgment_checkout.xqy
+++ b/src/caselawclient/xquery/break_judgment_checkout.xqy
@@ -1,0 +1,7 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+let $deep := fn:true()
+
+return dls:break-checkout($uri, $deep)

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -123,3 +123,19 @@ class TestGetCheckoutStatus(unittest.TestCase):
         result = self.client.calculate_seconds_until_midnight(dt)
         expected_result = 3600  # 1 hour in seconds
         assert result == expected_result
+
+    def test_break_judgment_checkout(self):
+        client = MarklogicApiClient("", "", "", False)
+
+        with patch.object(client, "eval"):
+            uri = "judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+            }
+            client.break_checkout(uri)
+
+            client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "break_judgment_checkout.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml",
+            )


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

Add the ability to break a checkout lock on a judgment. If a judgment is locked
we need a way to break the lock and return it to an editable state.

The XQuery uses `dls:break-checkout($uri, $deep)` to break the lock and
any locks on associated versions.

The function `break_checkout()` returns a request object containing no content
- the XQuery returns an empty sequence (assuming the requested URI exists).

## Trello card / Rollbar error (etc)

https://trello.com/c/3eDUGYfk/837-implement-break-checkout-endpoint-function

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
