### PR TITLE
Add dependencies to setup.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.28.1
 requests-toolbelt==0.9.1
 urllib3==1.26.8
 pytest==7.1.2
+memoization==0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,10 @@ classifiers =
 package_dir =
     = src
 packages = find:
+install_requires =
+    django-environ
+    requests-toolbelt
+    memoization
 python_requires = >=3.8
 include_package_data = True
 


### PR DESCRIPTION
Ensure that dependencies (including the new `memoization`) are imported, so editor-ui etc don't have to know about custom-api-client's dependencies themselves.

Currently looks like it's working but need to convince myself it's right.