### PR TITLE
Improve detection of when a judgment doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+- **BREAKING**: Instantiating a`Judgment` object will now raise a `caselawclient.errors.JudgmentNotFoundError` if the uri passed in does not correspond to a valid Judgment, rather than attempting (and failing) to return a `MarklogicResourceNotFoundError`
+- Added `judgment_exists` method to `Client` class
+
 ## [Release 6.1.0]
 - `Judgment.publish` method will now reject publication in more invalid states (must have a name, must have a valid NCN, must have a court code).
 - Less strict version pinning of dependencies to give downstream package users more flexibility in resolving.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ xml_tools.get_search_matches(element)
 To run the test suite:
 
 ```bash
-pip install -r requirements.txt
-python -m pytest
+poetry install
+poetry run pytest
 ```
 
 ## Making changes

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -42,8 +42,12 @@ def decode_multipart(response: requests.Response) -> str:
     """Decode a multipart response and return just the text inside it.
     Note that it is possible for multiple responses to be returned, if
     multiple top-level returns exist in the XQuery."""
+
+    # Arguably, this should return None -- it occurs when there are no
+    # matching entries
     if not (response.content):
         return ""
+
     multipart_data = decoder.MultipartDecoder.from_response(response)
     part_count = len(multipart_data.parts)
     if part_count > 1:
@@ -159,6 +163,12 @@ class MarklogicApiClient:
             accept_header="application/xml",
         )
 
+    def _eval_and_decode(
+        self, vars: query_dicts.MarkLogicAPIDict, xquery_file_name: str
+    ) -> str:
+        response = self._send_to_eval(vars, xquery_file_name)
+        return decode_multipart(response)
+
     def prepare_request_kwargs(
         self,
         method: str,
@@ -202,6 +212,19 @@ class MarklogicApiClient:
         logging.warning("POST() is deprecated, use eval() or invoke()")
         return self.make_request("POST", path, headers, data)  # type: ignore
 
+    def judgment_exists(self, judgment_uri: str) -> bool:
+        uri = self._format_uri_for_marklogic(judgment_uri)
+        vars: query_dicts.JudgmentExistsDict = {
+            "uri": uri,
+        }
+        decoded_response = self._eval_and_decode(vars, "judgment_exists.xqy")
+
+        if decoded_response == "true":
+            return True
+        if decoded_response == "false":
+            return False
+        raise RuntimeError("Marklogic response was neither true nor false")
+
     def get_judgment_xml(
         self,
         judgment_uri: str,
@@ -218,29 +241,24 @@ class MarklogicApiClient:
             "show_unpublished": show_unpublished,
         }
 
-        response = self._send_to_eval(vars, "get_judgment.xqy")
-
-        if not response.text:
+        decoded_response = self._eval_and_decode(vars, "get_judgment.xqy")
+        if not decoded_response:
             raise MarklogicNotPermittedError(
                 "The document is not published and show_unpublished was not set"
             )
 
-        return decode_multipart(response)
+        return decoded_response
+
+        return self._eval_and_decode(vars, "get_judgment.xqy")
 
     def get_judgment_name(self, judgment_uri: str) -> str:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.GetMetadataNameDict = {"uri": uri}
-
-        response = self._send_to_eval(vars, "get_metadata_name.xqy")
-        if not response.text:
-            return ""
-
-        return decode_multipart(response)
+        return self._eval_and_decode(vars, "get_metadata_name.xqy")
 
     def set_judgment_name(self, judgment_uri: str, content: str) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.SetMetadataNameDict = {"uri": uri, "content": content}
-
         return self._send_to_eval(vars, "set_metadata_name.xqy")
 
     def set_judgment_date(self, judgment_uri: str, content: str) -> requests.Response:
@@ -544,13 +562,7 @@ class MarklogicApiClient:
             "uri": uri,
             "name": name,
         }
-        response = self._send_to_eval(vars, "get_property.xqy")
-
-        if not response.text:
-            return ""
-
-        content = str(decoder.MultipartDecoder.from_response(response).parts[0].text)
-        return content
+        return self._eval_and_decode(vars, "get_property.xqy")
 
     def set_property(
         self, judgment_uri: str, name: str, value: str

--- a/src/caselawclient/errors.py
+++ b/src/caselawclient/errors.py
@@ -71,3 +71,9 @@ class InvalidContentHashError(MarklogicAPIError):
     default_message = (
         "The content hash in the document did not match the hash of the content"
     )
+
+
+class JudgmentNotFoundError(MarklogicAPIError):
+    # This error does not come from Marklogic, but is an error raised by this API...
+    status_code = 404
+    default_message = "The judgment was not found"

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -6,6 +6,7 @@ from ds_caselaw_utils import neutral_url
 from requests_toolbelt.multipart import decoder
 
 from caselawclient.Client import MarklogicApiClient
+from caselawclient.errors import JudgmentNotFoundError
 
 from .utilities import VersionsDict, get_judgment_root, render_versions
 from .utilities.aws import (
@@ -30,9 +31,11 @@ class Judgment:
     def __init__(self, uri: str, api_client: MarklogicApiClient):
         self.uri = uri.strip("/")
         self.api_client = api_client
+        if not self.judgment_exists():
+            raise JudgmentNotFoundError(f"Judgment {self.uri} does not exist")
 
-        # As part of initialisation, we preload the NCN so we can generate a MarklogicResourceNotFoundError early
-        self.neutral_citation
+    def judgment_exists(self) -> bool:
+        return self.api_client.judgment_exists(self.uri)
 
     @property
     def public_uri(self) -> str:

--- a/src/caselawclient/xquery/judgment_exists.xqy
+++ b/src/caselawclient/xquery/judgment_exists.xqy
@@ -1,0 +1,5 @@
+xquery version "1.0-ml";
+
+declare variable $uri as xs:string external;
+
+fn:doc-available($uri)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -96,6 +96,11 @@ class InsertJudgmentDict(MarkLogicAPIDict):
     uri: str
 
 
+# judgment_exists.xqy
+class JudgmentExistsDict(MarkLogicAPIDict):
+    uri: str
+
+
 # list_judgment_versions.xqy
 class ListJudgmentVersionsDict(MarkLogicAPIDict):
     uri: str

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -8,6 +8,39 @@ class ApiClientTest(unittest.TestCase):
     def setUp(self):
         self.client = MarklogicApiClient("", "", "", False)
 
+    @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
+    def test_eval_and_decode(self, mock_eval):
+        mock_eval.return_value.headers = {
+            "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+        }
+        mock_eval.return_value.content = (
+            b"\r\n--595658fa1db1aa98\r\n"
+            b"Content-Type: application/xml\r\n"
+            b"X-Primitive: element()\r\n"
+            b"X-Path: /*\r\n\r\n"
+            b"true\r\n"
+            b"--595658fa1db1aa98--\r\n"
+        )
+        assert (
+            self.client._eval_and_decode({"url": "/2029/eat/1"}, "myfile.xqy") == "true"
+        )
+
+    @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
+    def test_judgment_exists(self, mock_decode):
+        mock_decode.return_value = "true"
+        assert self.client.judgment_exists("/2029/eat/1") is True
+        mock_decode.assert_called_with(
+            {"uri": "/2029/eat/1.xml"}, "judgment_exists.xqy"
+        )
+
+    @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
+    def test_judgment_not_exists(self, mock_decode):
+        mock_decode.return_value = "false"
+        assert self.client.judgment_exists("/2029/eat/1") is False
+        mock_decode.assert_called_with(
+            {"uri": "/2029/eat/1.xml"}, "judgment_exists.xqy"
+        )
+
     @patch("caselawclient.Client.Path")
     def test_eval_calls_request(self, MockPath):
         mock_path_instance = MockPath.return_value

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -44,7 +44,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
 
     def test_get_unset_boolean_property(self):
         with patch.object(self.client, "eval") as mock_eval:
-            mock_eval.return_value.text = ""
+            mock_eval.return_value.content = ""
             result = self.client.get_boolean_property("/judgment/uri", "my-property")
 
             assert result is False
@@ -89,7 +89,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
 
     def test_get_unset_property(self):
         with patch.object(self.client, "eval") as mock_eval:
-            mock_eval.return_value.text = ""
+            mock_eval.return_value.content = ""
             result = self.client.get_property("/judgment/uri", "my-property")
 
             assert "" == result

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from caselawclient.Client import MarklogicApiClient
+from caselawclient.errors import JudgmentNotFoundError
 from caselawclient.models.judgments import (
     JUDGMENT_STATUS_HOLD,
     JUDGMENT_STATUS_IN_PROGRESS,
@@ -30,6 +31,11 @@ class TestJudgment:
         assert (
             judgment.public_uri == "https://caselaw.nationalarchives.gov.uk/test/1234"
         )
+
+    def test_judgment_exists_check(self, mock_api_client):
+        mock_api_client.judgment_exists.return_value = False
+        with pytest.raises(JudgmentNotFoundError):
+            Judgment("not_a_real_judgment", mock_api_client)
 
     def test_judgment_neutral_citation(self, mock_api_client):
         mock_api_client.get_judgment_citation.return_value = "[2023] TEST 1234"


### PR DESCRIPTION
The existing implementation is based on a misunderstanding of the `get_neutral_citation` implementation; this does not return an exception if the document doesn't exist, it returns an empty string.

Implement a new function which explicitly tests for the existence of a document or not, and use that as part of `Judgment.__init__`.