### PR TITLE
Methods & XQueries to get & set all metadata

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -258,7 +258,7 @@ class MarklogicApiClient:
 
         response = self.eval(
             xquery_path,
-            vars=f'{{"uri":"{uri}", "content":"{content}"}}',
+            vars=f'{{"uri": "{uri}", "content": "{content}"}}',
             accept_header="application/xml",
         )
         return response
@@ -740,6 +740,16 @@ class MarklogicApiClient:
             )
             return False
         return show_unpublished
+
+    def get_judgment_citation(self, judgment_uri):
+        uri = self._format_uri(judgment_uri)
+        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
+        vars = json.dumps({"uri": uri})
+        return self.eval(
+            xquery_path,
+            vars=vars,
+            accept_header="application/xml",
+        )
 
 
 api_client = MarklogicApiClient(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -761,6 +761,16 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def get_judgment_work_date(self, judgment_uri):
+        uri = self._format_uri(judgment_uri)
+        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_work_date.xqy")
+        vars = json.dumps({"uri": uri})
+        return self.eval(
+            xquery_path,
+            vars=vars,
+            accept_header="application/xml",
+        )
+
 
 api_client = MarklogicApiClient(
     host=env("MARKLOGIC_HOST", default=None),

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -269,7 +269,7 @@ class MarklogicApiClient:
 
         response = self.eval(
             xquery_path,
-            vars=f'{{"uri":"{uri}", "content":"{content}"}}',
+            vars=f'{{"uri": "{uri}", "content": "{content}"}}',
             accept_header="application/xml",
         )
         return response
@@ -744,6 +744,16 @@ class MarklogicApiClient:
     def get_judgment_citation(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
+        vars = json.dumps({"uri": uri})
+        return self.eval(
+            xquery_path,
+            vars=vars,
+            accept_header="application/xml",
+        )
+
+    def get_judgment_court(self, judgment_uri):
+        uri = self._format_uri(judgment_uri)
+        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_court.xqy")
         vars = json.dumps({"uri": uri})
         return self.eval(
             xquery_path,

--- a/src/caselawclient/xquery/get_metadata_citation.xqy
+++ b/src/caselawclient/xquery/get_metadata_citation.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+
+let $judgment := fn:document($uri)
+
+return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite/text()

--- a/src/caselawclient/xquery/get_metadata_court.xqy
+++ b/src/caselawclient/xquery/get_metadata_court.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+
+let $judgment := fn:document($uri)
+
+return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court/text()

--- a/src/caselawclient/xquery/get_metadata_work_date.xqy
+++ b/src/caselawclient/xquery/get_metadata_work_date.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
+declare variable $uri as xs:string external;
+
+let $judgment := fn:document($uri)
+
+return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -63,3 +63,32 @@ class TestGetSetMetadata(unittest.TestCase):
             assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
                 expected_vars
             )
+
+    def test_get_judgment_date(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            expected_vars = {"uri": "/judgment/uri.xml"}
+            self.client.get_judgment_work_date(uri)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "get_metadata_work_date.xqy")
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_set_judgment_date(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            content = "01-01-2023"
+            expected_vars = {"uri": "/judgment/uri.xml", "content": content}
+            self.client.set_judgment_work_expression_date(uri, content)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(
+                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
+                )
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -31,8 +31,35 @@ class TestGetSetMetadata(unittest.TestCase):
             self.client.set_judgment_citation(uri, content)
 
             assert self.client.eval.call_args.args[0] == (
-                os.path.join(
-                    ROOT_DIR, "xquery", "set_metadata_citation.xqy"
-                )
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
             )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_get_judgment_court(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            expected_vars = {"uri": "/judgment/uri.xml"}
+            self.client.get_judgment_court(uri)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "get_metadata_court.xqy")
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_set_judgment_court(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            content = "new court"
+            expected_vars = {"uri": "/judgment/uri.xml", "content": content}
+            self.client.set_judgment_court(uri, content)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -1,0 +1,38 @@
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
+
+
+class TestGetSetMetadata(unittest.TestCase):
+    def setUp(self):
+        self.client = MarklogicApiClient("", "", "", False)
+
+    def test_get_judgment_citation(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            expected_vars = {"uri": "/judgment/uri.xml"}
+            self.client.get_judgment_citation(uri)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_set_judgment_citation(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            content = "new neutral citation"
+            expected_vars = {"uri": "/judgment/uri.xml", "content": content}
+            self.client.set_judgment_citation(uri, content)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(
+                    ROOT_DIR, "xquery", "set_metadata_citation.xqy"
+                )
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+import warnings
 from unittest.mock import patch
 
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
@@ -88,6 +89,60 @@ class TestGetSetMetadata(unittest.TestCase):
                 os.path.join(
                     ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
                 )
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_set_judgment_date_warn(self):
+        with patch.object(warnings, "warn") as mock_warn, patch.object(
+            self.client, "eval"
+        ):
+            uri = "judgment/uri"
+            content = "2022-01-01"
+            expected_vars = {"uri": "/judgment/uri.xml", "content": "2022-01-01"}
+            self.client.set_judgment_date(uri, content)
+
+            assert mock_warn.call_args.kwargs == {"stacklevel": 2}
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(
+                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
+                )
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_set_internal_uri_leading_slash(self):
+        with patch.object(self.client, "eval"):
+            uri = "/judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
+                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
+                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
+            }
+            self.client.set_judgment_this_uri(uri)
+
+            self.client.eval.assert_called_with(
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"),
+                vars=json.dumps(expected_vars),
+                accept_header="application/xml",
+            )
+
+    def test_set_internal_uri_no_leading_slash(self):
+        with patch.object(self.client, "eval"):
+            uri = "judgment/uri"
+            expected_vars = {
+                "uri": "/judgment/uri.xml",
+                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
+                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
+                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
+            }
+            self.client.set_judgment_this_uri(uri)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy")
             )
             assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
                 expected_vars

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -1,7 +1,6 @@
 import json
 import os
 import unittest
-import warnings
 from unittest.mock import patch
 
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
@@ -109,74 +108,4 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "set_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
-            )
-
-    def test_set_internal_uri_leading_slash(self):
-        with patch.object(self.client, "eval"):
-            uri = "/judgment/uri"
-            expected_vars = {
-                "uri": "/judgment/uri.xml",
-                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
-                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
-                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
-            }
-            self.client.set_judgment_this_uri(uri)
-
-            self.client.eval.assert_called_with(
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"),
-                vars=json.dumps(expected_vars),
-                accept_header="application/xml",
-            )
-
-    def test_set_internal_uri_no_leading_slash(self):
-        with patch.object(self.client, "eval"):
-            uri = "judgment/uri"
-            expected_vars = {
-                "uri": "/judgment/uri.xml",
-                "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",
-                "content_without_id": "https://caselaw.nationalarchives.gov.uk/judgment/uri",
-                "content_with_xml": "https://caselaw.nationalarchives.gov.uk/judgment/uri/data.xml",
-            }
-            self.client.set_judgment_this_uri(uri)
-
-            assert self.client.eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy")
-            )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
-                expected_vars
-            )
-
-    def test_set_judgment_date_warn(self):
-        with patch.object(warnings, "warn") as mock_warn, patch.object(
-            self.client, "eval"
-        ):
-            uri = "judgment/uri"
-            content = "2022-01-01"
-            expected_vars = {"uri": "/judgment/uri.xml", "content": "2022-01-01"}
-            self.client.set_judgment_date(uri, content)
-
-            assert mock_warn.call_args.kwargs == {"stacklevel": 2}
-            assert self.client.eval.call_args.args[0] == (
-                os.path.join(
-                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
-                )
-            )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
-                expected_vars
-            )
-
-    def test_set_judgment_date_work_expression(self):
-        with patch.object(self.client, "eval"):
-            uri = "judgment/uri"
-            content = "2022-01-01"
-            expected_vars = {"uri": "/judgment/uri.xml", "content": "2022-01-01"}
-            self.client.set_judgment_work_expression_date(uri, content)
-
-            assert self.client.eval.call_args.args[0] == (
-                os.path.join(
-                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
-                )
-            )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
-                expected_vars
             )


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Currently we have XQuery-based methods for setting some metadata values, but not for getting them. Instead, the editor UI uses methods in XMLTools to get some of the metadata values ([example](https://github.com/nationalarchives/ds-caselaw-custom-api-client/blob/main/src/caselawclient/xml_tools.py#L18)). This is less efficient than using the XQuery-based methods, as it involves getting the entire document in memory, parsing it and picking out the desired values; using XQuery we can extract the values directly from Marklogic. 

This PR adds getters for all the metadata values we edit in the editor UI. It also adds some missing tests and moves some tests from TetGetSetProperties to a new TestGetSetMetadata file. 

## Trello card / Rollbar error (etc)

https://trello.com/c/bqXeyL28/896-add-methods-to-get-set-all-metadata-in-the-custom-api-client
Towards https://trello.com/c/X1IkTexF/883-refactor-xmltools-usage-in-eui

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
