### PR TITLE
Add PEP-561 typing declaration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     memoization
 python_requires = >=3.8
 include_package_data = True
+zip_safe = False
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The existence of the `py.typed` file declares that this package implements PEP-561-compliant type annotations and is safe for type checkers (such as mypy) to evaluate.