### PR TITLE
Ensure Citations output as text rather than raw MarkLogic xml

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -22,6 +22,13 @@ ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
 
 
+def decode_multipart(response):
+    """Decode a multipart response and return just the text inside it."""
+
+    multipart_data = decoder.MultipartDecoder.from_response(response)
+    return multipart_data.parts[0].text
+
+
 class MarklogicAPIError(requests.HTTPError):
     status_code = 500
     default_message = "An error occurred, and we didn't recognise it."
@@ -234,8 +241,7 @@ class MarklogicApiClient:
                 "The document is not published and show_unpublished was not set"
             )
 
-        multipart_data = decoder.MultipartDecoder.from_response(response)
-        return multipart_data.parts[0].text
+        return decode_multipart(response)
 
     def get_judgment_name(self, judgment_uri) -> str:
         uri = self._format_uri_for_marklogic(judgment_uri)
@@ -245,8 +251,7 @@ class MarklogicApiClient:
         if not response.text:
             return ""
 
-        multipart_data = decoder.MultipartDecoder.from_response(response)
-        return multipart_data.parts[0].text
+        return decode_multipart(response)
 
     def set_judgment_name(self, judgment_uri, content):
         uri = self._format_uri_for_marklogic(judgment_uri)
@@ -645,9 +650,7 @@ class MarklogicApiClient:
             "https://caselaw.nationalarchives.gov.uk/custom/privileges/can-view-unpublished-documents",
             "execute",
         )
-        multipart_data = decoder.MultipartDecoder.from_response(check_privilege)
-        result = multipart_data.parts[0].text
-        return result.lower() == "true"
+        return decode_multipart(check_privilege).lower() == "true"
 
     def user_has_role(self, username, role):
         vars = {

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -24,7 +24,6 @@ DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
 
 def decode_multipart(response):
     """Decode a multipart response and return just the text inside it."""
-
     multipart_data = decoder.MultipartDecoder.from_response(response)
     return multipart_data.parts[0].text
 
@@ -692,10 +691,12 @@ class MarklogicApiClient:
             return False
         return show_unpublished
 
-    def get_judgment_citation(self, judgment_uri):
+    def get_judgment_citation(self, judgment_uri) -> str:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
-        return self._send_to_eval(vars, "get_metadata_citation.xqy")
+
+        response = self._send_to_eval(vars, "get_metadata_citation.xqy")
+        return decode_multipart(response)
 
     def get_judgment_court(self, judgment_uri):
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -7,22 +7,23 @@ from unittest.mock import patch
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
 
 
+@patch("src.caselawclient.Client.decode_multipart")
+@patch("src.caselawclient.Client.MarklogicApiClient.eval")
+def test_get_judgment_citation(send, decode):
+    uri = "judgment/uri"
+    expected_vars = {"uri": "/judgment/uri.xml"}
+    decode.return_value = "ewca/fam/1"  # The decoder is called
+    MarklogicApiClient("", "", "", "").get_judgment_citation(uri) == "ewca/fam/1"
+
+    assert send.call_args.args[0] == (
+        os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
+    )
+    assert send.call_args.kwargs["vars"] == json.dumps(expected_vars)
+
+
 class TestGetSetMetadata(unittest.TestCase):
     def setUp(self):
         self.client = MarklogicApiClient("", "", "", False)
-
-    def test_get_judgment_citation(self):
-        with patch.object(self.client, "eval"):
-            uri = "judgment/uri"
-            expected_vars = {"uri": "/judgment/uri.xml"}
-            self.client.get_judgment_citation(uri)
-
-            assert self.client.eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
-            )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
-                expected_vars
-            )
 
     def test_set_judgment_citation(self):
         with patch.object(self.client, "eval"):


### PR DESCRIPTION
The get_judgment_citation function doesn't seem to be used anywhere else, so we can just change its output.