### PR TITLE
Add optional collections kwarg to Client.advanced_search  method for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Unreleased]
+- Added optional `collections` kwarg to `Client.advanced_search`  method for filtering by collections
+
+
 ## [Release 7.0.0]
 - **BREAKING**: Instantiating a`Judgment` object will now raise a `caselawclient.errors.JudgmentNotFoundError` if the uri passed in does not correspond to a valid Judgment, rather than attempting (and failing) to return a `MarklogicResourceNotFoundError`
 - Added `judgment_exists` method to `Client` class

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -463,6 +463,7 @@ class MarklogicApiClient:
         page_size: int = RESULTS_PER_PAGE,
         show_unpublished: bool = False,
         only_unpublished: bool = False,
+        collections: Optional[str] = None,
     ) -> requests.Response:
         """
         Performs a search on the entire document set.
@@ -480,6 +481,7 @@ class MarklogicApiClient:
         :param page_size:
         :param show_unpublished: If True, both published and unpublished documents will be returned
         :param only_unpublished: If True, will only return published documents. Ignores the value of show_unpublished
+        :param collections:
         :return:
         """
         module = "/judgments/search/search-v2.xqy"  # as stored on Marklogic
@@ -499,6 +501,7 @@ class MarklogicApiClient:
                 "to": str(date_to or ""),
                 "show_unpublished": str(show_unpublished).lower(),
                 "only_unpublished": str(only_unpublished).lower(),
+                "collections": str(collections or ""),
             }
         )
         return self.invoke(module, vars)

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -3,6 +3,8 @@ import logging
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from caselawclient.Client import MarklogicApiClient
 
 
@@ -10,11 +12,117 @@ class TestAdvancedSearch(unittest.TestCase):
     def setUp(self):
         self.client = MarklogicApiClient("", "testuser", "", False)
 
-    def test_advanced_search_user_can_view_unpublished_but_show_unpublished_is_false(
+    def test_invoke_called_with_default_params_when_optional_parameters_not_provided(
         self,
     ):
-        """If a user who is allowed to view unpublished judgments wishes to specifically see only published
-        judgments, do not change the value of `show_unpublished`"""
+        """
+        Scenario: Searching without specifying any arguments
+        Given a client instance
+        When the advanced_search method is called without any arguments
+        Then it should call the MarkLogic module with the defaults
+            parameters and return the response
+        """
+
+        with patch.object(self.client, "invoke"):
+            response = self.client.advanced_search()
+
+            self.client.invoke.assert_called_with(
+                "/judgments/search/search-v2.xqy",
+                json.dumps(
+                    {
+                        "court": None,
+                        "judge": "",
+                        "page": 1,
+                        "page-size": 10,
+                        "q": "",
+                        "party": "",
+                        "neutral_citation": "",
+                        "specific_keyword": "",
+                        "order": "",
+                        "from": "",
+                        "to": "",
+                        "show_unpublished": "false",
+                        "only_unpublished": "false",
+                        "collections": "",
+                    }
+                ),
+            )
+
+            assert response == self.client.invoke.return_value
+
+    def test_invoke_called_with_all_params_when_all_parameters_provided(self):
+        """
+        Scenario: Searching with all parameters
+        Given a client instance
+        When the advanced_search method is called with all available parameters
+        Then it should call the MarkLogic module with all the parameters
+            and return the response
+        """
+        with patch.object(self.client, "invoke"):
+            response = self.client.advanced_search(
+                q="test query",
+                court="court",
+                judge="judge",
+                party="party",
+                neutral_citation="citation",
+                specific_keyword="keyword",
+                order="order",
+                date_from="2010-01-01",
+                date_to="2010-12-31",
+                page=2,
+                page_size=10,
+                show_unpublished=False,
+                only_unpublished=False,
+                collections="foo,bar",
+            )
+
+            self.client.invoke.assert_called_with(
+                "/judgments/search/search-v2.xqy",
+                json.dumps(
+                    {
+                        "court": ["court"],
+                        "judge": "judge",
+                        "page": 2,
+                        "page-size": 10,
+                        "q": "test query",
+                        "party": "party",
+                        "neutral_citation": "citation",
+                        "specific_keyword": "keyword",
+                        "order": "order",
+                        "from": "2010-01-01",
+                        "to": "2010-12-31",
+                        "show_unpublished": "false",
+                        "only_unpublished": "false",
+                        "collections": "foo,bar",
+                    }
+                ),
+            )
+
+            assert response == self.client.invoke.return_value
+
+    def test_exception_raised_when_invoke_raises_an_exception(self):
+        """
+        Scenario: MarkLogic exception while searching
+        Given a client instance
+        When the advanced_search method is called and MarkLogic returns an exception
+        Then it should raise that same exception
+        """
+        exception = Exception("Error message from MarkLogic")
+        with patch.object(self.client, "invoke"):
+            self.client.invoke.side_effect = exception
+            with pytest.raises(Exception) as e:
+                self.client.advanced_search(q="test query")
+        assert e.value == exception
+
+    def test_user_can_view_unpublished_but_show_unpublished_is_false(
+        self,
+    ):
+        """
+        Scenario: User can view unpublished but show unpublished is false
+        Given a client instance with a user who is allowed to view unpublished judgments
+        When the advanced_search method is called with the show_unpublished parameter set to False
+        Then it should call the MarkLogic module with the expected query parameters
+        """
         with patch.object(self.client, "invoke") as mock_invoke:
             with patch.object(
                 self.client, "user_can_view_unpublished_judgments", return_value=True
@@ -43,17 +151,23 @@ class TestAdvancedSearch(unittest.TestCase):
                     "to": "",
                     "show_unpublished": "false",
                     "only_unpublished": "false",
+                    "collections": "",
                 }
 
                 mock_invoke.assert_called_with(
                     "/judgments/search/search-v2.xqy", json.dumps(expected_vars)
                 )
 
-    def test_advanced_search_user_can_view_unpublished_and_show_unpublished_is_true(
+    def test_user_can_view_unpublished_and_show_unpublished_is_true(
         self,
     ):
-        """The user is permitted to see unpublished judgments and requests to see unpublished judgments"""
-        with patch.object(self.client, "invoke") as mock_invoke:
+        """
+        Scenario: User can view unpublished and show unpublished is true
+        Given a client instance with a user who is allowed to view unpublished judgments
+        When the advanced_search method is called with the show_unpublished parameter set to True
+        Then it should call the MarkLogic module with the expected query parameters
+        """
+        with patch.object(self.client, "invoke"):
             with patch.object(
                 self.client, "user_can_view_unpublished_judgments", return_value=True
             ):
@@ -66,14 +180,20 @@ class TestAdvancedSearch(unittest.TestCase):
                     page_size=20,
                     show_unpublished=True,
                 )
-                assert '"show_unpublished": "true"' in mock_invoke.call_args.args[1]
+                assert (
+                    '"show_unpublished": "true"' in self.client.invoke.call_args.args[1]
+                )
 
-    def test_advanced_search_user_cannot_view_unpublished_but_show_unpublished_is_true(
+    def test_user_cannot_view_unpublished_but_show_unpublished_is_true(
         self,
     ):
-        """The user is not permitted to see unpublished judgments but is attempting to view them
-        Set `show_unpublished` to false and log a warning"""
-        with patch.object(self.client, "invoke") as mock_invoke:
+        """
+        Scenario: User cannot view unpublished but show unpublished is true
+        Given a client instance with a user who is not allowed to view unpublished judgments
+        When the advanced_search method is called with the show_unpublished parameter set to True
+        Then it should call the MarkLogic module with the show_unpublished parameter set to False and log a warning
+        """
+        with patch.object(self.client, "invoke"):
             with patch.object(
                 self.client, "user_can_view_unpublished_judgments", return_value=False
             ):
@@ -89,15 +209,21 @@ class TestAdvancedSearch(unittest.TestCase):
                     )
 
                     assert (
-                        '"show_unpublished": "false"' in mock_invoke.call_args.args[1]
+                        '"show_unpublished": "false"'
+                        in self.client.invoke.call_args.args[1]
                     )
                     mock_logging.assert_called()
 
-    def test_advanced_search_no_page_0(self):
-        """Requests for page 0 or lower are sent to page 1."""
-        with patch.object(self.client, "invoke") as mock_invoke:
+    def test_no_page_0(self):
+        """
+        Scenario: Requests for page 0 or lower are sent to page 1
+        Given a client instance
+        When the advanced_search method is called with the page parameter set to 0
+        Then it should call the MarkLogic module with the page parameter set to 1
+        """
+        with patch.object(self.client, "invoke"):
             self.client.advanced_search(
                 page=0,
             )
 
-            assert ', "page": 1,' in mock_invoke.call_args.args[1]
+            assert ', "page": 1,' in self.client.invoke.call_args.args[1]


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

- Added optional `collections` kwarg to `Client.advanced_search` method for filtering by collections
- improved the tests for `Client.advanced_search`
- Changelog updated appropriately

## Trello card / Rollbar error (etc)

https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously

## Testing
- [x] Before merging, I need to test the client manually to show that it is working end to end especially since the python tests mock out the calls to marklogic.

UPDATE: Have tested locally by instantiating `MarklogicAPIClient` with credentials pointing to our staging marklogic instance, added some documents manually to some collections in the marklogic console and then called `client.advanced_search("judgment")` and verified that it returned those documents from that collection.
