### PR TITLE
💔 [BREAKING CHANGE] Remove supplemental/anonymous/sensitive getters/setters 

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -559,32 +559,8 @@ class MarklogicApiClient:
     ) -> requests.Response:
         return self.set_boolean_property(judgment_uri, "published", published)
 
-    def set_sensitive(
-        self, judgment_uri: str, sensitive: bool = False
-    ) -> requests.Response:
-        return self.set_boolean_property(judgment_uri, "sensitive", sensitive)
-
-    def set_supplemental(
-        self, judgment_uri: str, supplemental: bool = False
-    ) -> requests.Response:
-        return self.set_boolean_property(judgment_uri, "supplemental", supplemental)
-
-    def set_anonymised(
-        self, judgment_uri: str, anonymised: bool = False
-    ) -> requests.Response:
-        return self.set_boolean_property(judgment_uri, "anonymised", anonymised)
-
     def get_published(self, judgment_uri: str) -> bool:
         return self.get_boolean_property(judgment_uri, "published")
-
-    def get_sensitive(self, judgment_uri: str) -> bool:
-        return self.get_boolean_property(judgment_uri, "sensitive")
-
-    def get_supplemental(self, judgment_uri: str) -> bool:
-        return self.get_boolean_property(judgment_uri, "supplemental")
-
-    def get_anonymised(self, judgment_uri: str) -> bool:
-        return self.get_boolean_property(judgment_uri, "anonymised")
 
     def get_last_modified(self, judgment_uri: str) -> str:
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -120,18 +120,6 @@ class Document:
         return self.api_client.get_property(self.uri, "editor-hold") == "true"
 
     @cached_property
-    def is_sensitive(self) -> bool:
-        return self.api_client.get_sensitive(self.uri)
-
-    @cached_property
-    def is_anonymised(self) -> bool:
-        return self.api_client.get_anonymised(self.uri)
-
-    @cached_property
-    def has_supplementary_materials(self) -> bool:
-        return self.api_client.get_supplemental(self.uri)
-
-    @cached_property
     def source_name(self) -> str:
         return self.api_client.get_property(self.uri, "source-name")
 

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -116,30 +116,6 @@ class TestDocument:
         assert document.is_held is False
         mock_api_client.get_property.assert_called_once_with("test/1234", "editor-hold")
 
-    def test_judgment_is_sensitive(self, mock_api_client):
-        mock_api_client.get_sensitive.return_value = True
-
-        document = Document("test/1234", mock_api_client)
-
-        assert document.is_sensitive is True
-        mock_api_client.get_sensitive.assert_called_once_with("test/1234")
-
-    def test_judgment_is_anonymised(self, mock_api_client):
-        mock_api_client.get_anonymised.return_value = True
-
-        document = Document("test/1234", mock_api_client)
-
-        assert document.is_anonymised is True
-        mock_api_client.get_anonymised.assert_called_once_with("test/1234")
-
-    def test_judgment_has_supplementary_materials(self, mock_api_client):
-        mock_api_client.get_supplemental.return_value = True
-
-        document = Document("test/1234", mock_api_client)
-
-        assert document.has_supplementary_materials is True
-        mock_api_client.get_supplemental.assert_called_once_with("test/1234")
-
     def test_judgment_source_name(self, mock_api_client):
         mock_api_client.get_property.return_value = "Test Name"
 


### PR DESCRIPTION
* Marklogic config doesn't touch these things -- getter/setter was generic boolean fields
* Ingester doesn't know about these things and does not explicitly set/reset them.
* Editor has already been tweaked to not get/set these things.

This is a BREAKING CHANGE to the API, and should be a major version when released.

https://trello.com/c/o2sNyDZ2/1170-remove-deprecated-sensitive-supplemental-anonymised-method-calls-from-api-and-marklogic