### PR TITLE
Add lxml stubs and fix typing issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
     rev: v1.2.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]"]
+        additional_dependencies:
+          [types-requests, "boto3-stubs[s3,sns]", "lxml-stubs"]
         files: ^src/
         args: ["--strict"]
 
@@ -47,7 +48,8 @@ repos:
     rev: v1.2.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]"]
+        additional_dependencies:
+          [types-requests, "boto3-stubs[s3,sns]", "lxml-stubs"]
         files: ^tests/
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date


### PR DESCRIPTION
These stubs provide type hinting for lxml, so that we can make sure we're calling it in a type-safe way.