### PR TITLE
Abstract away search result parsing into apiclient

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v1.2.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]"]
+        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
         files: ^src/
         args: ["--strict"]
 
@@ -47,7 +47,7 @@ repos:
     rev: v1.2.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]"]
+        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
         files: ^tests/
 
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Added `SearchParameters` dataclass for use with search functions using the legacy kwargs from `Client.advanced_search` and new `collections` field for filtering by collections
 - Changed `Client.advanced_search` interface to take in `SearchParameters` as opposed to the legacy kwargs.
 - Added `search_and_decode_response` and `search_judgments_and_decode_response` methods to `Client`
+- Added `SearchResponse`, `SearchResult`, `SearchResultMetadata` classes to encapsulate and process document search responses.
 
 ## [Release 7.0.0]
 - **BREAKING**: Instantiating a`Judgment` object will now raise a `caselawclient.errors.JudgmentNotFoundError` if the uri passed in does not correspond to a valid Judgment, rather than attempting (and failing) to return a `MarklogicResourceNotFoundError`

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -1,0 +1,65 @@
+from typing import List
+
+from lxml import etree
+
+from caselawclient.responses.search_result import SearchResult
+
+
+class SearchResponse:
+    """
+    Represents a search response obtained from XML data.
+
+    Attributes:
+        NAMESPACES (dict): Namespaces used in XPath expressions.
+    """
+
+    NAMESPACES = {"search": "http://marklogic.com/appservices/search"}
+
+    def __init__(self, node: etree._Element):
+        """
+        Initializes a SearchResponse instance from an xml node.
+
+        Args:
+            node (etree._Element): The XML data as an etree element.
+        """
+        self.node = node
+
+    @staticmethod
+    def from_response_string(xml: str) -> "SearchResponse":
+        """
+        Constructs a SearchResponse instance from an xml response string.
+
+        Args:
+            xml (str): The XML data as a string.
+        """
+        return SearchResponse(etree.fromstring(xml))
+
+    @property
+    def total(self) -> str:
+        """
+        Property: The total number of search results.
+
+        Returns:
+            str: The total number of search results.
+        """
+        return str(
+            self.node.xpath("//search:response/@total", namespaces=self.NAMESPACES)[0]
+        )
+
+    @property
+    def results(self) -> List[SearchResult]:
+        """
+        Property: Converts the SearchResponse to a list of SearchResult objects.
+
+        Returns:
+            List[SearchResult]: The list of search results.
+        """
+        results = self.node.xpath(
+            "//search:response/search:result", namespaces=self.NAMESPACES
+        )
+        return [
+            SearchResult(
+                result,
+            )
+            for result in results
+        ]

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -1,0 +1,224 @@
+import logging
+import os
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Optional
+
+from dateutil import parser as dateparser
+from dateutil.parser import ParserError
+from ds_caselaw_utils.courts import Court, CourtNotFoundException, courts
+from lxml import etree
+
+from caselawclient.Client import api_client
+
+
+class EditorStatus(Enum):
+    """
+    Enum representing the editor status.
+    """
+
+    NEW = "new"
+    IN_PROGRESS = "in progress"
+    HOLD = "hold"
+
+
+class EditorPriority(Enum):
+    """
+    Enum representing the editor priority.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class SearchResultMetadata:
+    """
+    Represents the metadata of a search result.
+
+    Properties:
+        author (str): The author of the search result.
+        author_email (str): The email of the author.
+        consignment_reference (str): The consignment reference.
+        assigned_to (str): The assigned editor.
+        editor_hold (str): The editor hold status.
+        editor_priority (str): The editor priority.
+        last_modified (str): The last modified date.
+        submission_datetime (datetime): The submission datetime.
+        editor_status (str): The editor status based on the metadata.
+    """
+
+    def __init__(self, node: etree._Element, last_modified: str):
+        self.node = node
+        self.last_modified = last_modified
+
+    @staticmethod
+    def create_from_uri(uri: str) -> "SearchResultMetadata":
+        """
+        Create a SearchResultMetadata instance from a search result URI.
+
+        Args:
+            uri (str): The URI of the search result.
+
+        Returns:
+            SearchResultMetadata: The created SearchResultMetadata instance.
+        """
+        response_text = api_client.get_properties_for_search_results([uri])
+        last_modified = api_client.get_last_modified(uri)
+        root = etree.fromstring(response_text)
+        return SearchResultMetadata(root, last_modified)
+
+    @property
+    def submission_datetime(self) -> datetime:
+        extracted_submission_datetime = self._get_xpath_match_string(
+            "//transfer-received-at/text()"
+        )
+        return (
+            datetime.strptime(extracted_submission_datetime, "%Y-%m-%dT%H:%M:%SZ")
+            if extracted_submission_datetime
+            else datetime.min
+        )
+
+    @property
+    def author(self) -> str:
+        return self._get_xpath_match_string("//source-name/text()")
+
+    @property
+    def author_email(self) -> str:
+        return self._get_xpath_match_string("//source-email/text()")
+
+    @property
+    def consignment_reference(self) -> str:
+        return self._get_xpath_match_string("//transfer-consignment-reference/text()")
+
+    @property
+    def assigned_to(self) -> str:
+        return self._get_xpath_match_string("//assigned-to/text()")
+
+    @property
+    def editor_hold(self) -> str:
+        return self._get_xpath_match_string("//editor-hold/text()")
+
+    @property
+    def editor_priority(self) -> str:
+        return self._get_xpath_match_string(
+            "//editor-priority/text()", EditorPriority.MEDIUM.value
+        )
+
+    @property
+    def editor_status(
+        self,
+    ) -> str:
+        if self.editor_hold == "true":
+            return EditorStatus.HOLD.value
+        if self.assigned_to:
+            return EditorStatus.IN_PROGRESS.value
+        return EditorStatus.NEW.value
+
+    def _get_xpath_match_string(self, path: str, fallback: str = "") -> str:
+        return get_xpath_match_string(self.node, path, fallback=fallback)
+
+
+class SearchResult:
+    """
+    Represents a search result obtained from XML data.
+
+    Attributes:
+        NAMESPACES (Dict[str, str]): Namespace mappings used in XPath expressions.
+
+    Args:
+        node (etree._Element): The XML element representing the search result.
+
+    Properties:
+        uri (str): The URI of the search result.
+        neutral_citation (str): The neutral citation of the search result.
+        name (str): The name of the search result.
+        court (Optional[Court]): The court of the search result.
+        date (Optional[datetime]): The date of the search result.
+        transformation_date (str): The transformation date of the search result.
+        content_hash (str): The content hash of the search result.
+        matches (str): The search result matches.
+        metadata (SearchResultMetadata): The metadata of the search result.
+    """
+
+    NAMESPACES: Dict[str, str] = {
+        "search": "http://marklogic.com/appservices/search",
+        "uk": "https://caselaw.nationalarchives.gov.uk/akn",
+        "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+    }
+
+    def __init__(self, node: etree._Element):
+        self.node = node
+
+    @property
+    def uri(self) -> str:
+        return self._get_xpath_match_string("@uri").lstrip("/").split(".xml")[0]
+
+    @property
+    def neutral_citation(self) -> str:
+        return self._get_xpath_match_string("search:extracted/uk:cite/text()")
+
+    @property
+    def name(self) -> str:
+        return self._get_xpath_match_string("search:extracted/akn:FRBRname/@value")
+
+    @property
+    def court(
+        self,
+    ) -> Optional[Court]:
+        court_code = self._get_xpath_match_string("search:extracted/uk:court/text()")
+        try:
+            court = courts.get_by_code(court_code)
+        except CourtNotFoundException:
+            court = None
+
+        return court
+
+    @property
+    def date(self) -> Optional[datetime]:
+        date_string = self._get_xpath_match_string(
+            "search:extracted/akn:FRBRdate[(@name='judgment' or @name='decision')]/@date"
+        )
+        try:
+            date = dateparser.parse(date_string)
+        except ParserError as e:
+            logging.warning(
+                f'Unable to parse document date "{date_string}". Full error: {e}'
+            )
+            date = None
+        return date
+
+    @property
+    def transformation_date(self) -> str:
+        return self._get_xpath_match_string(
+            "search:extracted/akn:FRBRdate[@name='transform']/@date"
+        )
+
+    @property
+    def content_hash(self) -> str:
+        return self._get_xpath_match_string("search:extracted/uk:hash/text()")
+
+    @property
+    def matches(self) -> str:
+        file_path = os.path.join(os.path.dirname(__file__), "xsl/search_match.xsl")
+        xslt_transform = etree.XSLT(etree.parse(file_path))
+        return str(xslt_transform(self.node))
+
+    @property
+    def metadata(self) -> SearchResultMetadata:
+        return SearchResultMetadata.create_from_uri(
+            self.uri,
+        )
+
+    def _get_xpath_match_string(self, path: str) -> str:
+        return get_xpath_match_string(self.node, path, namespaces=self.NAMESPACES)
+
+
+def get_xpath_match_string(
+    node: etree._Element,
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
+    fallback: str = "",
+) -> str:
+    kwargs = {"namespaces": namespaces} if namespaces else {}
+    return str((node.xpath(path, **kwargs) or [fallback])[0])

--- a/src/caselawclient/responses/xsl/search_match.xsl
+++ b/src/caselawclient/responses/xsl/search_match.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:search="http://marklogic.com/appservices/search"
+                exclude-result-prefixes="search"
+                version="1.0">
+    <xsl:output method="html" omit-xml-declaration="yes"/>
+
+    <xsl:template match="/">
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <xsl:template match="search:result">
+        <xsl:apply-templates select="search:snippet"/>
+    </xsl:template>
+
+    <xsl:template match="search:snippet">
+        <xsl:apply-templates select="search:match"/>
+    </xsl:template>
+
+    <xsl:template match="search:match">
+        <p data-path="{@path}">
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+
+    <xsl:template match="search:highlight">
+        <mark>
+            <xsl:apply-templates/>
+        </mark>
+    </xsl:template>
+</xsl:stylesheet>

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -1,0 +1,70 @@
+import pytest
+from lxml import etree
+
+from caselawclient.responses.search_response import SearchResponse
+
+
+class TestSearchResponse:
+    def test_total(
+        self,
+        valid_search_result_xml,
+        generate_search_response_xml,
+    ):
+        """
+        Given a SearchResponse instance with n results
+        When calling 'results' on it
+        Then it should return a list of n SearchResult elements
+        And each element's node attribute should be as expected
+        """
+        search_response = SearchResponse.from_response_string(
+            '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501
+            "foo"
+            "</search:response>"
+        )
+
+        assert search_response.total == "5"
+
+    def test_results(
+        self,
+        valid_search_result_xml,
+        generate_search_response_xml,
+    ):
+        """
+        Given a SearchResponse instance with n results
+        When calling 'results' on it
+        Then it should return a list of n SearchResult elements
+        And each element's node attribute should be as expected
+        """
+        search_response = SearchResponse.from_response_string(
+            generate_search_response_xml(2 * valid_search_result_xml)
+        )
+
+        results = search_response.results
+
+        assert len(results) == 2
+        assert etree.tostring(results[0].node) == etree.tostring(
+            etree.fromstring(valid_search_result_xml)
+        )
+        assert etree.tostring(results[1].node) == etree.tostring(
+            etree.fromstring(valid_search_result_xml)
+        )
+
+    def test_when_search_namespace_prefix_not_defined_on_response_xml_syntax_error_raised(
+        self,
+    ):
+        """
+        Given an XML response without the 'search' namespace prefix defined
+        When creating SearchResponse instance with the XML
+        Then a XMLSyntaxError with the expected message should be raised
+        """
+        xml_without_namespace = (
+            '<search:response xmlns:foo="http://marklogic.com/appservices/search" total="2">'  # noqa: E501
+            "<search:result>Result 1</search:result>"
+            "<search:result>Result 2</search:result>"
+            "</search:response>"
+        )
+        with pytest.raises(
+            etree.XMLSyntaxError,
+            match="Namespace prefix search on response is not defined",
+        ):
+            SearchResponse.from_response_string(xml_without_namespace)

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -1,0 +1,227 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+from ds_caselaw_utils.courts import Court
+from lxml import etree
+
+from caselawclient.responses.search_result import (
+    EditorPriority,
+    EditorStatus,
+    SearchResult,
+    SearchResultMetadata,
+)
+
+
+class TestSearchResult:
+    @patch("caselawclient.responses.search_result.api_client")
+    def test_init(self, mock_api_client, valid_search_result_xml):
+        """
+        GIVEN a valid search result XML and a mock API client
+        WHEN initializing a SearchResult object
+        THEN the attributes are set correctly
+        """
+        mock_api_client.get_properties_for_search_results.return_value = "<foo/>"
+        mock_api_client.get_last_modified.return_value = "bar"
+
+        node = etree.fromstring(valid_search_result_xml)
+        search_result = SearchResult(node)
+
+        assert search_result.uri == "a/c/2015/20"
+        assert search_result.neutral_citation == "[2015] A 20 (C)"
+        assert search_result.name == "Another made up case name"
+        assert search_result.date == datetime.datetime(2017, 8, 8, 0, 0)
+        assert search_result.court is None
+        assert search_result.matches == (
+            "<p data-path=\"fn:doc('/a/c/2015/20.xml')/*:akomaNtoso\">"
+            "text from the document that matched the search</p>\n"
+        )
+        assert search_result.content_hash == "test_content_hash"
+        assert search_result.transformation_date == "2023-04-09T18:05:45"
+        assert etree.tostring(search_result.metadata.node).decode() == "<foo/>"
+        assert search_result.metadata.last_modified == "bar"
+
+    def test_create_from_node_with_unparsable_date(self):
+        """
+        GIVEN an XML node with an unparsable date
+        WHEN creating a SearchResult object from the node
+        THEN the date attribute is set to None
+        """
+        xml = (
+            '<search:result xmlns:search="http://marklogic.com/appservices/search" uri="/a/c/2015/20.xml">\n '
+            '<search:extracted kind="element">'
+            '<FRBRdate date="blah" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
+            "</search:extracted>"
+            "</search:result>"
+        )
+        node = etree.fromstring(xml)
+        search_result = SearchResult(node)
+
+        assert search_result.date is None
+
+    def test_create_from_node_with_valid_court_code(self):
+        """
+        GIVEN an XML node with a valid court code
+        WHEN creating a SearchResult object from the node
+        THEN the court attribute is set to the corresponding Court object
+        """
+        xml = (
+            '<search:result xmlns:search="http://marklogic.com/appservices/search" uri="/uksc/2015/20.xml">\n '
+            '<search:extracted kind="element">'
+            '<uk:court xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">UKSC</uk:court>'
+            "</search:extracted>"
+            "</search:result>"
+        )
+        node = etree.fromstring(xml)
+        search_result = SearchResult(node)
+
+        assert isinstance(search_result.court, Court)
+        assert search_result.court.name == "United Kingdom Supreme Court"
+
+    def test_create_from_node_with_invalid_court_code(self):
+        """
+        GIVEN an XML node with an invalid court code
+        WHEN creating a SearchResult object from the node
+        THEN the court attribute is set to None
+        """
+        xml = (
+            '<search:result xmlns:search="http://marklogic.com/appservices/search" index="2" uri="/a/c/2015/20.xml">\n '
+            '<search:extracted kind="element">'
+            '<uk:court xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">A-C</uk:court>'
+            "</search:extracted>"
+            "</search:result>"
+        )
+        node = etree.fromstring(xml)
+        search_result = SearchResult(node)
+
+        assert search_result.date is None
+
+
+class TestSearchResultMeta:
+    def test_init(self):
+        """
+        GIVEN an XML node and last_modified string data
+        WHEN SearchResultMetadata is initialized with them
+        THEN all properties are set correctly
+        """
+        node = etree.fromstring(
+            "<property-results>"
+            "<property-result>"
+            "<assigned-to>test_assigned_to</assigned-to>"
+            "<source-name>test_author</source-name>"
+            "<source-email>test_author_email</source-email>"
+            "<transfer-consignment-reference>test_consignment_reference</transfer-consignment-reference>"
+            "<editor-hold>false</editor-hold>"
+            "<editor-priority>30</editor-priority>"
+            "<transfer-received-at>2023-01-26T14:17:02Z</transfer-received-at>"
+            "</property-result>"
+            "</property-results>"
+        )
+        meta = SearchResultMetadata(node, last_modified="test_last_modified")
+
+        assert meta.assigned_to == "test_assigned_to"
+        assert meta.author == "test_author"
+        assert meta.author_email == "test_author_email"
+        assert meta.consignment_reference == "test_consignment_reference"
+        assert meta.editor_hold == "false"
+        assert meta.editor_priority == "30"
+        assert meta.submission_datetime == datetime.datetime(2023, 1, 26, 14, 17, 2)
+        assert meta.last_modified == "test_last_modified"
+
+    def test_empty_properties_init(self):
+        """
+        GIVEN an XML node without any properties and last_modified string data
+        WHEN SearchResultMetadata is initialized with them
+        THEN all properties are set correctly
+        """
+        node = etree.fromstring(
+            "<property-results>"
+            "<property-result>"
+            "</property-result>"
+            "</property-results>"
+        )
+        meta = SearchResultMetadata(node, last_modified="test_last_modified")
+
+        assert meta.assigned_to == ""
+        assert meta.author == ""
+        assert meta.author_email == ""
+        assert meta.consignment_reference == ""
+        assert meta.editor_hold == ""
+        assert meta.editor_priority == EditorPriority.MEDIUM.value
+        assert meta.submission_datetime == datetime.datetime.min
+        assert meta.last_modified == "test_last_modified"
+
+    @pytest.mark.parametrize(
+        "editor_hold, assigned_to, expected_editor_status",
+        [
+            ("false", "", EditorStatus.NEW),
+            ("false", "TestEditor", EditorStatus.IN_PROGRESS),
+            ("true", "", EditorStatus.HOLD),
+            ("true", "TestEditor", EditorStatus.HOLD),
+        ],
+    )
+    def test_editor_status(self, assigned_to, editor_hold, expected_editor_status):
+        """
+        GIVEN editor_hold and assigned_to values
+        WHEN creating a SearchResultMetadata instance
+        THEN the editor_status property returns the expected_editor_status
+        """
+        node = etree.fromstring(
+            "<property-results>"
+            "<property-result>"
+            f"<assigned-to>{assigned_to}</assigned-to>"
+            f"<editor-hold>{editor_hold}</editor-hold>"
+            "</property-result>"
+            "</property-results>"
+        )
+        meta = SearchResultMetadata(node, last_modified="foo")
+
+        assert meta.editor_status == expected_editor_status.value
+
+    @patch("caselawclient.responses.search_result.api_client")
+    def test_create_from_uri(self, mock_api_client):
+        """
+        GIVEN a uri and a mock API client
+        WHEN SearchResultMetadata.create_from_uri is called with the uri
+        THEN a SearchResultMetadata object is returned with expected attributes
+        """
+        mock_api_client.get_properties_for_search_results.return_value = (
+            "<property-results>"
+            "<property-result>"
+            "<assigned-to>test_assigned_to</assigned-to>"
+            "<source-name>test_author</source-name>"
+            "<source-email>test_author_email</source-email>"
+            "<transfer-consignment-reference>test_consignment_reference</transfer-consignment-reference>"
+            "<editor-hold>false</editor-hold>"
+            "<editor-priority>30</editor-priority>"
+            "<transfer-received-at>2023-01-26T14:17:02Z</transfer-received-at>"
+            "</property-result>"
+            "</property-results>"
+        )
+        mock_api_client.get_last_modified.return_value = "test_last_modified"
+
+        meta = SearchResultMetadata.create_from_uri("test_uri")
+
+        assert (
+            etree.tostring(meta.node).decode()
+            == mock_api_client.get_properties_for_search_results.return_value
+        )
+        assert meta.last_modified == "test_last_modified"
+
+    def test_submission_date_is_min_when_transfer_received_at_empty(self):
+        """
+        GIVEN a node where the `transfer-received-at` element is empty
+        WHEN SearchResultMetadata.create_from_uri is called with the uri
+        THEN a SearchResultMetadata object is returned with
+            submission_datetime equal to datetime.min
+        """
+        node = etree.fromstring(
+            "<property-results>"
+            "<property-result>"
+            "<transfer-received-at></transfer-received-at>"
+            "</property-result>"
+            "</property-results>"
+        )
+        meta = SearchResultMetadata(node, last_modified="foo")
+
+        assert meta.submission_datetime == datetime.datetime.min


### PR DESCRIPTION
NOTE: This is the updated version of https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/216 given the change in abstraction in https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/222/files

## Changes in this PR:
- Added `SearchResponse` and `SearchResult`, `SearchResultMetadata`. These come from shared code between PUI AND EUI.

Differences to pui and eui implementations:
- `SearchResponse` is a renamed version of `SearchResults`
- `SearchResultMetadata` was added - but was found only in editor ui (renamed from `SearchResultMeta`.) 
- As part of this, note that publicui currently has `author` in main `SearchResult` class and note that it also has `last_modified` whereas not included in `SearchResult` or `SearchResultMeta` in editor ui so added to `SearchResultMeta` here.
- Made `SearchResult` and `SearchResultMeta` dataclasses. moving any dataprocessing logic from init methods into the static factory methods.
- `SearchMatches` not using django-xml as the client isnt a django project - uses lxml directly.
- Added tests for all classes!

- Have updated the changelog!

## PUI and EUI versions for reference:

### PUI
- `SearchResult` and `SearchMatch`: https://github.com/nationalarchives/ds-caselaw-public-ui/blob/8b9b5aa1101adfae58d50f7cb3c74e3b4c9be9c0/judgments/models.py#L17

### EUI
- `SearchResult`, `SearchMatch` and `SearchResultMeta`: https://github.com/nationalarchives/ds-caselaw-editor-ui/blob/a736c373a793c70794563b861781dc8fcb029d31/judgments/models/__init__.py#L73

### Trello card:
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously