### PR TITLE
Add search client helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Changed `Client.advanced_search` interface to take in `SearchParameters` as opposed to the legacy kwargs.
 - Added `search_and_decode_response` and `search_judgments_and_decode_response` methods to `Client`
 - Added `SearchResponse`, `SearchResult`, `SearchResultMetadata` classes to encapsulate and process document search responses.
+- Added `search_helpers` module allow clients to search and process document search responses in one go.
 
 ## [Release 7.0.0]
 - **BREAKING**: Instantiating a`Judgment` object will now raise a `caselawclient.errors.JudgmentNotFoundError` if the uri passed in does not correspond to a valid Judgment, rather than attempting (and failing) to return a `MarklogicResourceNotFoundError`

--- a/src/caselawclient/client_helpers/search_helpers.py
+++ b/src/caselawclient/client_helpers/search_helpers.py
@@ -1,0 +1,39 @@
+from caselawclient.Client import MarklogicApiClient
+from caselawclient.responses.search_response import SearchResponse
+from caselawclient.search_parameters import SearchParameters
+
+
+def search_judgments_and_parse_response(
+    api_client: MarklogicApiClient, search_parameters: SearchParameters
+) -> SearchResponse:
+    """
+    Search for judgments using the given search parameters and parse the response into a SearchResponse object.
+
+    Args:
+        api_client (MarklogicApiClient): An instance of MarklogicApiClient used to make the search request.
+        search_parameters (SearchParameters): An instance of SearchParameters containing the search parameters.
+
+    Returns:
+        SearchResponse: The parsed search response as a SearchResponse object.
+    """
+    return SearchResponse.from_response_string(
+        api_client.search_judgments_and_decode_response(search_parameters)
+    )
+
+
+def search_and_parse_response(
+    api_client: MarklogicApiClient, search_parameters: SearchParameters
+) -> SearchResponse:
+    """
+    Search using the given search parameters and parse the response into a SearchResponse object.
+
+    Args:
+        api_client (MarklogicApiClient): An instance of MarklogicApiClient used to make the search request.
+        search_parameters (SearchParameters): An instance of SearchParameters containing the search parameters.
+
+    Returns:
+        SearchResponse: The parsed search response as a SearchResponse object.
+    """
+    return SearchResponse.from_response_string(
+        api_client.search_and_decode_response(search_parameters)
+    )

--- a/tests/client_helpers/test_search_helpers.py
+++ b/tests/client_helpers/test_search_helpers.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+
+from lxml import etree
+
+from caselawclient.client_helpers.search_helpers import (
+    search_judgments_and_parse_response,
+)
+from caselawclient.search_parameters import SearchParameters
+
+
+def test_search_judgments_and_parse_results(
+    generate_search_response_xml, valid_search_result_xml
+):
+    """
+    Given the search parameters for search_judgments_and_parse_response are valid
+    And a mocked api_client.search_judgments_and_decode_response return mocked with a
+        xml string
+    When search_judgments_and_parse_response function is called with the mocked API client
+        and input parameters
+    Then the API client's search_judgments_and_decode_response method should be called once with the
+        same parameters
+    And the search_judgments_and_parse_response function should return an instance of
+        SearchResponse with a node made up of the same xml string
+    """
+    mock_api_client = Mock()
+    search_response_xml = generate_search_response_xml(2 * valid_search_result_xml)
+    mock_api_client.search_judgments_and_decode_response.return_value = (
+        search_response_xml
+    )
+
+    search_parameters = SearchParameters(
+        query="test query",
+        court="test court",
+        judge="test judge",
+        party="test party",
+        neutral_citation="test citation",
+        specific_keyword="test keyword",
+        date_from="2022-01-01",
+        date_to="2022-01-31",
+        page=1,
+        page_size=10,
+    )
+
+    search_response = search_judgments_and_parse_response(
+        mock_api_client, search_parameters
+    )
+
+    mock_api_client.search_judgments_and_decode_response.assert_called_once_with(
+        search_parameters
+    )
+
+    assert etree.tostring(search_response.node) == etree.tostring(
+        etree.fromstring(search_response_xml)
+    )

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -7,14 +7,11 @@ from caselawclient.responses.search_response import SearchResponse
 class TestSearchResponse:
     def test_total(
         self,
-        valid_search_result_xml,
-        generate_search_response_xml,
     ):
         """
-        Given a SearchResponse instance with n results
-        When calling 'results' on it
-        Then it should return a list of n SearchResult elements
-        And each element's node attribute should be as expected
+        Given a SearchResponse instance
+        When calling 'total' on it
+        Then it should return a string representing the total number of results
         """
         search_response = SearchResponse.from_response_string(
             '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501


### PR DESCRIPTION
## Changes in this PR:
- Added `search_judgments_and_parse_response` and `search_and_parse_response` in a `search_helpers` module to abstract away the search and parse away from clients (PUI and EUI) without bloating the main client itself as the main client generally just returns the xml string response.

## Trello card / Rollbar error (etc)
- https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously
