### PR TITLE
Modify q to query

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -437,7 +437,7 @@ class MarklogicApiClient:
         """
         Performs a search on the entire document set.
 
-        :param q:
+        :param query:
         :param court:
         :param judge:
         :param party:

--- a/src/caselawclient/search_parameters.py
+++ b/src/caselawclient/search_parameters.py
@@ -8,7 +8,7 @@ RESULTS_PER_PAGE = 10
 class SearchParameters:
     """Represents search parameters for a case law search."""
 
-    q: Optional[str] = None
+    query: Optional[str] = None
     court: Optional[str] = None
     judge: Optional[str] = None
     party: Optional[str] = None
@@ -33,7 +33,7 @@ class SearchParameters:
             "judge": str(self.judge or ""),
             "page": max(1, int(self.page)),
             "page-size": int(self.page_size),
-            "q": str(self.q or ""),
+            "q": str(self.query or ""),
             "party": str(self.party or ""),
             "neutral_citation": str(self.neutral_citation or ""),
             "specific_keyword": str(self.specific_keyword or ""),

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -62,7 +62,7 @@ class TestAdvancedSearch(unittest.TestCase):
         with patch.object(self.client, "invoke"):
             response = self.client.advanced_search(
                 SearchParameters(
-                    q="test query",
+                    query="test query",
                     court="court",
                     judge="judge",
                     party="party",
@@ -114,7 +114,7 @@ class TestAdvancedSearch(unittest.TestCase):
         with patch.object(self.client, "invoke"):
             self.client.invoke.side_effect = exception
             with pytest.raises(Exception) as e:
-                self.client.advanced_search(SearchParameters(q="test query"))
+                self.client.advanced_search(SearchParameters(query="test query"))
         assert e.value == exception
 
     def test_user_can_view_unpublished_but_show_unpublished_is_false(
@@ -132,7 +132,7 @@ class TestAdvancedSearch(unittest.TestCase):
             ):
                 self.client.advanced_search(
                     SearchParameters(
-                        q="my-query",
+                        query="my-query",
                         court="ewhc",
                         judge="a. judge",
                         party="a party",
@@ -178,7 +178,7 @@ class TestAdvancedSearch(unittest.TestCase):
             ):
                 self.client.advanced_search(
                     SearchParameters(
-                        q="my-query",
+                        query="my-query",
                         court="ewhc",
                         judge="a. judge",
                         party="a party",
@@ -207,7 +207,7 @@ class TestAdvancedSearch(unittest.TestCase):
                 with patch.object(logging, "warning") as mock_logging:
                     self.client.advanced_search(
                         SearchParameters(
-                            q="my-query",
+                            query="my-query",
                             court="ewhc",
                             judge="a. judge",
                             party="a party",

--- a/tests/client/test_search_and_decode_response.py
+++ b/tests/client/test_search_and_decode_response.py
@@ -26,7 +26,7 @@ def test_search_judgments_and_decode_response(
 
     search_response = api_client.search_judgments_and_decode_response(
         SearchParameters(
-            q="test query",
+            query="test query",
             court="test court",
             judge="test judge",
             party="test party",
@@ -41,7 +41,7 @@ def test_search_judgments_and_decode_response(
 
     mock_advanced_search.assert_called_once_with(
         SearchParameters(
-            q="test query",
+            query="test query",
             court="test court",
             judge="test judge",
             party="test party",

--- a/tests/client/test_search_parameters.py
+++ b/tests/client/test_search_parameters.py
@@ -35,7 +35,7 @@ class TestSearchParametersToMarklogicData:
         THEN it should return a dictionary with the specified parameter values
         """
         search_parameters = SearchParameters(
-            q="test query",
+            query="test query",
             court="test court",
             judge="test judge",
             party="test party",


### PR DESCRIPTION
## Changes in this PR:
-Renamed q to query in SearchParameters

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously
