### PR TITLE
Ensure Work Date and Court values are returned as text

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -708,12 +708,14 @@ class MarklogicApiClient:
     def get_judgment_court(self, judgment_uri):
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
-        return self._send_to_eval(vars, "get_metadata_court.xqy")
+        response = self._send_to_eval(vars, "get_metadata_court.xqy")
+        return decode_multipart(response)
 
     def get_judgment_work_date(self, judgment_uri):
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri}
-        return self._send_to_eval(vars, "get_metadata_work_date.xqy")
+        response = self._send_to_eval(vars, "get_metadata_work_date.xqy")
+        return decode_multipart(response)
 
     def get_properties_for_search_results(self, judgment_uris):
         uris = [

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -55,11 +55,14 @@ class TestGetSetMetadata(unittest.TestCase):
                 expected_vars
             )
 
-    def test_get_judgment_court(self):
+    @patch("src.caselawclient.Client.decode_multipart")
+    def test_get_judgment_court(self, decode):
         with patch.object(self.client, "eval"):
+            decode.return_value = "EWCA-Fam"
             uri = "judgment/uri"
             expected_vars = {"uri": "/judgment/uri.xml"}
-            self.client.get_judgment_court(uri)
+            retval = self.client.get_judgment_court(uri)
+            assert retval == "EWCA-Fam"
 
             assert self.client.eval.call_args.args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "get_metadata_court.xqy")
@@ -82,11 +85,14 @@ class TestGetSetMetadata(unittest.TestCase):
                 expected_vars
             )
 
-    def test_get_judgment_date(self):
+    @patch("src.caselawclient.Client.decode_multipart")
+    def test_get_judgment_date(self, decode):
         with patch.object(self.client, "eval"):
+            decode.return_value = "2022-01-01"
             uri = "judgment/uri"
             expected_vars = {"uri": "/judgment/uri.xml"}
-            self.client.get_judgment_work_date(uri)
+            retval = self.client.get_judgment_work_date(uri)
+            assert retval == "2022-01-01"
 
             assert self.client.eval.call_args.args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "get_metadata_work_date.xqy")


### PR DESCRIPTION
In https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/94
we changed the output of `get_judgment_citation` to be the text value of the
citation, not the response. This Commit beings `get_judgment_court` and
`get_judgment_work_date` in line with that function.

These functions are not yet used anywhere so it's safe to amend them.

