### PR TITLE
Re-add the code that was pointing the XSLT to the assets

### DIFF
--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -14,6 +14,13 @@ let $xsl_path := fn:concat("judgments/xslts/", $xsl_filename)
 
 let $params := map:map()
 
+(: change the image-base of the document to match the location of the assets in $image_base
+   so that references to images point to the correct places on the internet :)
+let $_put := map:put(
+                    $params,
+                    "image-base",
+                    $image_base)
+
 let $_ := if (not(exists($document_to_transform))) then
   (
     fn:error(xs:QName("FCL_DOCUMENTNOTFOUND"), "No XML document was found to transform")


### PR DESCRIPTION
I deleted some code that I thought did nothing, but the side-effects were critical -- they changed the imagebase of the XSLT document, pointing at the location of the actual images.

Looks good locally.

We'll need to redeploy editor/public after this is on PyPI.