### PR TITLE
Don't crash if multipart data is actually an empty byte string.

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -26,6 +26,8 @@ def decode_multipart(response):
     """Decode a multipart response and return just the text inside it.
     Note that it is possible for multiple responses to be returned, if
     multiple top-level returns exist in the XQuery."""
+    if not (response.content):
+        return ""
     multipart_data = decoder.MultipartDecoder.from_response(response)
     part_count = len(multipart_data.parts)
     if part_count > 1:


### PR DESCRIPTION
If the court string is set to be empty in the editor, Marklogic returns only an empty byte string, which the MultipartDecoder will choke on.

We test for this case and return an empty Unicode string to mirror the usual output type.
