### PR TITLE
Add content hash validation when we save a locked judgment

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -17,6 +17,7 @@ from requests.structures import CaseInsensitiveDict
 from requests_toolbelt.multipart import decoder
 
 from . import xml_tools
+from .content_hash import validate_content_hash
 from .errors import MarklogicAPIError  # noqa: F401
 from .errors import (
     MarklogicBadRequestError,
@@ -281,6 +282,7 @@ class MarklogicApiClient:
     ) -> requests.Response:
         """assumes the judgment is already locked, does not unlock/check in
         note this version assumes the XML is raw bytes, rather than a tree..."""
+        validate_content_hash(judgment_xml)
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars = {
             "uri": uri,

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -17,6 +17,19 @@ from requests.structures import CaseInsensitiveDict
 from requests_toolbelt.multipart import decoder
 
 from . import xml_tools
+from .errors import MarklogicAPIError  # noqa: F401
+from .errors import (
+    MarklogicBadRequestError,
+    MarklogicCheckoutConflictError,
+    MarklogicCommunicationError,
+    MarklogicNotPermittedError,
+    MarklogicResourceLockedError,
+    MarklogicResourceNotCheckedOutError,
+    MarklogicResourceNotFoundError,
+    MarklogicResourceUnmanagedError,
+    MarklogicUnauthorizedError,
+    MarklogicValidationFailedError,
+)
 
 env = environ.Env()
 RESULTS_PER_PAGE = 10
@@ -37,70 +50,6 @@ def decode_multipart(response):
             f"Throwing away multipart data ({part_count} items, expected 1)"
         )
     return multipart_data.parts[0].text
-
-
-class MarklogicAPIError(requests.HTTPError):
-    status_code = 500
-    default_message = "An error occurred, and we didn't recognise it."
-
-
-class MarklogicBadRequestError(MarklogicAPIError):
-    status_code = 400
-    default_message = "Marklogic did not understand the request that was made."
-
-
-class MarklogicUnauthorizedError(MarklogicAPIError):
-    status_code = 401
-    default_message = "Your credentials are not valid, or you did not provide any by basic authentication"
-
-
-class MarklogicNotPermittedError(MarklogicAPIError):
-    status_code = 403
-    default_message = "Your credentials are valid, but you are not allowed to do that."
-
-
-class MarklogicResourceNotFoundError(MarklogicAPIError):
-    status_code = 404
-    default_message = "No resource with that name could be found."
-
-
-class MarklogicResourceLockedError(MarklogicAPIError):
-    status_code = 409
-    default_message = "The resource is locked by another user, so you cannot change it."
-
-
-class MarklogicResourceUnmanagedError(MarklogicAPIError):
-    """Note: this exception may be raised if a document doesn't exist,
-    since all documents should be managed."""
-
-    status_code = 404
-    default_message = (
-        "The resource isn't managed. "
-        "It probably doesn't exist, and if it does, that's a problem. "
-        "Please report it."
-    )
-
-
-class MarklogicResourceNotCheckedOutError(MarklogicAPIError):
-    status_code = 409
-    default_message = "The resource is not checked out by anyone, but that request needed a checkout first."
-
-
-class MarklogicCheckoutConflictError(MarklogicAPIError):
-    status_code = 409
-    default_message = "The resource is checked out by another user."
-
-
-class MarklogicValidationFailedError(MarklogicAPIError):
-    status_code = 422
-    default_message = "The XML document did not validate according to the schema."
-
-
-class MarklogicCommunicationError(MarklogicAPIError):
-    status_code = 500
-    default_message = (
-        "Something unexpected happened when communicating with the Marklogic server."
-    )
 
 
 class MarklogicApiClient:

--- a/src/caselawclient/errors.py
+++ b/src/caselawclient/errors.py
@@ -1,0 +1,73 @@
+import requests
+
+
+class MarklogicAPIError(requests.HTTPError):
+    status_code = 500
+    default_message = "An error occurred, and we didn't recognise it."
+
+
+class MarklogicBadRequestError(MarklogicAPIError):
+    status_code = 400
+    default_message = "Marklogic did not understand the request that was made."
+
+
+class MarklogicUnauthorizedError(MarklogicAPIError):
+    status_code = 401
+    default_message = "Your credentials are not valid, or you did not provide any by basic authentication"
+
+
+class MarklogicNotPermittedError(MarklogicAPIError):
+    status_code = 403
+    default_message = "Your credentials are valid, but you are not allowed to do that."
+
+
+class MarklogicResourceNotFoundError(MarklogicAPIError):
+    status_code = 404
+    default_message = "No resource with that name could be found."
+
+
+class MarklogicResourceLockedError(MarklogicAPIError):
+    status_code = 409
+    default_message = "The resource is locked by another user, so you cannot change it."
+
+
+class MarklogicResourceUnmanagedError(MarklogicAPIError):
+    """Note: this exception may be raised if a document doesn't exist,
+    since all documents should be managed."""
+
+    status_code = 404
+    default_message = (
+        "The resource isn't managed. "
+        "It probably doesn't exist, and if it does, that's a problem. "
+        "Please report it."
+    )
+
+
+class MarklogicResourceNotCheckedOutError(MarklogicAPIError):
+    status_code = 409
+    default_message = "The resource is not checked out by anyone, but that request needed a checkout first."
+
+
+class MarklogicCheckoutConflictError(MarklogicAPIError):
+    status_code = 409
+    default_message = "The resource is checked out by another user."
+
+
+class MarklogicValidationFailedError(MarklogicAPIError):
+    status_code = 422
+    default_message = "The XML document did not validate according to the schema."
+
+
+class MarklogicCommunicationError(MarklogicAPIError):
+    status_code = 500
+    default_message = (
+        "Something unexpected happened when communicating with the Marklogic server."
+    )
+
+
+class InvalidContentHashError(MarklogicAPIError):
+    # This error does not come from Marklogic, but is an error raised by this API...
+    status_code = 422
+    default_message = (
+        "The content hash in the document did not match the hash of the content"
+    )

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -35,6 +35,11 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             )
 
     def test_save_locked_judgment_xml(self):
+        """
+        Given a locked judgement uri, a judgement_xml and an annotation
+        When `Client.save_locked_judgment_xml` is called with these as arguments
+        Then the xquery in `update_locked_judgment.xqy` is called on the Marklogic db with those arguments
+        """
         with patch.object(src.caselawclient.Client, "validate_content_hash"):
             with patch.object(self.client, "eval"):
                 uri = "/ewca/civ/2004/632"
@@ -55,6 +60,11 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 )
 
     def test_save_locked_judgment_xml_checks_content_hash(self):
+        """
+        Given content hash validation will fail with an error
+        When `Client.save_locked_judgment_xml` is called
+        Then the error is raised.
+        """
         with patch.object(src.caselawclient.Client, "validate_content_hash"):
             uri = "/ewca/civ/2004/632"
             judgment_str = "<root>My updated judgment</root>"

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -4,7 +4,11 @@ import unittest
 from unittest.mock import patch
 from xml.etree import ElementTree
 
+import pytest
+
+import src.caselawclient.Client
 from src.caselawclient.Client import ROOT_DIR, MarklogicApiClient
+from src.caselawclient.errors import InvalidContentHashError
 
 
 class TestSaveCopyDeleteJudgment(unittest.TestCase):
@@ -31,23 +35,35 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             )
 
     def test_save_locked_judgment_xml(self):
-        with patch.object(self.client, "eval"):
+        with patch.object(src.caselawclient.Client, "validate_content_hash"):
+            with patch.object(self.client, "eval"):
+                uri = "/ewca/civ/2004/632"
+                judgment_str = "<root>My updated judgment</root>"
+                judgment_xml = judgment_str.encode("utf-8")
+                expected_vars = {
+                    "uri": "/ewca/civ/2004/632.xml",
+                    "judgment": judgment_str,
+                    "annotation": "my annotation",
+                }
+                self.client.save_locked_judgment_xml(uri, judgment_xml, "my annotation")
+
+                assert self.client.eval.call_args.args[0] == (
+                    os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy")
+                )
+                assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
+                    expected_vars
+                )
+
+    def test_save_locked_judgment_xml_checks_content_hash(self):
+        with patch.object(src.caselawclient.Client, "validate_content_hash"):
             uri = "/ewca/civ/2004/632"
             judgment_str = "<root>My updated judgment</root>"
             judgment_xml = judgment_str.encode("utf-8")
-            expected_vars = {
-                "uri": "/ewca/civ/2004/632.xml",
-                "judgment": judgment_str,
-                "annotation": "my annotation",
-            }
-            self.client.save_locked_judgment_xml(uri, judgment_xml, "my annotation")
-
-            assert self.client.eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy")
+            src.caselawclient.Client.validate_content_hash.side_effect = (
+                InvalidContentHashError()
             )
-            assert self.client.eval.call_args.kwargs["vars"] == json.dumps(
-                expected_vars
-            )
+            with pytest.raises(InvalidContentHashError):
+                self.client.save_locked_judgment_xml(uri, judgment_xml, "my annotation")
 
     def test_insert_judgment_xml(self):
         with patch.object(self.client, "eval"):

--- a/tests/content_hash/test_content_hash.py
+++ b/tests/content_hash/test_content_hash.py
@@ -40,12 +40,14 @@ class TestIdentifyHashableString:
 
 
 class TestCorrectHashForString:
-    def test_content_hash(self):
+    def test_valid_content_hash(self):
         """Do we get a hex string when hashing the document, and is it what we expect?"""
         assert (
             hash_of_content(VALID_DOC)
             == "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
         )
+
+    def test_invalid_content_hash(self):
         assert (
             hash_of_content(INVALID_DOC)
             != "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"

--- a/tests/content_hash/test_content_hash.py
+++ b/tests/content_hash/test_content_hash.py
@@ -1,8 +1,11 @@
+import pytest
+
 from src.caselawclient.content_hash import (
-    content_hash,
+    hash_of_content,
     hashable_text,
     validate_content_hash,
 )
+from src.caselawclient.errors import InvalidContentHashError
 
 VALID_DOC = b"""<?xml version="1.0" encoding="UTF-8"?>
     <akomaNtoso
@@ -24,31 +27,42 @@ VALID_DOC = b"""<?xml version="1.0" encoding="UTF-8"?>
 INVALID_DOC = VALID_DOC.replace(b"Do", b"Do not").replace(b"valid", b"invalid")
 
 
-def test_hashable_text_valid_doc():
-    """
-    Do we correctly identify the text to hash, omitting the meta section and removing spaces?
-    Notably, the text from the meta section should NOT appear.
-    """
-    assert hashable_text(VALID_DOC) == b"Dousethisvalidtext"
+class TestIdentifyHashableString:
+    def test_hashable_text_valid_doc(self):
+        """
+        Do we correctly identify the text to hash, omitting the meta section and removing spaces?
+        Notably, the text from the meta section should NOT appear.
+        """
+        assert hashable_text(VALID_DOC) == b"Dousethisvalidtext"
+
+    def test_hashable_text_invalid_doc(self):
+        assert hashable_text(INVALID_DOC) == b"Donotusethisinvalidtext"
 
 
-def test_hashable_text_invalid_doc():
-    assert hashable_text(INVALID_DOC) == b"Donotusethisinvalidtext"
+class TestCorrectHashForString:
+    def test_content_hash(self):
+        """Do we get a hex string when hashing the document, and is it what we expect?"""
+        assert (
+            hash_of_content(VALID_DOC)
+            == "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
+        )
+        assert (
+            hash_of_content(INVALID_DOC)
+            != "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
+        )
 
 
-def test_content_hash():
-    """Do we get a hex string when hashing the document, and is it what we expect?"""
-    assert (
-        content_hash(VALID_DOC)
-        == "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
-    )
-    assert (
-        content_hash(INVALID_DOC)
-        != "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
-    )
+class TestCorrectlyRaisesExceptions:
+    def test_valid_content_hash(self):
+        """Do valid documents pass, and invalid ones fail? i.e. check the hash in the document"""
+        validate_content_hash(VALID_DOC)
 
+    def test_wrong_content_hash(self):
+        with pytest.raises(InvalidContentHashError, match="Hash of document was c436"):
+            validate_content_hash(INVALID_DOC)
 
-def test_validate_content_hash():
-    """Do valid documents pass, and invalid ones fail? i.e. check the hash in the document"""
-    assert validate_content_hash(VALID_DOC)
-    assert not validate_content_hash(INVALID_DOC)
+    def test_no_content_hash(self):
+        with pytest.raises(
+            InvalidContentHashError, match="Document did not have a content hash tag"
+        ):
+            validate_content_hash("<dog></dog>")


### PR DESCRIPTION
(i.e. when we receive something from the privileged API)

Includes pulling errors into another file to avoid circular references