### PR TITLE
Deprecate XMLTools methods

### DIFF
--- a/src/caselawclient/xml_tools.py
+++ b/src/caselawclient/xml_tools.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, ParseError
@@ -30,6 +31,10 @@ def get_element(
     element_namespace=akn_namespace_uri,
     has_value_attribute=True,
 ) -> Element:
+    logging.warning(
+        "XMLTools is deprecated and will be removed in later versions. "
+        "Use methods from MarklogicApiClient.Client instead."
+    )
     name = xml.find(
         xpath,
         namespaces=akn_uk_namespaces,
@@ -67,6 +72,10 @@ def get_neutral_citation_element(xml) -> Element:
 
 
 def get_judgment_date_element(xml) -> Element:
+    logging.warning(
+        "XMLTools is deprecated and will be removed in later versions. "
+        "Use methods from MarklogicApiClient.Client instead."
+    )
     name = xml.find(
         ".//akn:FRBRWork/akn:FRBRdate",
         namespaces=akn_uk_namespaces,
@@ -87,6 +96,10 @@ def get_court_element(xml) -> Element:
 
 
 def get_search_matches(element: Element) -> List[str]:
+    logging.warning(
+        "XMLTools is deprecated and will be removed in later versions. "
+        "Use methods from MarklogicApiClient.Client instead."
+    )
     nodes = element.findall(".//search:match", namespaces=search_namespace)
     results = []
     for node in nodes:
@@ -96,6 +109,10 @@ def get_search_matches(element: Element) -> List[str]:
 
 
 def get_error_code(xml_content: str):
+    logging.warning(
+        "XMLTools is deprecated and will be removed in later versions. "
+        "Use methods from MarklogicApiClient.Client instead."
+    )
     try:
         xml = ElementTree.fromstring(xml_content)
         return xml.find(

--- a/tests/xml_tools/test_xml_tools.py
+++ b/tests/xml_tools/test_xml_tools.py
@@ -1,5 +1,7 @@
+import logging
 import unittest
 import xml.etree.ElementTree as ET
+from unittest.mock import patch
 
 import src.caselawclient.xml_tools as xml_tools
 
@@ -336,3 +338,24 @@ class XmlToolsTests(unittest.TestCase):
         self.assertEqual(
             result, "Unknown error, Marklogic returned a null or empty response"
         )
+
+    def test_deprecation_warning(self):
+        with patch.object(logging, "warning") as mock_logging:
+            xml_string = """
+                       <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                           <judgment name="judgment" contains="originalVersion">
+                               <meta>
+                                   <identification source="#tna">
+                                       <FRBRname value="My Judgment Name"/>
+                                   </identification>
+                               </meta>
+                           </judgment>
+                       </akomaNtoso>
+                   """
+            xml = ET.ElementTree(ET.fromstring(xml_string))
+            result = xml_tools.get_metadata_name_value(xml)
+            self.assertEqual(result, "My Judgment Name")
+            mock_logging.assert_called_with(
+                "XMLTools is deprecated and will be removed in later versions. "
+                "Use methods from MarklogicApiClient.Client instead."
+            )


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

https://trello.com/c/X1IkTexF/883-refactor-xmltools-usage-in-eui

The XMLTools methods have been deprecated in favour of XQuery-based API calls.

Neither the editor UI nor the public UI use any XMLTools methods now. Deprecate these methods and remove them in a later major version.

## Trello card / Rollbar error (etc)

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
