### PR TITLE
Add ability to build a Judgment object from a known set of values

### DIFF
--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -110,6 +110,12 @@ class Judgment:
 
         return self.values_store[attr_name]
 
+    def __setattr__(self, attr_name: str, value: MarkLogicValueType) -> None:
+        if attr_name not in self.marklogic_attribute_map:
+            raise AttributeError
+
+        self.__dict__["values_store"][attr_name] = value
+
     @property
     def public_uri(self) -> str:
         return "https://caselaw.nationalarchives.gov.uk/{uri}".format(uri=self.uri)

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -265,6 +265,11 @@ class TestJudgmentMagicAttributes:
         with pytest.raises(AttributeError):
             judgment.this_attribute_does_not_exist
 
+    def test_setattr_raises_attributeerror_on_attribute_map_miss(self, mock_api_client):
+        judgment = Judgment("test/1234", mock_api_client)
+        with pytest.raises(AttributeError):
+            judgment.this_attribute_does_not_exist = "Any Value"
+
 
 class TestJudgmentPublication:
     @patch.object(Judgment, "is_held", True)


### PR DESCRIPTION
At the moment a Judgment can only be initialised from a URI and it will get other values as necessary, but the search flow returns a more complete set of data for each result.

We should be able to initialise a Judgment object from these pieces of data, which means retooling how a Judgment stores properties.

This needs to happen before we can implement search in the API layer.