### PR TITLE
Speed up privilege checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Unreleased]
+- Speed up privilege checking
+
 ## [Release 4.9.2]
 - Add user_has_privilege method & XQuery to check if a user has a privilege
 - Use `user_has_privilege` to check if a user can see unpublished documents

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.28.1
 requests-toolbelt==0.9.1
 urllib3==1.26.8
 pytest==7.1.2
+memoization==0.4.0

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -20,6 +20,8 @@ RESULTS_PER_PAGE = 10
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
 
+user_read_unpublished_cache: Dict[str, bool] = {}
+
 
 class MarklogicAPIError(requests.HTTPError):
     status_code = 500
@@ -624,6 +626,13 @@ class MarklogicApiClient:
         multipart_data = decoder.MultipartDecoder.from_response(check_privilege)
         result = multipart_data.parts[0].text
         return result.lower() == "true"
+
+    def user_can_view_unpublished_judgments_cached(self, username):
+        cached_privilege = user_read_unpublished_cache.get(username, None)
+        if cached_privilege is None:
+            cached_privilege = self.user_can_view_unpublished_judgments(username)
+            user_read_unpublished_cache[username] = cached_privilege
+        return cached_privilege
 
     def calculate_seconds_until_midnight(self, now=None):
         """

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -638,9 +638,8 @@ class MarklogicApiClient:
         return difference.seconds
 
     def verify_show_unpublished(self, show_unpublished):
-        if (
-            not self.user_can_view_unpublished_judgments(self.username)
-            and show_unpublished
+        if show_unpublished and not self.user_can_view_unpublished_judgments(
+            self.username
         ):
             # The user cannot view unpublished judgments but is requesting to see them
             logging.warning(

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -647,7 +647,7 @@ class MarklogicApiClient:
         return difference.seconds
 
     def verify_show_unpublished(self, show_unpublished):
-        if show_unpublished and not self.user_can_view_unpublished_judgments(
+        if show_unpublished and not self.user_can_view_unpublished_judgments_cached(
             self.username
         ):
             # The user cannot view unpublished judgments but is requesting to see them

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -8,7 +8,7 @@ from src.caselawclient.Client import MarklogicApiClient
 
 class TestAdvancedSearch(unittest.TestCase):
     def setUp(self):
-        self.client = MarklogicApiClient("", "", "", False)
+        self.client = MarklogicApiClient("", "testuser", "", False)
 
     def test_advanced_search_user_can_view_unpublished_but_show_unpublished_is_false(
         self,
@@ -77,7 +77,9 @@ class TestAdvancedSearch(unittest.TestCase):
         Set `show_unpublished` to false and log a warning"""
         with patch.object(self.client, "invoke"):
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=False
+                self.client,
+                "user_can_view_unpublished_judgments_cached",
+                return_value=False,
             ):
                 with patch.object(logging, "warning") as mock_logging:
                     self.client.advanced_search(

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -78,7 +78,7 @@ class TestAdvancedSearch(unittest.TestCase):
         with patch.object(self.client, "invoke"):
             with patch.object(
                 self.client,
-                "user_can_view_unpublished_judgments_cached",
+                "user_can_view_unpublished_judgments",
                 return_value=False,
             ):
                 with patch.object(logging, "warning") as mock_logging:

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -9,7 +9,7 @@ from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
 
 class TestEvalXslt(unittest.TestCase):
     def setUp(self):
-        self.client = MarklogicApiClient("", "", "", False)
+        self.client = MarklogicApiClient("", "testuser", "", False)
 
     def test_eval_xslt_user_can_view_unpublished(self):
         with patch.object(self.client, "eval"):
@@ -38,7 +38,9 @@ class TestEvalXslt(unittest.TestCase):
         Set `show_unpublished` to false and log a warning"""
         with patch.object(self.client, "eval"):
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=False
+                self.client,
+                "user_can_view_unpublished_judgments_cached",
+                return_value=False,
             ):
                 with patch.object(logging, "warning") as mock_logging:
                     uri = "/judgment/uri"

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -39,7 +39,7 @@ class TestEvalXslt(unittest.TestCase):
         with patch.object(self.client, "eval"):
             with patch.object(
                 self.client,
-                "user_can_view_unpublished_judgments_cached",
+                "user_can_view_unpublished_judgments",
                 return_value=False,
             ):
                 with patch.object(logging, "warning") as mock_logging:

--- a/tests/client/test_user_privileges.py
+++ b/tests/client/test_user_privileges.py
@@ -59,14 +59,3 @@ class TestUserPrivileges(unittest.TestCase):
 
             result = self.client.user_can_view_unpublished_judgments("laura")
             assert result is False
-
-    def test_cached_version_only_calls_uncached_once(self):
-        with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=False
-        ):
-
-            result = self.client.user_can_view_unpublished_judgments_cached("laura")
-            assert result is False
-            self.client.user_can_view_unpublished_judgments_cached("laura")
-            self.client.user_can_view_unpublished_judgments.assert_called_once()
-            self.client.user_can_view_unpublished_judgments.assert_called_with("laura")

--- a/tests/client/test_user_privileges.py
+++ b/tests/client/test_user_privileges.py
@@ -59,3 +59,14 @@ class TestUserPrivileges(unittest.TestCase):
 
             result = self.client.user_can_view_unpublished_judgments("laura")
             assert result is False
+
+    def test_cached_version_only_calls_uncached_once(self):
+        with patch.object(
+            self.client, "user_can_view_unpublished_judgments", return_value=False
+        ):
+
+            result = self.client.user_can_view_unpublished_judgments_cached("laura")
+            assert result is False
+            self.client.user_can_view_unpublished_judgments_cached("laura")
+            self.client.user_can_view_unpublished_judgments.assert_called_once()
+            self.client.user_can_view_unpublished_judgments.assert_called_with("laura")

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -15,7 +15,7 @@ class TestVerifyShowUnpublished(unittest.TestCase):
         # User cannot view unpublished but is asking to view unpublished judgments
         with patch.object(
             self.client,
-            "user_can_view_unpublished_judgments_cached",
+            "user_can_view_unpublished_judgments",
             return_value=False,
         ):
             with patch.object(logging, "warning") as mock_logger:
@@ -27,7 +27,7 @@ class TestVerifyShowUnpublished(unittest.TestCase):
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         with patch.object(
-            self.client, "user_can_view_unpublished_judgments_cached", return_value=True
+            self.client, "user_can_view_unpublished_judgments", return_value=True
         ):
             result = self.client.verify_show_unpublished(True)
             assert result is True

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -22,14 +22,6 @@ class TestVerifyShowUnpublished(unittest.TestCase):
                 # Check the logger was called
                 mock_logger.assert_called()
 
-    def test_hide_unpublished_if_unauthorised_and_does_not_ask_for_unpublished(self):
-        # User cannot view unpublished and is not asking to view unpublished judgments
-        with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=False
-        ):
-            result = self.client.verify_show_unpublished(False)
-            assert result is False
-
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         with patch.object(
@@ -38,10 +30,15 @@ class TestVerifyShowUnpublished(unittest.TestCase):
             result = self.client.verify_show_unpublished(True)
             assert result is True
 
-    def test_hide_unpublished_if_authorised_and_does_not_ask_for_unpublished(self):
-        # User can view unpublished but is NOT asking to view unpublished judgments
+    def test_does_not_ask_for_unpublished(self):
+        """
+        User can view unpublished but is NOT asking to view unpublished judgments
+        client.user_can_view_unpublished_judgments is not called because we check the value
+        of show_unpublished first
+        """
         with patch.object(
             self.client, "user_can_view_unpublished_judgments", return_value=True
         ):
             result = self.client.verify_show_unpublished(False)
+            self.client.user_can_view_unpublished_judgments.assert_not_called()
             assert result is False

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -7,14 +7,16 @@ from src.caselawclient.Client import MarklogicApiClient
 
 class TestVerifyShowUnpublished(unittest.TestCase):
     def setUp(self):
-        self.client = MarklogicApiClient("", "", "", False)
+        self.client = MarklogicApiClient("", "testuser", "", False)
 
     # Test `verify_show_unpublished` with users who can/cannot see unpublished judgments
     # and with them asking for unpublished judgments or not
     def test_hide_published_if_unauthorised_and_user_asks_for_unpublished(self):
         # User cannot view unpublished but is asking to view unpublished judgments
         with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=False
+            self.client,
+            "user_can_view_unpublished_judgments_cached",
+            return_value=False,
         ):
             with patch.object(logging, "warning") as mock_logger:
                 result = self.client.verify_show_unpublished(True)
@@ -25,7 +27,7 @@ class TestVerifyShowUnpublished(unittest.TestCase):
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=True
+            self.client, "user_can_view_unpublished_judgments_cached", return_value=True
         ):
             result = self.client.verify_show_unpublished(True)
             assert result is True


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

When testing the API Client before a release, we noticed that the performance of the editor UI had degraded. The culprit is `verify_show_unpublished()` which checks that the active user has the right to view unpublished judgments. This is being called every time a user tried to view a judgment, or lists judgments. As a result, it was being called 10 times for each search result page. 

Our quick and inelegant (and hopefully temporary) solution is to use a rudimentary cache, which will check to see if the user has been through `user_can_view_unpublished_judgments` already, and if so use the result of that which is stored in the cache. 

This has made the editor UI faster in local testing.

The ultimate aim is to replace this with privilege checking within Marklogic.

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
