### PR TITLE
Pin all instances of actions/checkout to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4


### PR DESCRIPTION
Pinned versions are more robust (they aren't likely to change in ways which break our workflow), and can be identified for updates by Dependabot.