### PR TITLE
Dummy date set/read

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -292,6 +292,7 @@ class MarklogicApiClient:
         return self.set_judgment_work_expression_date(judgment_uri, content)
 
     def set_judgment_work_expression_date(self, judgment_uri, content):
+        """Sets the date on both the Work and the Expression of the judgment to the given value"""
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {"uri": uri, "content": content}
 

--- a/src/caselawclient/xquery/get_metadata_work_date.xqy
+++ b/src/caselawclient/xquery/get_metadata_work_date.xqy
@@ -5,5 +5,5 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 
 let $judgment := fn:document($uri)
-
-return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date
+let $date_element := $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate
+return if ($date_element/@name = "dummy") then () else ($date_element/@date)

--- a/src/caselawclient/xquery/set_metadata_work_expression_date.xqy
+++ b/src/caselawclient/xquery/set_metadata_work_expression_date.xqy
@@ -4,16 +4,18 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-let $date_attr_name := doc($uri)/akn:akomaNtoso/akn:judgment/@name
-
 (: https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/doc/adr/0008-how-frbrdates-are-managed.md :)
 (: Keep these two dates in sync for now as per our ADR :)
+
+let $date_attr_value := if ($content='') then ('1000-01-01') else ($content)
+let $date_attr_name := if ($content='') then ('dummy') else (doc($uri)/akn:akomaNtoso/akn:judgment/@name)
+
 return (
     xdmp:node-replace(
     doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
-    <akn:FRBRdate date="{$content}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>),
+    <akn:FRBRdate date="{$date_attr_value}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>),
 
     xdmp:node-replace(
     doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRExpression/akn:FRBRdate,
-    <akn:FRBRdate date="{$content}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
+    <akn:FRBRdate date="{$date_attr_value}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
 )


### PR DESCRIPTION
Is this the correct approach?
* An empty input string is saved as `<FRBRdate date='1000-01-01' name='dummy'>`
* MarkLogic returns`dummy` dates as `()`
* The Multipart Decoder returns the empty string if no parts are encountered (existing behaviour)

This feels slightly risky and might not be the right behaviour.