### PR TITLE
Refactor Document class to reduce calls to marklogic for the metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- Refactored `Document` class' `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously judgment_date_...) on Document class and neutral_citation on Judgment class making use of the new cached `content_as_xml_tree` property.
+- Renamed `judgment_date_as_string` `judgment_date_as_date` to `document_date_as_string` and `document_date_as_date` respectively.
+- Added `content_as_xml_tree` cached property to `Document` class
+- Changed the `Document` class' `content_as_html` to be a cached_property also.
+- Removed `get_judgment_name`, `get_judgment_citation`, `get_judgment_court`, `get_judgment_work_date` from the `Client` class and associated `.xqy` files.
 - Add a new `MarklogicApiClient.get_document_by_uri` method to retrieve a document (of any type) by URI.
 
 ## [Release 12.0.0]

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -243,11 +243,6 @@ class MarklogicApiClient:
 
         return self._eval_and_decode(vars, "get_judgment.xqy")
 
-    def get_judgment_name(self, judgment_uri: str) -> str:
-        uri = self._format_uri_for_marklogic(judgment_uri)
-        vars: query_dicts.GetMetadataNameDict = {"uri": uri}
-        return self._eval_and_decode(vars, "get_metadata_name.xqy")
-
     def set_judgment_name(self, judgment_uri: str, content: str) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.SetMetadataNameDict = {"uri": uri, "content": content}
@@ -686,25 +681,6 @@ class MarklogicApiClient:
             )
             return False
         return show_unpublished
-
-    def get_judgment_citation(self, judgment_uri: str) -> str:
-        uri = self._format_uri_for_marklogic(judgment_uri)
-        vars: query_dicts.GetMetadataCitationDict = {"uri": uri}
-
-        response = self._send_to_eval(vars, "get_metadata_citation.xqy")
-        return decode_multipart(response)
-
-    def get_judgment_court(self, judgment_uri: str) -> str:
-        uri = self._format_uri_for_marklogic(judgment_uri)
-        vars: query_dicts.GetMetadataCourtDict = {"uri": uri}
-        response = self._send_to_eval(vars, "get_metadata_court.xqy")
-        return decode_multipart(response)
-
-    def get_judgment_work_date(self, judgment_uri: str) -> str:
-        uri = self._format_uri_for_marklogic(judgment_uri)
-        vars: query_dicts.GetMetadataWorkDateDict = {"uri": uri}
-        response = self._send_to_eval(vars, "get_metadata_work_date.xqy")
-        return decode_multipart(response)
 
     def get_properties_for_search_results(self, judgment_uris: list[str]) -> str:
         uris = [

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -4,6 +4,7 @@ from typing import Any
 from ds_caselaw_utils import neutral_url
 
 from caselawclient.models.documents import Document
+from caselawclient.xml_helpers import get_xpath_match_string
 
 
 class Judgment(Document):
@@ -28,7 +29,14 @@ class Judgment(Document):
 
     @cached_property
     def neutral_citation(self) -> str:
-        return self.api_client.get_judgment_citation(self.uri)
+        return get_xpath_match_string(
+            self.content_as_xml_tree,
+            "/root/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite/text()",
+            {
+                "uk": "https://caselaw.nationalarchives.gov.uk/akn",
+                "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+            },
+        )
 
     @cached_property
     def has_ncn(self) -> bool:

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -10,6 +10,7 @@ from ds_caselaw_utils.courts import Court, CourtNotFoundException, courts
 from lxml import etree
 
 from caselawclient.Client import api_client
+from caselawclient.xml_helpers import get_xpath_match_string
 
 
 class EditorStatus(Enum):
@@ -212,13 +213,3 @@ class SearchResult:
 
     def _get_xpath_match_string(self, path: str) -> str:
         return get_xpath_match_string(self.node, path, namespaces=self.NAMESPACES)
-
-
-def get_xpath_match_string(
-    node: etree._Element,
-    path: str,
-    namespaces: Optional[Dict[str, str]] = None,
-    fallback: str = "",
-) -> str:
-    kwargs = {"namespaces": namespaces} if namespaces else {}
-    return str((node.xpath(path, **kwargs) or [fallback])[0])

--- a/src/caselawclient/xml_helpers.py
+++ b/src/caselawclient/xml_helpers.py
@@ -1,0 +1,13 @@
+from typing import Dict, Optional
+
+from lxml import etree
+
+
+def get_xpath_match_string(
+    node: etree._Element,
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
+    fallback: str = "",
+) -> str:
+    kwargs = {"namespaces": namespaces} if namespaces else {}
+    return str((node.xpath(path, **kwargs) or [fallback])[0])

--- a/src/caselawclient/xml_tools.py
+++ b/src/caselawclient/xml_tools.py
@@ -112,15 +112,15 @@ def get_search_matches(element: ElementTree) -> List[str]:
     return results
 
 
-def get_error_code(xml_content: Optional[str]) -> str:
+def get_error_code(content_as_xml: Optional[str]) -> str:
     logging.warning(
         "XMLTools is deprecated and will be removed in later versions. "
         "Use methods from MarklogicApiClient.Client instead."
     )
-    if not xml_content:
+    if not content_as_xml:
         return "Unknown error, Marklogic returned a null or empty response"
     try:
-        xml = fromstring(xml_content)
+        xml = fromstring(content_as_xml)
         return xml.find(
             "message-code", namespaces={"": "http://marklogic.com/xdmp/error"}
         ).text  # type: ignore

--- a/src/caselawclient/xquery/get_metadata_citation.xqy
+++ b/src/caselawclient/xquery/get_metadata_citation.xqy
@@ -1,9 +1,0 @@
-xquery version "1.0-ml";
-
-declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
-declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
-declare variable $uri as xs:string external;
-
-let $judgment := fn:document($uri)
-
-return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite/text()

--- a/src/caselawclient/xquery/get_metadata_court.xqy
+++ b/src/caselawclient/xquery/get_metadata_court.xqy
@@ -1,9 +1,0 @@
-xquery version "1.0-ml";
-
-declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
-declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
-declare variable $uri as xs:string external;
-
-let $judgment := fn:document($uri)
-
-return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court/text()

--- a/src/caselawclient/xquery/get_metadata_name.xqy
+++ b/src/caselawclient/xquery/get_metadata_name.xqy
@@ -1,8 +1,0 @@
-xquery version "1.0-ml";
-
-declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
-declare variable $uri as xs:string external;
-
-let $judgment := fn:document($uri)
-
-return $judgment//akn:FRBRname/@value

--- a/src/caselawclient/xquery/get_metadata_work_date.xqy
+++ b/src/caselawclient/xquery/get_metadata_work_date.xqy
@@ -1,9 +1,0 @@
-xquery version "1.0-ml";
-
-declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
-declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
-declare variable $uri as xs:string external;
-
-let $judgment := fn:document($uri)
-
-return $judgment/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -64,26 +64,6 @@ class GetLastModifiedDict(MarkLogicAPIDict):
     uri: str
 
 
-# get_metadata_citation.xqy
-class GetMetadataCitationDict(MarkLogicAPIDict):
-    uri: str
-
-
-# get_metadata_court.xqy
-class GetMetadataCourtDict(MarkLogicAPIDict):
-    uri: str
-
-
-# get_metadata_name.xqy
-class GetMetadataNameDict(MarkLogicAPIDict):
-    uri: str
-
-
-# get_metadata_work_date.xqy
-class GetMetadataWorkDateDict(MarkLogicAPIDict):
-    uri: str
-
-
 # get_properties_for_search_results.xqy
 class GetPropertiesForSearchResultsDict(MarkLogicAPIDict):
     uris: list[Any]

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -24,21 +24,6 @@ def test_get_properties_for_search_results(send, decode):
     assert send.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
 
-@patch("caselawclient.Client.decode_multipart")
-@patch("caselawclient.Client.MarklogicApiClient.eval")
-def test_get_judgment_citation(send, decode):
-    uri = "judgment/uri"
-    expected_vars = {"uri": "/judgment/uri.xml"}
-    decode.return_value = "ewca/fam/1"  # The decoder is called
-    retval = MarklogicApiClient("", "", "", False).get_judgment_citation(uri)
-    assert retval == "ewca/fam/1"
-
-    assert send.call_args.args[0] == (
-        os.path.join(ROOT_DIR, "xquery", "get_metadata_citation.xqy")
-    )
-    assert send.call_args.kwargs["vars"] == json.dumps(expected_vars)
-
-
 class TestGetSetMetadata(unittest.TestCase):
     def setUp(self):
         self.client = MarklogicApiClient("", "", "", False)
@@ -67,20 +52,6 @@ class TestGetSetMetadata(unittest.TestCase):
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
-    @patch("caselawclient.Client.decode_multipart")
-    def test_get_judgment_court(self, decode):
-        with patch.object(self.client, "eval") as mock_eval:
-            decode.return_value = "EWCA-Fam"
-            uri = "judgment/uri"
-            expected_vars = {"uri": "/judgment/uri.xml"}
-            retval = self.client.get_judgment_court(uri)
-            assert retval == "EWCA-Fam"
-
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "get_metadata_court.xqy")
-            )
-            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
-
     def test_set_judgment_court(self):
         with patch.object(self.client, "eval") as mock_eval:
             uri = "judgment/uri"
@@ -90,20 +61,6 @@ class TestGetSetMetadata(unittest.TestCase):
 
             assert mock_eval.call_args.args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
-            )
-            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
-
-    @patch("caselawclient.Client.decode_multipart")
-    def test_get_judgment_date(self, decode):
-        with patch.object(self.client, "eval") as mock_eval:
-            decode.return_value = "2022-01-01"
-            uri = "judgment/uri"
-            expected_vars = {"uri": "/judgment/uri.xml"}
-            retval = self.client.get_judgment_work_date(uri)
-            assert retval == "2022-01-01"
-
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "get_metadata_work_date.xqy")
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -23,12 +23,27 @@ class TestJudgmentValidation:
         assert document_without_ncn.has_ncn is False
 
     def test_judgment_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_citation.return_value = "[2023] TEST 1234"
+        mock_api_client.get_judgment_xml.return_value = """
+            <root xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <akn:akomaNtoso>
+                    <akn:judgment>
+                        <akn:meta>
+                            <akn:proprietary>
+                                <uk:cite>[2023] TEST 1234</uk:cite>
+                            </akn:proprietary>
+                        </akn:meta>
+                    </akn:judgment>
+                </akn:akomaNtoso>
+            </root>
+        """
 
         judgment = Judgment("test/1234", mock_api_client)
 
         assert judgment.neutral_citation == "[2023] TEST 1234"
-        mock_api_client.get_judgment_citation.assert_called_once_with("test/1234")
+        mock_api_client.get_judgment_xml.assert_called_once_with(
+            "test/1234", show_unpublished=True
+        )
 
     @pytest.mark.parametrize(
         "ncn_to_test, valid",


### PR DESCRIPTION
## Changes in this PR:
- Refactor Document class to reduce calls to marklogic for the metadata
-  In particular updated `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously `judgment_date_...`) on Document class and `neutral_citation` on Judgment class.
- Added `xml_etree` cached property to Document class and adjusted content_as_html to be a cached_property also.
- Removed `get_judgment_name, get_judgment_citation, get_judgment_court, get_judgment_work_date` from the Client class and associated `.xqy` files.

## Trello card / Rollbar error (etc)
https://trello.com/c/gEGuXxmq/1156-api-client-refactor-the-apiclient-document-class-to-store-xml-rather-than-querying-the-db-for-each-metadata
