### PR TITLE
(Fix) Incorrect response type expected in `user_can_view_unpublished_judgments()`

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -621,7 +621,9 @@ class MarklogicApiClient:
             "https://caselaw.nationalarchives.gov.uk/custom/privileges/can-view-unpublished-documents",
             "execute",
         )
-        return check_privilege.text.lower() == "true"
+        multipart_data = decoder.MultipartDecoder.from_response(check_privilege)
+        result = multipart_data.parts[0].text
+        return result.lower() == "true"
 
     def calculate_seconds_until_midnight(self, now=None):
         """

--- a/tests/client/test_user_privileges.py
+++ b/tests/client/test_user_privileges.py
@@ -31,14 +31,31 @@ class TestUserPrivileges(unittest.TestCase):
 
     def test_user_can_view_unpublished_judgments_true(self):
         with patch.object(self.client, "eval"):
-            self.client.eval.return_value.text = "true"
-
+            self.client.eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+            }
+            self.client.eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"content-type: text/plain\r\n"
+                b"X-Primitive: boolean\r\n\r\n"
+                b"true\r\n"
+                b"--595658fa1db1aa98--\r\n"
+            )
             result = self.client.user_can_view_unpublished_judgments("laura")
             assert result is True
 
     def test_user_can_view_unpublished_judgments_false(self):
         with patch.object(self.client, "eval"):
-            self.client.eval.return_value.text = "false"
+            self.client.eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+            }
+            self.client.eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"content-type: text/plain\r\n"
+                b"X-Primitive: boolean\r\n\r\n"
+                b"false\r\n"
+                b"--595658fa1db1aa98--\r\n"
+            )
 
             result = self.client.user_can_view_unpublished_judgments("laura")
             assert result is False


### PR DESCRIPTION

I was expecting the reponse from `self.user_has_privilege()` to be a plain text response but it is actually a multipart response.

Correct the method and test, to expect a multipart response, decode it, and check the boolean contents.

