### PR TITLE
Prevent publication in more invalid states

### DIFF
--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -1,6 +1,7 @@
 import datetime
 from functools import cached_property
 
+from ds_caselaw_utils import neutral_url
 from requests_toolbelt.multipart import decoder
 
 from caselawclient.Client import MarklogicApiClient
@@ -152,6 +153,14 @@ class Judgment:
         return True
 
     @cached_property
+    def has_valid_ncn(self) -> bool:
+        # The checks that we can convert an NCN to a URI using the function from utils
+        if not self.has_ncn or not neutral_url(self.neutral_citation):
+            return False
+
+        return True
+
+    @cached_property
     def has_court(self) -> bool:
         if not self.court:
             return False
@@ -167,6 +176,9 @@ class Judgment:
             return False
 
         if not self.has_ncn:
+            return False
+
+        if not self.has_valid_ncn:
             return False
 
         if not self.has_court:

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -152,6 +152,13 @@ class Judgment:
         return True
 
     @cached_property
+    def has_court(self) -> bool:
+        if not self.court:
+            return False
+
+        return True
+
+    @cached_property
     def is_publishable(self) -> bool:
         if self.is_held:
             return False
@@ -160,6 +167,9 @@ class Judgment:
             return False
 
         if not self.has_ncn:
+            return False
+
+        if not self.has_court:
             return False
 
         return True

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -145,11 +145,21 @@ class Judgment:
         return True
 
     @cached_property
+    def has_ncn(self) -> bool:
+        if not self.neutral_citation:
+            return False
+
+        return True
+
+    @cached_property
     def is_publishable(self) -> bool:
         if self.is_held:
             return False
 
         if not self.has_name:
+            return False
+
+        if not self.has_ncn:
             return False
 
         return True

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -138,8 +138,18 @@ class Judgment:
         return get_judgment_root(self.content_as_xml())
 
     @cached_property
+    def has_name(self) -> bool:
+        if not self.name:
+            return False
+
+        return True
+
+    @cached_property
     def is_publishable(self) -> bool:
         if self.is_held:
+            return False
+
+        if not self.has_name:
             return False
 
         return True

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -169,19 +169,13 @@ class Judgment:
 
     @cached_property
     def is_publishable(self) -> bool:
-        if self.is_held:
-            return False
-
-        if not self.has_name:
-            return False
-
-        if not self.has_ncn:
-            return False
-
-        if not self.has_valid_ncn:
-            return False
-
-        if not self.has_court:
+        if (
+            self.is_held
+            or not self.has_name
+            or not self.has_ncn
+            or not self.has_valid_ncn
+            or not self.has_court
+        ):
             return False
 
         return True

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -193,17 +193,34 @@ class TestJudgment:
         published_judgment.is_published = True
         assert published_judgment.status == JUDGMENT_STATUS_PUBLISHED
 
+    def test_has_name(self, mock_api_client):
+        judgment_with_name = Judgment("test/1234", mock_api_client)
+        judgment_with_name.name = "Judgment v Judgement"
+
+        judgment_without_name = Judgment("test/1234", mock_api_client)
+        judgment_without_name.name = ""
+
+        assert judgment_with_name.has_name is True
+        assert judgment_without_name.has_name is False
+
 
 class TestJudgmentPublication:
-    def test_judgment_is_publishable_if_held(self, mock_api_client):
+    def test_judgment_not_publishable_if_held(self, mock_api_client):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.is_held = True
 
         assert judgment.is_publishable is False
 
-    def test_judgment_is_publishable_if_not_held(self, mock_api_client):
+    def test_judgment_not_publishable_if_missing_name(self, mock_api_client):
+        judgment = Judgment("test/1234", mock_api_client)
+        judgment.has_name = False
+
+        assert judgment.is_publishable is False
+
+    def test_judgment_is_publishable_if_conditions_met(self, mock_api_client):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.is_held = False
+        judgment.has_name = True
 
         assert judgment.is_publishable is True
 

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -203,6 +203,16 @@ class TestJudgment:
         assert judgment_with_name.has_name is True
         assert judgment_without_name.has_name is False
 
+    def test_has_ncn(self, mock_api_client):
+        judgment_with_ncn = Judgment("test/1234", mock_api_client)
+        judgment_with_ncn.neutral_citation = "[2023] TEST 1234"
+
+        judgment_without_ncn = Judgment("test/1234", mock_api_client)
+        judgment_without_ncn.neutral_citation = ""
+
+        assert judgment_with_ncn.has_ncn is True
+        assert judgment_without_ncn.has_ncn is False
+
 
 class TestJudgmentPublication:
     def test_judgment_not_publishable_if_held(self, mock_api_client):
@@ -217,10 +227,17 @@ class TestJudgmentPublication:
 
         assert judgment.is_publishable is False
 
+    def test_judgment_not_publishable_if_missing_ncn(self, mock_api_client):
+        judgment = Judgment("test/1234", mock_api_client)
+        judgment.has_ncn = False
+
+        assert judgment.is_publishable is False
+
     def test_judgment_is_publishable_if_conditions_met(self, mock_api_client):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.is_held = False
         judgment.has_name = True
+        judgment.has_ncn = True
 
         assert judgment.is_publishable is True
 

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -213,6 +213,16 @@ class TestJudgment:
         assert judgment_with_ncn.has_ncn is True
         assert judgment_without_ncn.has_ncn is False
 
+    def test_has_court(self, mock_api_client):
+        judgment_with_court = Judgment("test/1234", mock_api_client)
+        judgment_with_court.court = "[2023] TEST 1234"
+
+        judgment_without_court = Judgment("test/1234", mock_api_client)
+        judgment_without_court.court = ""
+
+        assert judgment_with_court.has_court is True
+        assert judgment_without_court.has_court is False
+
 
 class TestJudgmentPublication:
     def test_judgment_not_publishable_if_held(self, mock_api_client):
@@ -233,11 +243,18 @@ class TestJudgmentPublication:
 
         assert judgment.is_publishable is False
 
+    def test_judgment_not_publishable_if_missing_court(self, mock_api_client):
+        judgment = Judgment("test/1234", mock_api_client)
+        judgment.has_court = False
+
+        assert judgment.is_publishable is False
+
     def test_judgment_is_publishable_if_conditions_met(self, mock_api_client):
         judgment = Judgment("test/1234", mock_api_client)
         judgment.is_held = False
         judgment.has_name = True
         judgment.has_ncn = True
+        judgment.has_court = True
 
         assert judgment.is_publishable is True
 


### PR DESCRIPTION
At the moment the only thing which prevents a publication is the presence of a hold flag, but this is not the only state in which publishing a document is an invalid operation.

Add some more condition checks to the publish flow around a document's name, court code and NCN.

## What next?

We should be able to expose a list of reasons a document isn't publishable, so we can relay them to editors.