### PR TITLE
Make collections parameter a list in advanced_search

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -501,7 +501,9 @@ class MarklogicApiClient:
                 "to": str(date_to or ""),
                 "show_unpublished": str(show_unpublished).lower(),
                 "only_unpublished": str(only_unpublished).lower(),
-                "collections": str(collections or ""),
+                "collections": ",".join(collections or [])
+                .replace(" ", "")
+                .replace(",,", ","),
             }
         )
         return self.invoke(module, vars)

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -73,7 +73,7 @@ class TestAdvancedSearch(unittest.TestCase):
                 page_size=10,
                 show_unpublished=False,
                 only_unpublished=False,
-                collections="foo,bar",
+                collections=[" foo ", "abc def", " bar"],
             )
 
             self.client.invoke.assert_called_with(
@@ -93,7 +93,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "to": "2010-12-31",
                         "show_unpublished": "false",
                         "only_unpublished": "false",
-                        "collections": "foo,bar",
+                        "collections": "foo,abcdef,bar",
                     }
                 ),
             )


### PR DESCRIPTION
When filtering by judgment collection in the PUI in https://github.com/nationalarchives/ds-caselaw-public-ui/pull/701/files, I realised it was nicer for `collections` to be a list rather than a comma-separated string - so this PR changes that.

## Changes in this PR:
- Adjust collections filter on advanced_search so that it is passed as a list of possible collection uri strings instead of a comma separated list in a string
- Added some empty string/space filtering to it, so that it doesn't error in the marklogic query due to spaces/empty strings as marklogic collection names must be valid uris and empty strings / strings with spaces are not valid. Could do more validation but I dont think its worth it for now and probably best to do in the marklogic query itself. These filters seemed simple enough to add though, so I did. Thoughts?

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously