### PR TITLE
Get properties for a list of search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## [Unreleased]
+## [Release 5.1.1]
+- Get properties for a range of URIs for use in search results
 
 ## [Release 5.1.0]
 - Remove a debug `print()` statement that was missed
@@ -137,7 +138,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.1...HEAD
+[Release 5.1.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.1...v5.1.0
 [Release 5.1.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.1.0...v5.0.0
 [Release 5.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.0.0...v4.10.0
 [Release 4.10.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v4.10.0...v4.9.2
@@ -165,7 +167,7 @@ The format is based on [Keep a Changelog 1.0.0].
 [Release 2.1.2]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v2.1.1...v2.1.2
 [Release 2.1.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v2.1.0...v2.1.1
 [Release 2.1.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v2.0.1...v2.1.0
-[release 2.0.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v2.0.0...v2.0.1
-[release 2.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v1.0.5...v2.0.0
-[release 1.0.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v1.0.5
+[Release 2.0.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v2.0.0...v2.0.1
+[Release 2.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v1.0.5...v2.0.0
+[Release 1.0.5]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases/tag/v1.0.5
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ds-caselaw-marklogic-api-client
-version = 5.1.0
+version = 5.1.1
 author = The National Archives
 description = An API client for interacting with the Caselaw Marklogic instance
 long_description = file: README.md

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -166,7 +166,7 @@ class MarklogicApiClient:
 
     def _format_uri_for_marklogic(self, uri):
         """
-        Marklogic requiores a document URI that begins with a slash `/` and ends in `.xml`.
+        Marklogic requires a document URI that begins with a slash `/` and ends in `.xml`.
         This method ensures any URI passed into the client matches this format.
         """
         return f"/{uri.lstrip('/').rstrip('/')}.xml"

--- a/src/caselawclient/xquery/get_properties_for_search_results.xqy
+++ b/src/caselawclient/xquery/get_properties_for_search_results.xqy
@@ -1,0 +1,20 @@
+xquery version "1.0-ml";
+
+declare variable $uris as json:array external;
+let $properties := (
+    fn:QName("", 'editor-priority'),
+    fn:QName("", 'assigned-to'),
+    fn:QName("", 'editor-hold'),
+    fn:QName("", 'source-name'),
+    fn:QName("", 'source-email'),
+    fn:QName("", 'transfer-consignment-reference'),
+    fn:QName("", 'transfer-received-at')
+)
+
+return <property-results>{
+for $uri in json:array-values($uris)
+  return <property-result uri='{$uri}'> {
+    for $prop in $properties
+      return xdmp:document-get-properties($uri, $prop)
+  } </property-result>
+}</property-results>

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -9,11 +9,27 @@ from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
 
 @patch("src.caselawclient.Client.decode_multipart")
 @patch("src.caselawclient.Client.MarklogicApiClient.eval")
+def test_get_properties_for_search_results(send, decode):
+    uris = ["judgment/uri"]
+    expected_vars = {"uris": ["/judgment/uri.xml"]}
+    decode.return_value = "decoded_value"  # The decoder is called
+    retval = MarklogicApiClient("", "", "", "").get_properties_for_search_results(uris)
+    assert retval == "decoded_value"
+
+    assert send.call_args.args[0] == (
+        os.path.join(ROOT_DIR, "xquery", "get_properties_for_search_results.xqy")
+    )
+    assert send.call_args.kwargs["vars"] == json.dumps(expected_vars)
+
+
+@patch("src.caselawclient.Client.decode_multipart")
+@patch("src.caselawclient.Client.MarklogicApiClient.eval")
 def test_get_judgment_citation(send, decode):
     uri = "judgment/uri"
     expected_vars = {"uri": "/judgment/uri.xml"}
     decode.return_value = "ewca/fam/1"  # The decoder is called
-    MarklogicApiClient("", "", "", "").get_judgment_citation(uri) == "ewca/fam/1"
+    retval = MarklogicApiClient("", "", "", "").get_judgment_citation(uri)
+    assert retval == "ewca/fam/1"
 
     assert send.call_args.args[0] == (
         os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

For multiple URIs, we can get multiple properties. Or pass a single item list if you only want data for one.

Current properties provided are:

**TDR Metadata**
source-name, source-email -- which clark sent the judgment?
transfer-consignment-reference -- TDR reference
transfer-received-at -- when was it sent?

**Editor Metadata**
editor-priority -- how important it is that the editors process this judgment
assigned-to -- which editor is responsible for this judgment?
editor-hold (not yet written to anywhere) -- is this judgment on hold?


## Trello card / Rollbar error (etc)
https://trello.com/c/m8KuGSEk/33-%F0%9F%91%A9%F0%9F%92%BBeui-assign-judgments-http-endpoint

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
