### PR TITLE
Support renaming of the XSL Transformation files

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -18,6 +18,7 @@ from . import xml_tools
 env = environ.Env()
 RESULTS_PER_PAGE = 10
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
+DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
 
 
 class MarklogicAPIError(requests.HTTPError):
@@ -527,7 +528,7 @@ class MarklogicApiClient:
         judgment_uri,
         version_uri=None,
         show_unpublished=False,
-        xsl_filename="accessible-html.xsl",
+        xsl_filename=DEFAULT_XSL_TRANSFORM,
     ) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         if version_uri:
@@ -555,7 +556,10 @@ class MarklogicApiClient:
         self, judgment_uri, version_uri=None, show_unpublished=False
     ):
         return self.eval_xslt(
-            judgment_uri, version_uri, show_unpublished, xsl_filename="accessible-html.xsl"
+            judgment_uri,
+            version_uri,
+            show_unpublished,
+            xsl_filename=DEFAULT_XSL_TRANSFORM,
         )
 
     def original_judgment_transformation(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -527,7 +527,7 @@ class MarklogicApiClient:
         judgment_uri,
         version_uri=None,
         show_unpublished=False,
-        xsl_filename="judgment2.xsl",
+        xsl_filename="accessible-html.xsl",
     ) -> requests.Response:
         uri = f"/{judgment_uri.lstrip('/')}.xml"
         if version_uri:
@@ -555,14 +555,17 @@ class MarklogicApiClient:
         self, judgment_uri, version_uri=None, show_unpublished=False
     ):
         return self.eval_xslt(
-            judgment_uri, version_uri, show_unpublished, xsl_filename="judgment2.xsl"
+            judgment_uri, version_uri, show_unpublished, xsl_filename="accessible-html.xsl"
         )
 
     def original_judgment_transformation(
         self, judgment_uri, version_uri=None, show_unpublished=False
     ):
         return self.eval_xslt(
-            judgment_uri, version_uri, show_unpublished, xsl_filename="judgment0.xsl"
+            judgment_uri,
+            version_uri,
+            show_unpublished,
+            xsl_filename="as-handed-down.xsl",
         )
 
     def get_property(self, judgment_uri, name):

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -22,7 +22,7 @@ class TestEvalXslt(unittest.TestCase):
                     "version_uri": None,
                     "show_unpublished": "true",
                     "img_location": "",
-                    "xsl_filename": "judgment2.xsl",
+                    "xsl_filename": "accessible-html.xsl",
                 }
                 self.client.eval_xslt(uri, show_unpublished=True)
 
@@ -47,7 +47,7 @@ class TestEvalXslt(unittest.TestCase):
                         "version_uri": None,
                         "show_unpublished": "false",
                         "img_location": "",
-                        "xsl_filename": "judgment2.xsl",
+                        "xsl_filename": "accessible-html.xsl",
                     }
                     self.client.eval_xslt(uri, show_unpublished=True)
 
@@ -70,10 +70,10 @@ class TestEvalXslt(unittest.TestCase):
                     "version_uri": None,
                     "show_unpublished": "true",
                     "img_location": "",
-                    "xsl_filename": "judgment0.xsl",
+                    "xsl_filename": "as-handed-down.xsl",
                 }
                 self.client.eval_xslt(
-                    uri, show_unpublished=True, xsl_filename="judgment0.xsl"
+                    uri, show_unpublished=True, xsl_filename="as-handed-down.xsl"
                 )
 
                 assert self.client.eval.call_args.args[0] == (


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

In https://github.com/nationalarchives/ds-caselaw-public-access-service/pull/72
we will be renaming the XSL Transformation files in Marklogic from `judgment0`
and `judgment2` to `as-handed-down` and `accessible-html`, in order to be more
descriptive. This commit supports those changes.

## Trello card / Rollbar error (etc)

https://trello.com/c/dylwn8lt/830-rename-judgment2-and-judgment0-xslts-in-public-access-service

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
