### PR TITLE
Correct relative import in judgment model

### DIFF
--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -3,7 +3,7 @@ from functools import cached_property
 
 from requests_toolbelt.multipart import decoder
 
-from src.caselawclient.Client import MarklogicApiClient
+from caselawclient.Client import MarklogicApiClient
 
 from .utilities import get_judgment_root, render_versions
 from .utilities.aws import (


### PR DESCRIPTION
This now correctly imports the judgment model, so that it doesn't run into a missing module problem when deployed.