### PR TITLE
Admin users can't read unpublished judgments

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -637,6 +637,9 @@ class MarklogicApiClient:
 
     @cached
     def user_can_view_unpublished_judgments(self, username):
+        if self.user_has_admin_role(username):
+            return True
+
         check_privilege = self.user_has_privilege(
             username,
             "https://caselaw.nationalarchives.gov.uk/custom/privileges/can-view-unpublished-documents",

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -646,6 +646,23 @@ class MarklogicApiClient:
         result = multipart_data.parts[0].text
         return result.lower() == "true"
 
+    def user_has_role(self, username, role):
+        vars = {
+            "user": username,
+            "role": role,
+        }
+        return self._send_to_eval(vars, "user_has_role.xqy")
+
+    @cached
+    def user_has_admin_role(self, username):
+        check_role = self.user_has_role(
+            username,
+            "admin",
+        )
+        multipart_data = decoder.MultipartDecoder.from_response(check_role)
+        result = multipart_data.parts[0].text
+        return result.lower() == "true"
+
     def calculate_seconds_until_midnight(self, now=None):
         """
         Get timedelta until end of day on the datetime passed, or current time.

--- a/src/caselawclient/xquery/user_has_role.xqy
+++ b/src/caselawclient/xquery/user_has_role.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare variable $user as xs:string external;
+declare variable $role as xs:string external;
+
+let $user_roles := xdmp:user-roles($user)
+let $role_id := xdmp:role($role)
+
+return fn:boolean(index-of($role_id, $user_roles))

--- a/tests/client/test_user_privileges.py
+++ b/tests/client/test_user_privileges.py
@@ -59,3 +59,9 @@ class TestUserPrivileges(unittest.TestCase):
 
             result = self.client.user_can_view_unpublished_judgments("laura")
             assert result is False
+
+    def test_user_can_view_unpublished_judgments_with_admin_role(self):
+        with patch.object(self.client, "user_has_admin_role"):
+            self.client.user_has_admin_role.return_value = True
+            result = self.client.user_can_view_unpublished_judgments("laura")
+            assert result is True

--- a/tests/client/test_user_roles.py
+++ b/tests/client/test_user_roles.py
@@ -1,0 +1,56 @@
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
+
+
+class TestUserRoles(unittest.TestCase):
+    def setUp(self):
+        self.client = MarklogicApiClient("", "", "", False)
+
+    def test_user_has_role(self):
+        with patch.object(self.client, "eval"):
+            user = "laura"
+            role = "admin"
+            expected_vars = {"user": "laura", "role": "admin"}
+            self.client.user_has_role(user, role)
+
+            assert self.client.eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "user_has_role.xqy")
+            )
+            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars
+            )
+
+    def test_user_has_admin_role_true(self):
+        with patch.object(self.client, "eval"):
+            self.client.eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+            }
+            self.client.eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"content-type: text/plain\r\n"
+                b"X-Primitive: boolean\r\n\r\n"
+                b"true\r\n"
+                b"--595658fa1db1aa98--\r\n"
+            )
+            result = self.client.user_has_admin_role("laura")
+            assert result is True
+
+    def test_user_has_admin_role_false(self):
+        with patch.object(self.client, "eval"):
+            self.client.eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+            }
+            self.client.eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"content-type: text/plain\r\n"
+                b"X-Primitive: boolean\r\n\r\n"
+                b"false\r\n"
+                b"--595658fa1db1aa98--\r\n"
+            )
+
+            result = self.client.user_has_admin_role("laura")
+            assert result is False


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Allow users who have the `admin` role to view unpublished judgments.
This feels slightly backwards to me but unfortunately the `admin` role is not
editable in Marklogic, so granting the `admin` user the correct custom privilege
to view unpublished judgments is not immediately obvious.

As we have now figured out our custom roles in a previous PR (
https://github.com/nationalarchives/ds-caselaw-public-access-service/pull/86)
this work seems less urgent (as we can tailor our custom roles and should not
need to grant admin access to users). But it is still useful to be able to view
unpublished judgments as an admin user, for completeness.

There may be a way to grant this access via Marklogic's QBAC system
https://docs.marklogic.com/guide/security/qbac - for future investigation.

## Trello card / Rollbar error (etc)

https://trello.com/c/Z7IXPWVq

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
