### PR TITLE
Add strict typing for dicts used in MarkLogic queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
       - id: flake8
         args: ["--config=setup.cfg"]
 
+  - repo: local
+    hooks:
+      - id: build-xquery-type-dicts
+        name: build-xquery-type-dicts
+        language: python
+        entry: script/build_xquery_type_dicts
+
   # Check the library itself in strict mode
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.2.0

--- a/script/build_xquery_type_dicts
+++ b/script/build_xquery_type_dicts
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+
+import re
+from os import listdir
+from os.path import join
+
+DICTS_FILE_PREAMBLE = """# This file is built automatically with script/build_xquery_type_dicts.
+# DO NOT CHANGE IT MANUALLY!
+
+from typing import Any, Optional, TypedDict
+
+
+class MarkLogicAPIDict(TypedDict):
+    pass"""
+
+XQY_FILES_PATCH = join("src", "caselawclient", "xquery")
+DICTS_FILES_PATCH = join("src", "caselawclient", "xquery_type_dicts.py")
+
+ML_TYPES_TO_PYTHON_TYPES_DICT = {
+    "xs:string": "str",
+    "json:array": "list[Any]",
+    "xs:boolean": "bool",
+    "xs:int": "int",
+}
+
+XQY_VARIABLE_DECLARATION_REGEX = re.compile(
+    r"\s*declare variable \$(.+) as (.+) external;".replace(" ", "\\s+"),
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def file_name_to_class_name(file_name: str):
+    return file_name.split(".")[0].title().replace("_", "") + "Dict"
+
+
+def ml_type_to_python_type(type: str):
+    if type[-1] == "?":
+        type = ML_TYPES_TO_PYTHON_TYPES_DICT[type[:-1]]
+        return f"Optional[{type}]"
+    else:
+        return ML_TYPES_TO_PYTHON_TYPES_DICT[type]
+
+
+xquery_files = [f for f in listdir(XQY_FILES_PATCH) if f.endswith(".xqy")]
+
+with open(DICTS_FILES_PATCH, "w") as dicts_file:
+    dicts_file.write(DICTS_FILE_PREAMBLE)
+
+    for xquery_file in sorted(xquery_files):
+        with open(join(XQY_FILES_PATCH, xquery_file)) as file:
+            data = file.read()
+
+            matches = XQY_VARIABLE_DECLARATION_REGEX.findall(data)
+
+            if len(matches) > 0:
+                class_name = file_name_to_class_name(xquery_file)
+                dicts_file.write(
+                    f"""
+
+
+# {xquery_file}
+class {class_name}(MarkLogicAPIDict):"""
+                )
+
+                for match in sorted(matches):
+                    variable_name = match[0]
+                    variable_type = ml_type_to_python_type(match[1])
+                    dicts_file.write(f"\n    {variable_name}: {variable_type}")
+
+    dicts_file.write("\n")

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -1,0 +1,188 @@
+# This file is built automatically with script/build_xquery_type_dicts.
+# DO NOT CHANGE IT MANUALLY!
+
+from typing import Any, Optional, TypedDict
+
+
+class MarkLogicAPIDict(TypedDict):
+    pass
+
+
+# break_judgment_checkout.xqy
+class BreakJudgmentCheckoutDict(MarkLogicAPIDict):
+    uri: str
+
+
+# checkin_judgment.xqy
+class CheckinJudgmentDict(MarkLogicAPIDict):
+    uri: str
+
+
+# checkout_judgment.xqy
+class CheckoutJudgmentDict(MarkLogicAPIDict):
+    annotation: str
+    timeout: int
+    uri: str
+
+
+# copy_judgment.xqy
+class CopyJudgmentDict(MarkLogicAPIDict):
+    new_uri: str
+    old_uri: str
+
+
+# delete_judgment.xqy
+class DeleteJudgmentDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_judgment.xqy
+class GetJudgmentDict(MarkLogicAPIDict):
+    show_unpublished: Optional[bool]
+    uri: str
+    version_uri: Optional[str]
+
+
+# get_judgment_checkout_status.xqy
+class GetJudgmentCheckoutStatusDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_judgment_version.xqy
+class GetJudgmentVersionDict(MarkLogicAPIDict):
+    uri: str
+    version: str
+
+
+# get_last_modified.xqy
+class GetLastModifiedDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_metadata_citation.xqy
+class GetMetadataCitationDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_metadata_court.xqy
+class GetMetadataCourtDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_metadata_name.xqy
+class GetMetadataNameDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_metadata_work_date.xqy
+class GetMetadataWorkDateDict(MarkLogicAPIDict):
+    uri: str
+
+
+# get_properties_for_search_results.xqy
+class GetPropertiesForSearchResultsDict(MarkLogicAPIDict):
+    uris: list[Any]
+
+
+# get_property.xqy
+class GetPropertyDict(MarkLogicAPIDict):
+    name: str
+    uri: str
+
+
+# insert_judgment.xqy
+class InsertJudgmentDict(MarkLogicAPIDict):
+    judgment: str
+    uri: str
+
+
+# list_judgment_versions.xqy
+class ListJudgmentVersionsDict(MarkLogicAPIDict):
+    uri: str
+
+
+# set_boolean_property.xqy
+class SetBooleanPropertyDict(MarkLogicAPIDict):
+    name: str
+    uri: str
+    value: str
+
+
+# set_metadata_citation.xqy
+class SetMetadataCitationDict(MarkLogicAPIDict):
+    content: str
+    uri: str
+
+
+# set_metadata_court.xqy
+class SetMetadataCourtDict(MarkLogicAPIDict):
+    content: str
+    uri: str
+
+
+# set_metadata_name.xqy
+class SetMetadataNameDict(MarkLogicAPIDict):
+    content: str
+    uri: str
+
+
+# set_metadata_this_uri.xqy
+class SetMetadataThisUriDict(MarkLogicAPIDict):
+    content_with_id: str
+    content_with_xml: str
+    content_without_id: str
+    uri: str
+
+
+# set_metadata_work_expression_date.xqy
+class SetMetadataWorkExpressionDateDict(MarkLogicAPIDict):
+    content: str
+    uri: str
+
+
+# set_property.xqy
+class SetPropertyDict(MarkLogicAPIDict):
+    name: str
+    uri: str
+    value: str
+
+
+# update_judgment.xqy
+class UpdateJudgmentDict(MarkLogicAPIDict):
+    annotation: str
+    judgment: str
+    uri: str
+
+
+# update_locked_judgment.xqy
+class UpdateLockedJudgmentDict(MarkLogicAPIDict):
+    annotation: str
+    judgment: str
+    uri: str
+
+
+# user_has_privilege.xqy
+class UserHasPrivilegeDict(MarkLogicAPIDict):
+    privilege_action: str
+    privilege_uri: str
+    user: str
+
+
+# user_has_role.xqy
+class UserHasRoleDict(MarkLogicAPIDict):
+    role: str
+    user: str
+
+
+# xslt.xqy
+class XsltDict(MarkLogicAPIDict):
+    uri: str
+
+
+# xslt_transform.xqy
+class XsltTransformDict(MarkLogicAPIDict):
+    img_location: Optional[str]
+    show_unpublished: Optional[bool]
+    uri: str
+    version_uri: Optional[str]
+    xsl_filename: Optional[str]

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -20,7 +20,7 @@ class TestEvalXslt(unittest.TestCase):
                 expected_vars = {
                     "uri": "/judgment/uri.xml",
                     "version_uri": None,
-                    "show_unpublished": "true",
+                    "show_unpublished": True,
                     "img_location": "",
                     "xsl_filename": "accessible-html.xsl",
                 }
@@ -45,7 +45,7 @@ class TestEvalXslt(unittest.TestCase):
                     expected_vars = {
                         "uri": "/judgment/uri.xml",
                         "version_uri": None,
-                        "show_unpublished": "false",
+                        "show_unpublished": False,
                         "img_location": "",
                         "xsl_filename": "accessible-html.xsl",
                     }
@@ -68,7 +68,7 @@ class TestEvalXslt(unittest.TestCase):
                 expected_vars = {
                     "uri": "/judgment/uri.xml",
                     "version_uri": None,
-                    "show_unpublished": "true",
+                    "show_unpublished": True,
                     "img_location": "",
                     "xsl_filename": "as-handed-down.xsl",
                 }

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -79,7 +79,6 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             expected_vars = {
                 "uri": "/ewca/civ/2004/632.xml",
                 "judgment": judgment_str,
-                "annotation": "",
             }
             self.client.insert_judgment_xml(uri, judgment_xml)
 


### PR DESCRIPTION
This introduces a new script, `build_xquery_type_dicts`, which looks through the `.xqy` files in `src/caselawclient/xquery` and uses their contents to generate a new `xquery_type_dicts.py`. This file strictly declares all required and optional parameters for each query as `TypedDict`s, which in this case are subclassed via `MarkLogicAPIDict`.

`Client.py` requires that all `dict`s passed to `_send_to_eval` are instances of `MarkLogicAPIDict`, which means they will fail if they are not one of the `TypedDict`s generated by the script.

As a final belt-and-braces, generating these typings is added to pre-commit; changing the parameters in a `.xqy` file will cause changes to be made in `xquery_type_dicts.py`, which will in turn cause mypy to fail if they are incompatible with the current implementation.