### PR TITLE
Release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Release 6.1.0]
+- `Judgment.publish` method will now reject publication in more invalid states (must have a name, must have a valid NCN, must have a court code).
+- Less strict version pinning of dependencies to give downstream package users more flexibility in resolving.
+
 ## [Release 6.0.0]
 - Significantly more type annotations on `Client` and `Judgment` methods, including some which are stricter than before.
   This is potentially a *breaking change* if implementations have been relying on duck typing.
 - Automatic generation of strict typing for XQuery files which run against MarkLogic.
 - Improvements to the methods used in content hashing, which will be breaking changes if these are used downstream.
+
 ## [Release 5.3.2]
 - Correct import location used in Judgment model, so it's usable when packaged
+
 ## [Release 5.3.1]
 - Fix broken build process
 
@@ -193,7 +199,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v6.0.0...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v6.1.0...HEAD
+[Release 6.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v6.0.0...v6.1.0
 [Release 6.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.3.2...v6.0.0
 [Release 5.3.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.3.1...v5.3.2
 [Release 5.3.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v5.3.0...v5.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "6.0.0"
+version = "6.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
- `Judgment.publish` method will now reject publication in more invalid states (must have a name, must have a valid NCN, must have a court code).
- Less strict version pinning of dependencies to give downstream package users more flexibility in resolving.