### PR TITLE
Validate against a schema when priv API document is uploaded

### DIFF
--- a/src/caselawclient/xquery/update_locked_judgment.xqy
+++ b/src/caselawclient/xquery/update_locked_judgment.xqy
@@ -8,7 +8,8 @@ declare variable $judgment as xs:string external;
 declare variable $annotation as xs:string external;
 
 let $judgment_xml := xdmp:unquote($judgment)
-
+(: alternative: check output of let $output := xdmp:validate($judgment_xml) :)
+let $crash_if_invalid := validate strict {$judgment_xml}
 return dls:document-update(
    $uri,
    $judgment_xml,

--- a/src/caselawclient/xquery/validate_all_documents.xqy
+++ b/src/caselawclient/xquery/validate_all_documents.xqy
@@ -1,0 +1,4 @@
+xquery version "1.0-ml";
+import module namespace dls = "http://marklogic.com/xdmp/dls"
+   at "/MarkLogic/dls.xqy";
+dls:validate-all-documents(  fn:true() )


### PR DESCRIPTION
Invalid documents will fail with an error like:

```
<error-response xmlns="http://marklogic.com/xdmp/error">
  <status-code>500</status-code>
  <status>Internal Server Error</status>
  <message-code>XDMP-VALIDATEUNEXPECTED</message-code>
  <message>XDMP-VALIDATEUNEXPECTED: (err:XQDY0027) validate strict { $judgment_xml } -- Invalid node: Found {http://docs.oasis-open.org/legaldocml/ns/akn/3.0}DragonMangledThisNode but expected ({http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRuri*,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRalias*,...,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRauthoritative?) at fn:doc("")/*:akomaNtoso/*:judgment/*:meta/*:identification/*:FRBRWork/*:DragonMangledThisNode using schema "/akn-modified.xsd"</message>
  <message-detail>
    <message-title>Invalid node</message-title>
  </message-detail>
</error-response>
```