### PR TITLE
Only run coverage reporting on latest Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,11 @@ jobs:
         run: poetry run coverage run -m pytest
 
       - name: Generate coverage XML
+        if: ${{ matrix.python-version == '3.11' }}
         run: poetry run coverage xml
 
       - name: Upload coverage to CodeClimate
         uses: paambaati/codeclimate-action@v3.2.0
+        if: ${{ matrix.python-version == '3.11' }}
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
At the moment we report coverage for all three test runs; we should really only report it for the most recent version.