### PR TITLE
Rename press_summary to press-summary and set default permissions

### DIFF
--- a/src/caselawclient/xquery/insert_document.xqy
+++ b/src/caselawclient/xquery/insert_document.xqy
@@ -8,8 +8,8 @@ declare variable $document as xs:string external;
 let $document_xml := xdmp:unquote($document)
 
 let $collections :=
-  if (fn:contains($uri, 'press_summary'))
-  then ("press_summary")
+  if (fn:contains($uri, 'press-summary'))
+  then ("press-summary")
   else ("judgment")
 
 return dls:document-insert-and-manage($uri, fn:true(), $document_xml, (), (), $collections)


### PR DESCRIPTION
## Changes in this PR:
Verified on slack that we had decided to have `press-summary` in the uri not `press_summary` so updated that pattern match. 
Also made the collection name consistent with that format

https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously