### PR TITLE
Add a note to the readme about github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,6 @@ To create a release:
 5. Get approval on the PR
 6. Tag the HEAD of the PR `v{major}.{minor}.{patch}` and push the tag
 7. Merge the PR to main and push
+
+Then create a release in [Github releases](https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases)
+using the created tag & changelog, for ease of reference.


### PR DESCRIPTION
We don't use Github releases to actually *release* this project (we use a github action that publishes the package to PyPi) but we've been using the Github release feature to keep a record of them. Document this in the README.

