### PR TITLE
Page 0 redirects to page 1

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -448,7 +448,7 @@ class MarklogicApiClient:
             {
                 "court": str(court or ""),
                 "judge": str(judge or ""),
-                "page": page,
+                "page": max(1, int(page)),
                 "page-size": int(page_size),
                 "q": str(q or ""),
                 "party": str(party or ""),

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -77,9 +77,7 @@ class TestAdvancedSearch(unittest.TestCase):
         Set `show_unpublished` to false and log a warning"""
         with patch.object(self.client, "invoke"):
             with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=False,
+                self.client, "user_can_view_unpublished_judgments", return_value=False
             ):
                 with patch.object(logging, "warning") as mock_logging:
                     self.client.advanced_search(
@@ -97,3 +95,12 @@ class TestAdvancedSearch(unittest.TestCase):
                         in self.client.invoke.call_args.args[1]
                     )
                     mock_logging.assert_called()
+
+    def test_advanced_search_no_page_0(self):
+        """Requests for page 0 or lower are sent to page 1."""
+        with patch.object(self.client, "invoke"):
+            self.client.advanced_search(
+                page=0,
+            )
+
+            assert ', "page": 1,' in self.client.invoke.call_args.args[1]


### PR DESCRIPTION
If a non-positive page is selected, force it to be the first page instead.