### PR TITLE
Allow court to be comma-separated list of courts, some courts search multiple names

### DIFF
--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -30,7 +30,7 @@ class TestAdvancedSearch(unittest.TestCase):
                 )
 
                 expected_vars = {
-                    "court": "ewhc",
+                    "court": ["ewhc"],
                     "judge": "a. judge",
                     "page": 2,
                     "page-size": 20,
@@ -46,7 +46,7 @@ class TestAdvancedSearch(unittest.TestCase):
                 }
 
                 self.client.invoke.assert_called_with(
-                    "/judgments/search/search.xqy", json.dumps(expected_vars)
+                    "/judgments/search/search-v2.xqy", json.dumps(expected_vars)
                 )
 
     def test_advanced_search_user_can_view_unpublished_and_show_unpublished_is_true(

--- a/tests/client/test_parse_url.py
+++ b/tests/client/test_parse_url.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.caselawclient.Client import MarklogicApiClient
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        ["kitten", ["kitten"]],
+        ["ewhc/qb", ["ewhc/qb", "ewhc/kb"]],
+        ["ewhc/costs", ["ewhc/costs", "ewhc/scco"]],
+        ["EWHC/KB,EWHC/scco", ["ewhc/qb", "ewhc/kb", "ewhc/costs", "ewhc/scco"]],
+    ],
+)
+def test_court_list(test_input, expected):
+    c = MarklogicApiClient("", "", "", "")._court_list
+    assert set(c(test_input)) == set(expected)
+
+
+def test_court_list_nothing():
+    assert MarklogicApiClient("", "", "", "")._court_list("") is None


### PR DESCRIPTION
i.e. Queen's/King's Bench Division and SCCO/Costs each search each other, because they're the same court under a different neutral citation.

Note this'll need to be parallel with the search upgrades in https://github.com/nationalarchives/ds-caselaw-public-access-service/pull/76