### PR TITLE
Unlock judgment on Judgment.unpublish()

### DIFF
--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -207,6 +207,7 @@ class Judgment:
         )
 
     def unpublish(self) -> None:
+        self.api_client.break_checkout(self.uri)
         unpublish_documents(uri_for_s3(self.uri))
         self.api_client.set_published(self.uri, False)
         notify_changed(

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -329,6 +329,7 @@ class TestJudgmentPublication:
         judgment.unpublish()
         mock_unpublish_documents.assert_called_once_with("test/1234")
         mock_api_client.set_published.assert_called_once_with("test/1234", False)
+        mock_api_client.break_checkout.assert_called_once_with("test/1234")
         mock_notify_changed.assert_called_once_with(
             uri="test/1234", status="not published", enrich=False
         )


### PR DESCRIPTION
notes:
* Unlock is before we attempt to unpublish, as unpublishing is impossible whilst locked
* Unlocking an unlocked judgment is fine

https://trello.com/c/O8J1bxp7/861-publishing-and-unpublishing-quickly-causing-document-to-stay-locked-due-to-enrichment
