### PR TITLE
Introduce new Judgment.validation_failure_messages method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## [Unreleased]
+
+- `Judgment.validation_failure_messages` method for retrieving a list of strings with reasons a judgment cannot be published.
+
 ## [Release 10.0.1]
 - Fixed `insert_document_xml` to pattern match uris with and add documents to `press-summary`, not `press_summary`.
 

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -171,18 +171,53 @@ class Judgment:
 
         return True
 
+    # attribute name, value which passes validation, error message
+    VALIDATION_ATTRIBUTES: list[tuple[str, bool, str]] = [
+        (
+            "is_failure",
+            False,
+            "This judgment has failed to parse",
+        ),
+        (
+            "is_held",
+            False,
+            "This judgment is currently on hold",
+        ),
+        (
+            "has_name",
+            True,
+            "This judgment has no name",
+        ),
+        (
+            "has_ncn",
+            True,
+            "This judgment has no neutral citation number",
+        ),
+        (
+            "has_valid_ncn",
+            True,
+            "The neutral citation number of this judgment is not valid",
+        ),
+        (
+            "has_court",
+            True,
+            "This judgment has no court",
+        ),
+    ]
+
     @cached_property
     def is_publishable(self) -> bool:
-        if (
-            self.is_held
-            or not self.has_name
-            or not self.has_ncn
-            or not self.has_valid_ncn
-            or not self.has_court
-        ):
-            return False
+        # If there are any validation failures, there will be no messages in the list.
+        # An empty list (which is falsy) therefore means the judgment can be published safely.
+        return not self.validation_failure_messages
 
-        return True
+    @cached_property
+    def validation_failure_messages(self) -> list[str]:
+        exception_list = []
+        for function_name, pass_value, message in self.VALIDATION_ATTRIBUTES:
+            if getattr(self, function_name) != pass_value:
+                exception_list.append(message)
+        return sorted(exception_list)
 
     @property
     def status(self) -> str:


### PR DESCRIPTION
This method returns a list of reasons why the judgment has failed validation and is not publishable, by iterating over a list of attributes of a judgment which must 'pass' in order for it to be considered publishable and appending their error message if they fail. This also means we can refactor `is_publishable` to lean on the same list of attributes to test, which reduces function complexity.

Take this opportunity to tidy up the organisation of tests, and to also make parser failure a publish-blocking condition.