### PR TITLE
Trim whitespace when trying to set an NCN

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -271,7 +271,10 @@ class MarklogicApiClient:
         self, judgment_uri: str, content: str
     ) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)
-        vars: query_dicts.SetMetadataCitationDict = {"uri": uri, "content": content}
+        vars: query_dicts.SetMetadataCitationDict = {
+            "uri": uri,
+            "content": content.strip(),
+        }
 
         return self._send_to_eval(vars, "set_metadata_citation.xqy")
 

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -55,6 +55,18 @@ class TestGetSetMetadata(unittest.TestCase):
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
+    def test_set_judgment_citation_whitespace_stripping(self):
+        with patch.object(self.client, "eval") as mock_eval:
+            uri = "judgment/uri"
+            content = "  [2033] UKSC 1234  "
+            expected_vars = {"uri": "/judgment/uri.xml", "content": "[2033] UKSC 1234"}
+            self.client.set_judgment_citation(uri, content)
+
+            assert mock_eval.call_args.args[0] == (
+                os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
+            )
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+
     @patch("caselawclient.Client.decode_multipart")
     def test_get_judgment_court(self, decode):
         with patch.object(self.client, "eval") as mock_eval:


### PR DESCRIPTION
When setting a judgement's neutral citation, make sure we're not also including leading/trailing whitespace.