### PR TITLE
Switch Renovate to use the new global FCL config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    ":approveMajorUpdates",
-    ":automergeLinters",
-    ":automergePatch",
-    ":automergePr",
-    ":automergeRequireAllStatusChecks",
-    ":automergeTesters",
-    ":dependencyDashboard",
-    ":enablePreCommit",
-    ":maintainLockFilesWeekly"
-  ],
-  "platformAutomerge": true,
-  "minimumReleaseAge": "2 days",
-  "packageRules": [
-    {
-      "matchDatasources": ["npm"],
-      "minimumReleaseAge": "3 days"
-    }
-  ]
+  "extends": ["github>nationalarchives/ds-find-caselaw-docs"]
 }


### PR DESCRIPTION
Once https://github.com/nationalarchives/ds-find-caselaw-docs/pull/139 is merged, use that config instead of a repo-specific one.