### PR TITLE
Blank court strings delete the <uk:court/> tag

### DIFF
--- a/src/caselawclient/xquery/set_metadata_court.xqy
+++ b/src/caselawclient/xquery/set_metadata_court.xqy
@@ -2,17 +2,33 @@ xquery version "1.0-ml";
 
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+declare function local:delete($uri)
+{
+   xdmp:node-delete(document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court)
+};
+declare function local:edit($uri, $content)
+{
+   xdmp:node-replace(
+     document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
+     <uk:court>{$content}</uk:court>
+   )
+};
+declare function local:add($uri, $content)
+{
+
+   xdmp:node-insert-child(
+     document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary,
+     <uk:court>{$content}</uk:court>
+   )
+};
+
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-if (fn:boolean(
+
+return if (fn:boolean(
 cts:search(doc($uri),
 cts:element-query(xs:QName('uk:court'),cts:and-query(()))))) then
-    xdmp:node-replace(
-    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
-    <uk:court>{$content}</uk:court>)
+    if ($content = "") then local:delete($uri) else local:edit($uri, $content)
 else
-    xdmp:node-insert-child(
-      document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary,
-      <uk:court>{$content}</uk:court>
-    )
+    local:add($uri, $content)


### PR DESCRIPTION
The string "" will be interpreted as a request to delete the court tag entirely by MarkLogic.

According to the schema, the `<uk:court>` tag must have one of a number of specific values for the courts; the blank string is not one of them; an unknown court is represented by the absence of a `<uk:court>` tag.