### PR TITLE
DRY up some aspects of the API Client

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -138,7 +138,11 @@ class MarklogicApiClient:
             raise new_exception
 
     def _format_uri(self, uri):
-        return f"/{uri.lstrip('/')}.xml"
+        """
+        Marklogic requiores a document URI that begins with a slash `/` and ends in `.xml`.
+        This method ensures any URI passed into the client matches this format.
+        """
+        return f"/{uri.lstrip('/').rstrip('/')}.xml"
 
     def prepare_request_kwargs(
         self, method: str, path: str, body=None, data: Optional[Dict[str, Any]] = None
@@ -182,7 +186,7 @@ class MarklogicApiClient:
     def get_judgment_xml(
         self, judgment_uri, version_uri=None, show_unpublished=False
     ) -> str:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         show_unpublished = self.verify_show_unpublished(show_unpublished)
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
@@ -208,7 +212,7 @@ class MarklogicApiClient:
         return multipart_data.parts[0].text
 
     def get_judgment_name(self, judgment_uri) -> str:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_name.xqy")
 
         response = self.eval(
@@ -221,7 +225,7 @@ class MarklogicApiClient:
         return multipart_data.parts[0].text
 
     def set_judgment_name(self, judgment_uri, content):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_name.xqy")
 
         response = self.eval(
@@ -240,7 +244,7 @@ class MarklogicApiClient:
         return self.set_judgment_work_expression_date(judgment_uri, content)
 
     def set_judgment_work_expression_date(self, judgment_uri, content):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(
             ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
         )
@@ -253,7 +257,7 @@ class MarklogicApiClient:
         return response
 
     def set_judgment_citation(self, judgment_uri, content):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
 
         response = self.eval(
@@ -264,7 +268,7 @@ class MarklogicApiClient:
         return response
 
     def set_judgment_court(self, judgment_uri, content):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
 
         response = self.eval(
@@ -275,7 +279,7 @@ class MarklogicApiClient:
         return response
 
     def set_judgment_this_uri(self, judgment_uri):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         content_with_id = (
             f"https://caselaw.nationalarchives.gov.uk/id/{judgment_uri.lstrip('/')}"
         )
@@ -301,7 +305,7 @@ class MarklogicApiClient:
     ) -> requests.Response:
         """assumes the judgment is already locked, does not unlock/check in
         note this version assumes the XML is raw bytes, rather than a tree..."""
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy")
         vars = {
             "uri": uri,
@@ -321,7 +325,7 @@ class MarklogicApiClient:
         """update_judgment uses dls:document-checkout-update-checkin as a single operation"""
         xml = ElementTree.tostring(judgment_xml)
 
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "update_judgment.xqy")
         vars = {
             "uri": uri,
@@ -340,7 +344,7 @@ class MarklogicApiClient:
     ) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "insert_judgment.xqy")
         vars = {"uri": uri, "judgment": xml.decode("utf-8"), "annotation": ""}
 
@@ -351,7 +355,7 @@ class MarklogicApiClient:
         )
 
     def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "list_judgment_versions.xqy")
         vars = {"uri": uri}
 
@@ -364,7 +368,7 @@ class MarklogicApiClient:
     def checkout_judgment(
         self, judgment_uri: str, annotation="", expires_at_midnight=False
     ) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy")
         vars = {
             "uri": uri,
@@ -384,7 +388,7 @@ class MarklogicApiClient:
         )
 
     def checkin_judgment(self, judgment_uri: str) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "checkin_judgment.xqy")
         vars = {"uri": uri}
 
@@ -395,7 +399,7 @@ class MarklogicApiClient:
         )
 
     def get_judgment_checkout_status(self, judgment_uri: str) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(
             ROOT_DIR, "xquery", "get_judgment_checkout_status.xqy"
         )
@@ -423,7 +427,7 @@ class MarklogicApiClient:
     def get_judgment_version(
         self, judgment_uri: str, version: int
     ) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "get_judgment_version.xqy")
         vars = {"uri": uri, "version": str(version)}
 
@@ -529,9 +533,9 @@ class MarklogicApiClient:
         show_unpublished=False,
         xsl_filename="judgment2.xsl",
     ) -> requests.Response:
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         if version_uri:
-            version_uri = f"/{version_uri.lstrip('/')}.xml"
+            version_uri = self._format_uri(version_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
         if os.getenv("XSLT_IMAGE_LOCATION"):
             image_location = os.getenv("XSLT_IMAGE_LOCATION")
@@ -603,7 +607,7 @@ class MarklogicApiClient:
         )
 
     def set_boolean_property(self, judgment_uri, name, value):
-        uri = f"/{judgment_uri.lstrip('/')}.xml"
+        uri = self._format_uri(judgment_uri)
         xquery_path = os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy")
         string_value = "true" if value else "false"
         vars = json.dumps(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -215,10 +215,11 @@ class MarklogicApiClient:
 
     def get_judgment_name(self, judgment_uri) -> str:
         uri = self._format_uri(judgment_uri)
+        vars = {"uri": uri}
 
         response = self.eval(
             self._xquery_path("get_metadata_name.xqy"),
-            vars=f'{{"uri":"{uri}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         if not response.text:
@@ -229,10 +230,11 @@ class MarklogicApiClient:
 
     def set_judgment_name(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
+        vars = {"uri": uri, "content": content}
 
         response = self.eval(
             self._xquery_path("set_metadata_name.xqy"),
-            vars=f'{{"uri":"{uri}", "content":"{content}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         return response
@@ -247,30 +249,33 @@ class MarklogicApiClient:
 
     def set_judgment_work_expression_date(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
+        vars = {"uri": uri, "content": content}
 
         response = self.eval(
             self._xquery_path("set_metadata_work_expression_date.xqy"),
-            vars=f'{{"uri": "{uri}", "content": "{content}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         return response
 
     def set_judgment_citation(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
+        vars = {"uri": uri, "content": content}
 
         response = self.eval(
             self._xquery_path("set_metadata_citation.xqy"),
-            vars=f'{{"uri": "{uri}", "content": "{content}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         return response
 
     def set_judgment_court(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
+        vars = {"uri": uri, "content": content}
 
         response = self.eval(
             self._xquery_path("set_metadata_court.xqy"),
-            vars=f'{{"uri": "{uri}", "content": "{content}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         return response
@@ -284,13 +289,16 @@ class MarklogicApiClient:
             f"https://caselaw.nationalarchives.gov.uk/{judgment_uri.lstrip('/')}"
         )
         content_with_xml = f"https://caselaw.nationalarchives.gov.uk/{judgment_uri.lstrip('/')}/data.xml"
+        vars = {
+            "uri": uri,
+            "content_with_id": content_with_id,
+            "content_without_id": content_without_id,
+            "content_with_xml": content_with_xml,
+        }
 
         response = self.eval(
             self._xquery_path("set_metadata_this_uri.xqy"),
-            vars=f'{{"uri": "{uri}", '
-            f'"content_with_id": "{content_with_id}", '
-            f'"content_without_id": "{content_without_id}", '
-            f'"content_with_xml": "{content_with_xml}"}}',
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
         return response
@@ -528,18 +536,17 @@ class MarklogicApiClient:
 
         show_unpublished = self.verify_show_unpublished(show_unpublished)
 
-        vars = json.dumps(
-            {
-                "uri": uri,
-                "version_uri": version_uri,
-                "show_unpublished": str(show_unpublished).lower(),
-                "img_location": image_location,
-                "xsl_filename": xsl_filename,
-            }
-        )
+        vars = {
+            "uri": uri,
+            "version_uri": version_uri,
+            "show_unpublished": str(show_unpublished).lower(),
+            "img_location": image_location,
+            "xsl_filename": xsl_filename,
+        }
+
         return self.eval(
             self._xquery_path("xslt_transform.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -559,15 +566,13 @@ class MarklogicApiClient:
 
     def get_property(self, judgment_uri, name):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps(
-            {
-                "uri": uri,
-                "name": name,
-            }
-        )
+        vars = {
+            "uri": uri,
+            "name": name,
+        }
         response = self.eval(
             self._xquery_path("get_property.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -579,32 +584,29 @@ class MarklogicApiClient:
 
     def set_property(self, judgment_uri, name, value):
         uri = f"/{judgment_uri.lstrip('/')}.xml"
-        vars = json.dumps(
-            {
-                "uri": uri,
-                "value": value,
-                "name": name,
-            }
-        )
+        vars = {
+            "uri": uri,
+            "value": value,
+            "name": name,
+        }
+
         return self.eval(
             self._xquery_path("set_property.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def set_boolean_property(self, judgment_uri, name, value):
         uri = self._format_uri(judgment_uri)
         string_value = "true" if value else "false"
-        vars = json.dumps(
-            {
-                "uri": uri,
-                "value": string_value,
-                "name": name,
-            }
-        )
+        vars = {
+            "uri": uri,
+            "value": string_value,
+            "name": name,
+        }
         return self.eval(
             self._xquery_path("set_boolean_property.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -638,14 +640,12 @@ class MarklogicApiClient:
 
     def get_last_modified(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps(
-            {
-                "uri": uri,
-            }
-        )
+        vars = {
+            "uri": uri,
+        }
         response = self.eval(
             self._xquery_path("get_last_modified.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -657,10 +657,10 @@ class MarklogicApiClient:
 
     def delete_judgment(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps({"uri": uri})
+        vars = {"uri": uri}
         self.eval(
             self._xquery_path("delete_judgment.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -668,42 +668,36 @@ class MarklogicApiClient:
         old_uri = self._format_uri(old)
         new_uri = self._format_uri(new)
 
-        vars = json.dumps(
-            {
-                "old_uri": old_uri,
-                "new_uri": new_uri,
-            }
-        )
+        vars = {
+            "old_uri": old_uri,
+            "new_uri": new_uri,
+        }
         return self.eval(
             self._xquery_path("copy_judgment.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def break_checkout(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps(
-            {
-                "uri": uri,
-            }
-        )
+        vars = {
+            "uri": uri,
+        }
         return self.eval(
             self._xquery_path("break_judgment_checkout.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def user_has_privilege(self, username, privilege_uri, privilege_action):
-        vars = json.dumps(
-            {
-                "user": username,
-                "privilege_uri": privilege_uri,
-                "privilege_action": privilege_action,
-            }
-        )
+        vars = {
+            "user": username,
+            "privilege_uri": privilege_uri,
+            "privilege_action": privilege_action,
+        }
         return self.eval(
             self._xquery_path("user_has_privilege.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
@@ -741,28 +735,28 @@ class MarklogicApiClient:
 
     def get_judgment_citation(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps({"uri": uri})
+        vars = {"uri": uri}
         return self.eval(
             self._xquery_path("get_metadata_citation.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def get_judgment_court(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps({"uri": uri})
+        vars = {"uri": uri}
         return self.eval(
             self._xquery_path("get_metadata_court.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def get_judgment_work_date(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        vars = json.dumps({"uri": uri})
+        vars = {"uri": uri}
         return self.eval(
             self._xquery_path("get_metadata_work_date.xqy"),
-            vars=vars,
+            vars=json.dumps(vars),
             accept_header="application/xml",
         )
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -137,7 +137,7 @@ class MarklogicApiClient:
             new_exception.response = response
             raise new_exception
 
-    def _format_uri(self, uri):
+    def _format_uri_for_marklogic(self, uri):
         """
         Marklogic requiores a document URI that begins with a slash `/` and ends in `.xml`.
         This method ensures any URI passed into the client matches this format.
@@ -196,7 +196,7 @@ class MarklogicApiClient:
     def get_judgment_xml(
         self, judgment_uri, version_uri=None, show_unpublished=False
     ) -> str:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         show_unpublished = self.verify_show_unpublished(show_unpublished)
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
@@ -217,7 +217,7 @@ class MarklogicApiClient:
         return multipart_data.parts[0].text
 
     def get_judgment_name(self, judgment_uri) -> str:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
 
         response = self._send_to_eval(vars, "get_metadata_name.xqy")
@@ -228,7 +228,7 @@ class MarklogicApiClient:
         return multipart_data.parts[0].text
 
     def set_judgment_name(self, judgment_uri, content):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "content": content}
 
         return self._send_to_eval(vars, "set_metadata_name.xqy")
@@ -242,25 +242,25 @@ class MarklogicApiClient:
         return self.set_judgment_work_expression_date(judgment_uri, content)
 
     def set_judgment_work_expression_date(self, judgment_uri, content):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "content": content}
 
         return self._send_to_eval(vars, "set_metadata_work_expression_date.xqy")
 
     def set_judgment_citation(self, judgment_uri, content):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "content": content}
 
         return self._send_to_eval(vars, "set_metadata_citation.xqy")
 
     def set_judgment_court(self, judgment_uri, content):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "content": content}
 
         return self._send_to_eval(vars, "set_metadata_court.xqy")
 
     def set_judgment_this_uri(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         content_with_id = (
             f"https://caselaw.nationalarchives.gov.uk/id/{judgment_uri.lstrip('/')}"
         )
@@ -282,7 +282,7 @@ class MarklogicApiClient:
     ) -> requests.Response:
         """assumes the judgment is already locked, does not unlock/check in
         note this version assumes the XML is raw bytes, rather than a tree..."""
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
             "judgment": judgment_xml.decode("utf-8"),
@@ -297,7 +297,7 @@ class MarklogicApiClient:
         """update_judgment uses dls:document-checkout-update-checkin as a single operation"""
         xml = ElementTree.tostring(judgment_xml)
 
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
             "judgment": xml.decode("utf-8"),
@@ -311,13 +311,13 @@ class MarklogicApiClient:
     ) -> requests.Response:
         xml = ElementTree.tostring(judgment_xml)
 
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "judgment": xml.decode("utf-8"), "annotation": ""}
 
         return self._send_to_eval(vars, "insert_judgment.xqy")
 
     def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
 
         return self._send_to_eval(vars, "list_judgment_versions.xqy")
@@ -325,7 +325,7 @@ class MarklogicApiClient:
     def checkout_judgment(
         self, judgment_uri: str, annotation="", expires_at_midnight=False
     ) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
             "annotation": annotation,
@@ -340,13 +340,13 @@ class MarklogicApiClient:
         return self._send_to_eval(vars, "checkout_judgment.xqy")
 
     def checkin_judgment(self, judgment_uri: str) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
 
         return self._send_to_eval(vars, "checkin_judgment.xqy")
 
     def get_judgment_checkout_status(self, judgment_uri: str) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
 
         return self._send_to_eval(vars, "get_judgment_checkout_status.xqy")
@@ -367,7 +367,7 @@ class MarklogicApiClient:
     def get_judgment_version(
         self, judgment_uri: str, version: int
     ) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "version": str(version)}
 
         return self._send_to_eval(vars, "get_judgment_version.xqy")
@@ -468,9 +468,9 @@ class MarklogicApiClient:
         show_unpublished=False,
         xsl_filename="judgment2.xsl",
     ) -> requests.Response:
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         if version_uri:
-            version_uri = self._format_uri(version_uri)
+            version_uri = self._format_uri_for_marklogic(version_uri)
         if os.getenv("XSLT_IMAGE_LOCATION"):
             image_location = os.getenv("XSLT_IMAGE_LOCATION")
         else:
@@ -503,7 +503,7 @@ class MarklogicApiClient:
         )
 
     def get_property(self, judgment_uri, name):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
             "name": name,
@@ -527,7 +527,7 @@ class MarklogicApiClient:
         return self._send_to_eval(vars, "set_property.xqy")
 
     def set_boolean_property(self, judgment_uri, name, value):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         string_value = "true" if value else "false"
         vars = {
             "uri": uri,
@@ -565,7 +565,7 @@ class MarklogicApiClient:
         return self.get_boolean_property(judgment_uri, "anonymised")
 
     def get_last_modified(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
         }
@@ -579,13 +579,13 @@ class MarklogicApiClient:
         return content
 
     def delete_judgment(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
         return self._send_to_eval(vars, "delete_judgment.xqy")
 
     def copy_judgment(self, old, new):
-        old_uri = self._format_uri(old)
-        new_uri = self._format_uri(new)
+        old_uri = self._format_uri_for_marklogic(old)
+        new_uri = self._format_uri_for_marklogic(new)
 
         vars = {
             "old_uri": old_uri,
@@ -594,7 +594,7 @@ class MarklogicApiClient:
         return self._send_to_eval(vars, "copy_judgment.xqy")
 
     def break_checkout(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,
         }
@@ -641,17 +641,17 @@ class MarklogicApiClient:
         return show_unpublished
 
     def get_judgment_citation(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
         return self._send_to_eval(vars, "get_metadata_citation.xqy")
 
     def get_judgment_court(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
         return self._send_to_eval(vars, "get_metadata_court.xqy")
 
     def get_judgment_work_date(self, judgment_uri):
-        uri = self._format_uri(judgment_uri)
+        uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
         return self._send_to_eval(vars, "get_metadata_work_date.xqy")
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -147,6 +147,13 @@ class MarklogicApiClient:
     def _xquery_path(self, xquery_file_name):
         return os.path.join(ROOT_DIR, "xquery", xquery_file_name)
 
+    def _send_to_eval(self, vars, xquery_file_name):
+        return self.eval(
+            self._xquery_path(xquery_file_name),
+            vars=json.dumps(vars),
+            accept_header="application/xml",
+        )
+
     def prepare_request_kwargs(
         self, method: str, path: str, body=None, data: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
@@ -199,11 +206,7 @@ class MarklogicApiClient:
             "show_unpublished": str(show_unpublished).lower(),
         }
 
-        response = self.eval(
-            self._xquery_path("get_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        response = self._send_to_eval(vars, "get_judgment.xqy")
 
         if not response.text:
             raise MarklogicNotPermittedError(
@@ -217,11 +220,7 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
 
-        response = self.eval(
-            self._xquery_path("get_metadata_name.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        response = self._send_to_eval(vars, "get_metadata_name.xqy")
         if not response.text:
             return ""
 
@@ -232,12 +231,7 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "content": content}
 
-        response = self.eval(
-            self._xquery_path("set_metadata_name.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
-        return response
+        return self._send_to_eval(vars, "set_metadata_name.xqy")
 
     def set_judgment_date(self, judgment_uri, content):
         warnings.warn(
@@ -251,34 +245,19 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "content": content}
 
-        response = self.eval(
-            self._xquery_path("set_metadata_work_expression_date.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
-        return response
+        return self._send_to_eval(vars, "set_metadata_work_expression_date.xqy")
 
     def set_judgment_citation(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "content": content}
 
-        response = self.eval(
-            self._xquery_path("set_metadata_citation.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
-        return response
+        return self._send_to_eval(vars, "set_metadata_citation.xqy")
 
     def set_judgment_court(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "content": content}
 
-        response = self.eval(
-            self._xquery_path("set_metadata_court.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
-        return response
+        return self._send_to_eval(vars, "set_metadata_court.xqy")
 
     def set_judgment_this_uri(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
@@ -296,12 +275,7 @@ class MarklogicApiClient:
             "content_with_xml": content_with_xml,
         }
 
-        response = self.eval(
-            self._xquery_path("set_metadata_this_uri.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
-        return response
+        return self._send_to_eval(vars, "set_metadata_this_uri.xqy")
 
     def save_locked_judgment_xml(
         self, judgment_uri: str, judgment_xml: bytes, annotation=None
@@ -315,11 +289,7 @@ class MarklogicApiClient:
             "annotation": annotation or "edited by save_judgment_xml",
         }
 
-        return self.eval(
-            self._xquery_path("update_locked_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "update_locked_judgment.xqy")
 
     def save_judgment_xml(
         self, judgment_uri: str, judgment_xml: Element, annotation=None
@@ -334,11 +304,7 @@ class MarklogicApiClient:
             "annotation": annotation or "edited by save_judgment_xml",
         }
 
-        return self.eval(
-            self._xquery_path("update_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "update_judgment.xqy")
 
     def insert_judgment_xml(
         self, judgment_uri: str, judgment_xml: Element
@@ -348,21 +314,13 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "judgment": xml.decode("utf-8"), "annotation": ""}
 
-        return self.eval(
-            self._xquery_path("insert_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "insert_judgment.xqy")
 
     def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
 
-        return self.eval(
-            self._xquery_path("list_judgment_versions.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "list_judgment_versions.xqy")
 
     def checkout_judgment(
         self, judgment_uri: str, annotation="", expires_at_midnight=False
@@ -379,31 +337,19 @@ class MarklogicApiClient:
         else:
             vars["timeout"] = -1
 
-        return self.eval(
-            self._xquery_path("checkout_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "checkout_judgment.xqy")
 
     def checkin_judgment(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
 
-        return self.eval(
-            self._xquery_path("checkin_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "checkin_judgment.xqy")
 
     def get_judgment_checkout_status(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
 
-        return self.eval(
-            self._xquery_path("get_judgment_checkout_status.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "get_judgment_checkout_status.xqy")
 
     def get_judgment_checkout_status_message(self, judgment_uri: str):
         """Return the annotation of the lock or `None` if there is no lock."""
@@ -424,11 +370,7 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri, "version": str(version)}
 
-        return self.eval(
-            self._xquery_path("get_judgment_version.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "get_judgment_version.xqy")
 
     def eval(self, xquery_path, vars, accept_header="multipart/mixed"):
         headers = {
@@ -544,11 +486,7 @@ class MarklogicApiClient:
             "xsl_filename": xsl_filename,
         }
 
-        return self.eval(
-            self._xquery_path("xslt_transform.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "xslt_transform.xqy")
 
     def accessible_judgment_transformation(
         self, judgment_uri, version_uri=None, show_unpublished=False
@@ -570,11 +508,7 @@ class MarklogicApiClient:
             "uri": uri,
             "name": name,
         }
-        response = self.eval(
-            self._xquery_path("get_property.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        response = self._send_to_eval(vars, "get_property.xqy")
 
         if not response.text:
             return ""
@@ -590,11 +524,7 @@ class MarklogicApiClient:
             "name": name,
         }
 
-        return self.eval(
-            self._xquery_path("set_property.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "set_property.xqy")
 
     def set_boolean_property(self, judgment_uri, name, value):
         uri = self._format_uri(judgment_uri)
@@ -604,11 +534,7 @@ class MarklogicApiClient:
             "value": string_value,
             "name": name,
         }
-        return self.eval(
-            self._xquery_path("set_boolean_property.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "set_boolean_property.xqy")
 
     def get_boolean_property(self, judgment_uri, name):
         content = self.get_property(judgment_uri, name)
@@ -643,11 +569,8 @@ class MarklogicApiClient:
         vars = {
             "uri": uri,
         }
-        response = self.eval(
-            self._xquery_path("get_last_modified.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+
+        response = self._send_to_eval(vars, "get_last_modified.xqy")
 
         if not response.text:
             return ""
@@ -658,11 +581,7 @@ class MarklogicApiClient:
     def delete_judgment(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
-        self.eval(
-            self._xquery_path("delete_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "delete_judgment.xqy")
 
     def copy_judgment(self, old, new):
         old_uri = self._format_uri(old)
@@ -672,22 +591,14 @@ class MarklogicApiClient:
             "old_uri": old_uri,
             "new_uri": new_uri,
         }
-        return self.eval(
-            self._xquery_path("copy_judgment.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "copy_judgment.xqy")
 
     def break_checkout(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         vars = {
             "uri": uri,
         }
-        return self.eval(
-            self._xquery_path("break_judgment_checkout.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "break_judgment_checkout.xqy")
 
     def user_has_privilege(self, username, privilege_uri, privilege_action):
         vars = {
@@ -695,11 +606,7 @@ class MarklogicApiClient:
             "privilege_uri": privilege_uri,
             "privilege_action": privilege_action,
         }
-        return self.eval(
-            self._xquery_path("user_has_privilege.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "user_has_privilege.xqy")
 
     def user_can_view_unpublished_judgments(self, username):
         check_privilege = self.user_has_privilege(
@@ -736,29 +643,17 @@ class MarklogicApiClient:
     def get_judgment_citation(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
-        return self.eval(
-            self._xquery_path("get_metadata_citation.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "get_metadata_citation.xqy")
 
     def get_judgment_court(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
-        return self.eval(
-            self._xquery_path("get_metadata_court.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "get_metadata_court.xqy")
 
     def get_judgment_work_date(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
         vars = {"uri": uri}
-        return self.eval(
-            self._xquery_path("get_metadata_work_date.xqy"),
-            vars=json.dumps(vars),
-            accept_header="application/xml",
-        )
+        return self._send_to_eval(vars, "get_metadata_work_date.xqy")
 
 
 api_client = MarklogicApiClient(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -144,6 +144,9 @@ class MarklogicApiClient:
         """
         return f"/{uri.lstrip('/').rstrip('/')}.xml"
 
+    def _xquery_path(self, xquery_file_name):
+        return os.path.join(ROOT_DIR, "xquery", xquery_file_name)
+
     def prepare_request_kwargs(
         self, method: str, path: str, body=None, data: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
@@ -190,7 +193,6 @@ class MarklogicApiClient:
         show_unpublished = self.verify_show_unpublished(show_unpublished)
         if version_uri:
             version_uri = f"/{version_uri.lstrip('/')}.xml"
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_judgment.xqy")
         vars = {
             "uri": uri,
             "version_uri": version_uri,
@@ -198,7 +200,7 @@ class MarklogicApiClient:
         }
 
         response = self.eval(
-            xquery_path,
+            self._xquery_path("get_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -213,10 +215,11 @@ class MarklogicApiClient:
 
     def get_judgment_name(self, judgment_uri) -> str:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_name.xqy")
 
         response = self.eval(
-            xquery_path, vars=f'{{"uri":"{uri}"}}', accept_header="application/xml"
+            self._xquery_path("get_metadata_name.xqy"),
+            vars=f'{{"uri":"{uri}"}}',
+            accept_header="application/xml",
         )
         if not response.text:
             return ""
@@ -226,10 +229,9 @@ class MarklogicApiClient:
 
     def set_judgment_name(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_name.xqy")
 
         response = self.eval(
-            xquery_path,
+            self._xquery_path("set_metadata_name.xqy"),
             vars=f'{{"uri":"{uri}", "content":"{content}"}}',
             accept_header="application/xml",
         )
@@ -245,12 +247,9 @@ class MarklogicApiClient:
 
     def set_judgment_work_expression_date(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(
-            ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
-        )
 
         response = self.eval(
-            xquery_path,
+            self._xquery_path("set_metadata_work_expression_date.xqy"),
             vars=f'{{"uri": "{uri}", "content": "{content}"}}',
             accept_header="application/xml",
         )
@@ -258,10 +257,9 @@ class MarklogicApiClient:
 
     def set_judgment_citation(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
 
         response = self.eval(
-            xquery_path,
+            self._xquery_path("set_metadata_citation.xqy"),
             vars=f'{{"uri": "{uri}", "content": "{content}"}}',
             accept_header="application/xml",
         )
@@ -269,10 +267,9 @@ class MarklogicApiClient:
 
     def set_judgment_court(self, judgment_uri, content):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
 
         response = self.eval(
-            xquery_path,
+            self._xquery_path("set_metadata_court.xqy"),
             vars=f'{{"uri": "{uri}", "content": "{content}"}}',
             accept_header="application/xml",
         )
@@ -288,10 +285,8 @@ class MarklogicApiClient:
         )
         content_with_xml = f"https://caselaw.nationalarchives.gov.uk/{judgment_uri.lstrip('/')}/data.xml"
 
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy")
-
         response = self.eval(
-            xquery_path,
+            self._xquery_path("set_metadata_this_uri.xqy"),
             vars=f'{{"uri": "{uri}", '
             f'"content_with_id": "{content_with_id}", '
             f'"content_without_id": "{content_without_id}", '
@@ -306,7 +301,6 @@ class MarklogicApiClient:
         """assumes the judgment is already locked, does not unlock/check in
         note this version assumes the XML is raw bytes, rather than a tree..."""
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy")
         vars = {
             "uri": uri,
             "judgment": judgment_xml.decode("utf-8"),
@@ -314,7 +308,7 @@ class MarklogicApiClient:
         }
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("update_locked_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -326,7 +320,6 @@ class MarklogicApiClient:
         xml = ElementTree.tostring(judgment_xml)
 
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "update_judgment.xqy")
         vars = {
             "uri": uri,
             "judgment": xml.decode("utf-8"),
@@ -334,7 +327,7 @@ class MarklogicApiClient:
         }
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("update_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -345,22 +338,20 @@ class MarklogicApiClient:
         xml = ElementTree.tostring(judgment_xml)
 
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "insert_judgment.xqy")
         vars = {"uri": uri, "judgment": xml.decode("utf-8"), "annotation": ""}
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("insert_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def list_judgment_versions(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "list_judgment_versions.xqy")
         vars = {"uri": uri}
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("list_judgment_versions.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -369,7 +360,6 @@ class MarklogicApiClient:
         self, judgment_uri: str, annotation="", expires_at_midnight=False
     ) -> requests.Response:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy")
         vars = {
             "uri": uri,
             "annotation": annotation,
@@ -382,31 +372,27 @@ class MarklogicApiClient:
             vars["timeout"] = -1
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("checkout_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def checkin_judgment(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "checkin_judgment.xqy")
         vars = {"uri": uri}
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("checkin_judgment.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
 
     def get_judgment_checkout_status(self, judgment_uri: str) -> requests.Response:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(
-            ROOT_DIR, "xquery", "get_judgment_checkout_status.xqy"
-        )
         vars = {"uri": uri}
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("get_judgment_checkout_status.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -428,11 +414,10 @@ class MarklogicApiClient:
         self, judgment_uri: str, version: int
     ) -> requests.Response:
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_judgment_version.xqy")
         vars = {"uri": uri, "version": str(version)}
 
         return self.eval(
-            xquery_path,
+            self._xquery_path("get_judgment_version.xqy"),
             vars=json.dumps(vars),
             accept_header="application/xml",
         )
@@ -536,7 +521,6 @@ class MarklogicApiClient:
         uri = self._format_uri(judgment_uri)
         if version_uri:
             version_uri = self._format_uri(version_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
         if os.getenv("XSLT_IMAGE_LOCATION"):
             image_location = os.getenv("XSLT_IMAGE_LOCATION")
         else:
@@ -553,7 +537,11 @@ class MarklogicApiClient:
                 "xsl_filename": xsl_filename,
             }
         )
-        return self.eval(xquery_path, vars=vars, accept_header="application/xml")
+        return self.eval(
+            self._xquery_path("xslt_transform.xqy"),
+            vars=vars,
+            accept_header="application/xml",
+        )
 
     def accessible_judgment_transformation(
         self, judgment_uri, version_uri=None, show_unpublished=False
@@ -571,7 +559,6 @@ class MarklogicApiClient:
 
     def get_property(self, judgment_uri, name):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_property.xqy")
         vars = json.dumps(
             {
                 "uri": uri,
@@ -579,7 +566,7 @@ class MarklogicApiClient:
             }
         )
         response = self.eval(
-            xquery_path,
+            self._xquery_path("get_property.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
@@ -592,7 +579,6 @@ class MarklogicApiClient:
 
     def set_property(self, judgment_uri, name, value):
         uri = f"/{judgment_uri.lstrip('/')}.xml"
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_property.xqy")
         vars = json.dumps(
             {
                 "uri": uri,
@@ -601,14 +587,13 @@ class MarklogicApiClient:
             }
         )
         return self.eval(
-            xquery_path,
+            self._xquery_path("set_property.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
 
     def set_boolean_property(self, judgment_uri, name, value):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy")
         string_value = "true" if value else "false"
         vars = json.dumps(
             {
@@ -618,7 +603,7 @@ class MarklogicApiClient:
             }
         )
         return self.eval(
-            xquery_path,
+            self._xquery_path("set_boolean_property.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
@@ -653,14 +638,13 @@ class MarklogicApiClient:
 
     def get_last_modified(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_last_modified.xqy")
         vars = json.dumps(
             {
                 "uri": uri,
             }
         )
         response = self.eval(
-            xquery_path,
+            self._xquery_path("get_last_modified.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
@@ -673,10 +657,9 @@ class MarklogicApiClient:
 
     def delete_judgment(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "delete_judgment.xqy")
         vars = json.dumps({"uri": uri})
         self.eval(
-            xquery_path,
+            self._xquery_path("delete_judgment.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
@@ -685,7 +668,6 @@ class MarklogicApiClient:
         old_uri = self._format_uri(old)
         new_uri = self._format_uri(new)
 
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "copy_judgment.xqy")
         vars = json.dumps(
             {
                 "old_uri": old_uri,
@@ -693,27 +675,25 @@ class MarklogicApiClient:
             }
         )
         return self.eval(
-            xquery_path,
+            self._xquery_path("copy_judgment.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
 
     def break_checkout(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "break_judgment_checkout.xqy")
         vars = json.dumps(
             {
                 "uri": uri,
             }
         )
         return self.eval(
-            xquery_path,
+            self._xquery_path("break_judgment_checkout.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
 
     def user_has_privilege(self, username, privilege_uri, privilege_action):
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "user_has_privilege.xqy")
         vars = json.dumps(
             {
                 "user": username,
@@ -722,7 +702,7 @@ class MarklogicApiClient:
             }
         )
         return self.eval(
-            xquery_path,
+            self._xquery_path("user_has_privilege.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
@@ -761,30 +741,27 @@ class MarklogicApiClient:
 
     def get_judgment_citation(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
         vars = json.dumps({"uri": uri})
         return self.eval(
-            xquery_path,
+            self._xquery_path("get_metadata_citation.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
 
     def get_judgment_court(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_court.xqy")
         vars = json.dumps({"uri": uri})
         return self.eval(
-            xquery_path,
+            self._xquery_path("get_metadata_court.xqy"),
             vars=vars,
             accept_header="application/xml",
         )
 
     def get_judgment_work_date(self, judgment_uri):
         uri = self._format_uri(judgment_uri)
-        xquery_path = os.path.join(ROOT_DIR, "xquery", "get_metadata_work_date.xqy")
         vars = json.dumps({"uri": uri})
         return self.eval(
-            xquery_path,
+            self._xquery_path("get_metadata_work_date.xqy"),
             vars=vars,
             accept_header="application/xml",
         )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -48,16 +48,16 @@ class ApiClientTest(unittest.TestCase):
 
     def test_format_uri(self):
         uri = "/ewca/2022/123"
-        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
 
     def test_format_uri_no_leading_slash(self):
         uri = "ewca/2022/123"
-        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
 
     def test_format_uri_trailing_slash(self):
         uri = "ewca/2022/123/"
-        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
 
     def test_format_uri_all_the_slashes(self):
         uri = "/ewca/2022/123/"
-        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -45,3 +45,19 @@ class ApiClientTest(unittest.TestCase):
             },
             data={"module": "mock-query-path.xqy", "vars": '{{"testvar":"test"}}'},
         )
+
+    def test_format_uri(self):
+        uri = "/ewca/2022/123"
+        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+
+    def test_format_uri_no_leading_slash(self):
+        uri = "ewca/2022/123"
+        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+
+    def test_format_uri_trailing_slash(self):
+        uri = "ewca/2022/123/"
+        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"
+
+    def test_format_uri_all_the_slashes(self):
+        uri = "/ewca/2022/123/"
+        assert self.client._format_uri(uri) == "/ewca/2022/123.xml"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

`Client.py` is getting long. We should look into splitting/reducing it.

In the meantime, use three methods to DRY up the code a little:

1. We already had `self._format_uri()` but weren't using it everywhere. Use it everywhere!
2. We were repeatedly using `os.path.join` to get the XQuery file path. Add `self._xquery_path()` to remove this duplicated code and remove a few lines. 
3. Standardise all calls to `eval()` and then bundle them up into a helper method `self._send_to_eval()` and use this on all method calls.

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
