### PR TITLE
v12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## [Unreleased]
+## [Release 12.1.0]
 
 - Refactored `Document` class' `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously judgment_date_...) on Document class and neutral_citation on Judgment class making use of the new cached `content_as_xml_tree` property.
 - Renamed `judgment_date_as_string` `judgment_date_as_date` to `document_date_as_string` and `document_date_as_date` respectively.
@@ -250,7 +250,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Release 1.0.5]
 - Initial tagged release
 
-[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v12.0.0...HEAD
+[Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v12.1.0...HEAD
+[Release 12.1.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v12.0.0...v12.1.0
 [Release 12.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v11.0.1...v12.0.0
 [Release 11.0.1]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v11.0.0...v11.0.1
 [Release 11.0.0]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v10.1.0...v11.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "12.0.0"
+version = "12.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION

- Refactored `Document` class' `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously judgment_date_...) on Document class and neutral_citation on Judgment class making use of the new cached `content_as_xml_tree` property.
- Renamed `judgment_date_as_string` `judgment_date_as_date` to `document_date_as_string` and `document_date_as_date` respectively.
- Added `content_as_xml_tree` cached property to `Document` class
- Changed the `Document` class' `content_as_html` to be a cached_property also.
- Removed `get_judgment_name`, `get_judgment_citation`, `get_judgment_court`, `get_judgment_work_date` from the `Client` class and associated `.xqy` files.
- Add a new `MarklogicApiClient.get_document_by_uri` method to retrieve a document (of any type) by URI.