### PR TITLE
Do not default to current version if version doesn't exist

### DIFF
--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -6,21 +6,13 @@ declare variable $version_uri as xs:string? external;
 declare variable $img_location as xs:string? external;
 declare variable $xsl_filename as xs:string? external;
 
-let $judgment_xml := fn:doc($uri)
-let $version_xml := if ($version_uri) then fn:document($version_uri) else ()
 let $judgment_published_property := xdmp:document-get-properties($uri, xs:QName("published"))[1]
 let $is_published := $judgment_published_property/text()
 let $image_base := if ($img_location) then $img_location else ""
-let $xsl := if ($xsl_filename) then $xsl_filename else "judgment2.xsl"
-
-let $document_to_transform := if ($version_xml) then $version_xml else $judgment_xml
-let $xsl_path := fn:concat("judgments/xslts/", $xsl)
+let $document_to_transform := if ($version_uri) then fn:document($version_uri) else fn:doc($uri)
+let $xsl_path := fn:concat("judgments/xslts/", $xsl_filename)
 
 let $params := map:map()
-let $_put := map:put(
-                    $params,
-                    "image-base",
-                    $image_base)
 
 let $return_value := if (xs:boolean($is_published) or $show_unpublished) then
         xdmp:xslt-invoke($xsl_path,

--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -14,6 +14,11 @@ let $xsl_path := fn:concat("judgments/xslts/", $xsl_filename)
 
 let $params := map:map()
 
+let $_ := if (not(exists($document_to_transform))) then
+  (
+    fn:error(xs:QName("FCL_DOCUMENTNOTFOUND"), "No XML document was found to transform")
+  ) else ()
+
 let $return_value := if (xs:boolean($is_published) or $show_unpublished) then
         xdmp:xslt-invoke($xsl_path,
           $document_to_transform,


### PR DESCRIPTION
[Trello](https://trello.com/c/VIVTctiL/534-make-invalid-version-uris-return-an-error-state)

`fn:doc` of a non-existant node returns `()`, which looks the same as no version doc being passed in the first place