### PR TITLE
Release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+## [Release 5.1.0]
+- Remove a debug `print()` statement that was missed
+- Admin users can't read unpublished judgments
+- Deprecate XMLTools methods
+- Fix `TypeError: 'type' object is not subscriptable`
+
 ## [Release 5.0.0]
 - Breaking change: passes a list of zero-or-more courts, rather than a string that might be empty.
 - Search queries: pages less than one are treated as one
@@ -131,7 +137,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.0...HEAD
+[Release 5.1.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.0...v5.0.0
 [Release 5.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.0.0...v4.10.0
 [Release 4.10.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v4.10.0...v4.9.2
 [Release 4.9.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v4.9.2...v4.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ds-caselaw-marklogic-api-client
-version = 5.0.0
+version = 5.1.0
 author = The National Archives
 description = An API client for interacting with the Caselaw Marklogic instance
 long_description = file: README.md


### PR DESCRIPTION
- Remove a debug `print()` statement that was missed
- Admin users can't read unpublished judgments
- Deprecate XMLTools methods
- Fix `TypeError: 'type' object is not subscriptable`

