### PR TITLE
Add detection of 'parked' URIs

### DIFF
--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -134,6 +134,12 @@ class Judgment:
         return False
 
     @cached_property
+    def is_parked(self) -> bool:
+        if "parked" in self.uri:
+            return True
+        return False
+
+    @cached_property
     def is_editable(self) -> bool:
         if "error" in self._get_root():
             return False
@@ -177,6 +183,11 @@ class Judgment:
             "is_failure",
             False,
             "This judgment has failed to parse",
+        ),
+        (
+            "is_parked",
+            False,
+            "This judgment is currently parked at a temporary URI",
         ),
         (
             "is_held",


### PR DESCRIPTION
Where the ingester detects that it cannot assign a URI to a document (for example, the document is claiming to have the same URI as an existing document and it needs manual version reconciliation) then it will assign a URI in the format `parked/{uuid}`.

This PR adds detection of those parked URIs to the API client; parked URIs cannot be published.