### PR TITLE
Explicitly provide the directory to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"
 keywords = ["national archives", "caselaw"]
 readme = "README.md"
+packages = [
+    { include = "src/caselawclient" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
We weren't explicitly providing the source directory to Poetry, which meant it wasn't able to build the package. Now we do.