### PR TITLE
Check content hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tests/client/__pycache__/
 tests/xml_tools/__pycache__/
 src/caselawclient/__pycache__/
 /build
+__pycache__
+__pypackages__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
     rev: 5.11.4
     hooks:
       - id: isort
+        args: ["--profile", "black"]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
-        additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991  # Use the sha / tag you want to point at

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,34 +3,35 @@ default_stages: [commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
         additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971  # Use the sha / tag you want to point at
+    rev: v0.991  # Use the sha / tag you want to point at
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]
+        args: ["--no-namespace-packages"]
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests-toolbelt==0.9.1
 urllib3==1.26.8
 pytest==7.1.2
 memoization==0.4.0
+lxml==4.9.2

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -225,7 +225,7 @@ class MarklogicApiClient:
         method: str,
         path: str,
         headers: CaseInsensitiveDict[Union[str, Any]],
-        body: str = None,
+        body: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
         kwargs = self.prepare_request_kwargs(method, path, body, data)

--- a/src/caselawclient/content_hash.py
+++ b/src/caselawclient/content_hash.py
@@ -1,0 +1,45 @@
+"""
+The content hash is the SHA256 hash of the judgment text with all whitespace removed.
+This is intended to confirm that various processing has not changed the content of
+the judgment, whilst allowing variations in the XML which might not allow for
+preservation of whitespace.
+
+The canonical version of this hashing function is in the parser:
+https://github.com/nationalarchives/tna-judgments-parser/blob/main/src/akn/SHA256.cs
+"""
+
+import re
+from hashlib import sha256
+
+import lxml.etree
+
+
+def content_hash(doc: bytes) -> str:
+    """Return the content hash for a document"""
+    return sha256(hashable_text(doc)).hexdigest()
+
+
+def hashable_text(doc: bytes) -> bytes:
+    """Extract the text (as UTF-8 bytes) that would be hashed"""
+    root = lxml.etree.fromstring(doc)
+    metadatas = root.xpath(
+        "//akn:meta",
+        namespaces={"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"},
+    )
+    for (
+        metadata
+    ) in metadatas:  # there should be no more than one, but handle zero case gracefully
+        metadata.getparent().remove(metadata)
+    text = "".join(root.itertext())
+    spaceless = re.sub(r"\s", "", text)
+    return spaceless.encode("utf-8")
+
+
+def validate_content_hash(doc: bytes) -> bool:
+    """Check a document's self-described content hash is the same as the hash of its content"""
+    root = lxml.etree.fromstring(doc)
+    hash_from_doc = root.xpath(
+        "//uk:hash/text()",
+        namespaces={"uk": "https://caselaw.nationalarchives.gov.uk/akn"},
+    )[0]
+    return hash_from_doc == content_hash(doc)

--- a/tests/content_hash/test_content_hash.py
+++ b/tests/content_hash/test_content_hash.py
@@ -1,5 +1,8 @@
-from src.caselawclient.content_hash import (content_hash, hashable_text,
-                                            validate_content_hash)
+from src.caselawclient.content_hash import (
+    content_hash,
+    hashable_text,
+    validate_content_hash,
+)
 
 VALID_DOC = b"""<?xml version="1.0" encoding="UTF-8"?>
     <akomaNtoso

--- a/tests/content_hash/test_content_hash.py
+++ b/tests/content_hash/test_content_hash.py
@@ -1,0 +1,51 @@
+from src.caselawclient.content_hash import (content_hash, hashable_text,
+                                            validate_content_hash)
+
+VALID_DOC = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <akomaNtoso
+      xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+      xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+      <judgment name="judgment">
+        <meta>
+        <proprietary>
+        <uk:hash>c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565</uk:hash>
+        <uk:cite>the meta section should not be present BAD</uk:cite>
+        </proprietary>
+        </meta>
+        <p>Do <b>use</b></p>
+        <p>this <i>valid</i> text</p>
+      </judgment>
+    </akomaNtoso>
+    """
+
+INVALID_DOC = VALID_DOC.replace(b"Do", b"Do not").replace(b"valid", b"invalid")
+
+
+def test_hashable_text_valid_doc():
+    """
+    Do we correctly identify the text to hash, omitting the meta section and removing spaces?
+    Notably, the text from the meta section should NOT appear.
+    """
+    assert hashable_text(VALID_DOC) == b"Dousethisvalidtext"
+
+
+def test_hashable_text_invalid_doc():
+    assert hashable_text(INVALID_DOC) == b"Donotusethisinvalidtext"
+
+
+def test_content_hash():
+    """Do we get a hex string when hashing the document, and is it what we expect?"""
+    assert (
+        content_hash(VALID_DOC)
+        == "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
+    )
+    assert (
+        content_hash(INVALID_DOC)
+        != "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
+    )
+
+
+def test_validate_content_hash():
+    """Do valid documents pass, and invalid ones fail? i.e. check the hash in the document"""
+    assert validate_content_hash(VALID_DOC)
+    assert not validate_content_hash(INVALID_DOC)


### PR DESCRIPTION
Implements https://github.com/nationalarchives/tna-judgments-parser/blob/main/src/akn/SHA256.cs

Gets the text of the judgment (ignoring the metadata section) and strips out all whitespace and SHA256 hashes it.

Had some problems with getting the linters to play nice: see #118 fora resolution.

* Is this the right place in the code base?
* Need to wire this up to stuff -- is that best done here or in priv-api etc.