### PR TITLE
Use tagged release of pypi publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,6 @@ jobs:
         run: poetry build
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The `master` branch of this action is no longer used. Instead, use an explicitly tagged release. This increases reproducibility, and also lets Dependabot spot when it needs updating.