### PR TITLE
💔 [BREAKING] Better MarkLogic multipart response handling

### DIFF
--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -49,7 +49,7 @@ class TestMarklogicResponseHandlers(unittest.TestCase):
     def test_get_multipart_strings_from_marklogic_response_if_no_content(self):
         response = MagicMock(requests.Response)
         response.content = None
-        assert get_multipart_strings_from_marklogic_response(response) == [""]
+        assert get_multipart_strings_from_marklogic_response(response) == []
 
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_single_string_from_marklogic_response(
@@ -59,6 +59,16 @@ class TestMarklogicResponseHandlers(unittest.TestCase):
         assert (
             get_single_string_from_marklogic_response(MagicMock(requests.Response))
             == "test string"
+        )
+
+    @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
+    def test_get_single_string_from_marklogic_response_if_empty_set(
+        self, mock_multipart_strings_handler
+    ):
+        mock_multipart_strings_handler.return_value = []
+        assert (
+            get_single_string_from_marklogic_response(MagicMock(requests.Response))
+            == ""
         )
 
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,11 +1,17 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 import responses
 
-from caselawclient.Client import MarklogicApiClient
+from caselawclient.Client import (
+    MarklogicApiClient,
+    MultipartResponseLongerThanExpected,
+    get_multipart_strings_from_marklogic_response,
+    get_single_string_from_marklogic_response,
+)
 from caselawclient.errors import GatewayTimeoutError
 
 
@@ -25,6 +31,46 @@ class TestErrors(unittest.TestCase):
         with pytest.raises(GatewayTimeoutError) as gateway_exception:
             self.client._raise_for_status(response)
         assert "Example Gateway Timeout" in str(gateway_exception.value)
+
+
+class TestMarklogicResponseHandlers(unittest.TestCase):
+    @patch("caselawclient.Client.decoder.MultipartDecoder.from_response")
+    def test_get_multipart_strings_from_marklogic_response(
+        self, mock_multipart_decoder
+    ):
+        mock_multipart_decoder.return_value.parts = (
+            SimpleNamespace(text="string 1"),
+            SimpleNamespace(text="string 2"),
+        )
+        assert get_multipart_strings_from_marklogic_response(
+            MagicMock(requests.Response)
+        ) == ["string 1", "string 2"]
+
+    def test_get_multipart_strings_from_marklogic_response_if_no_content(self):
+        response = MagicMock(requests.Response)
+        response.content = None
+        assert get_multipart_strings_from_marklogic_response(response) == [""]
+
+    @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
+    def test_get_single_string_from_marklogic_response(
+        self, mock_multipart_strings_handler
+    ):
+        mock_multipart_strings_handler.return_value = ["test string"]
+        assert (
+            get_single_string_from_marklogic_response(MagicMock(requests.Response))
+            == "test string"
+        )
+
+    @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
+    def test_get_single_string_from_marklogic_response_if_multiple_strings(
+        self, mock_multipart_strings_handler
+    ):
+        mock_multipart_strings_handler.return_value = [
+            "test string",
+            "too many strings",
+        ]
+        with pytest.raises(MultipartResponseLongerThanExpected):
+            get_single_string_from_marklogic_response(MagicMock(requests.Response))
 
 
 class ApiClientTest(unittest.TestCase):

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 
 
-@patch("caselawclient.Client.decode_multipart")
+@patch("caselawclient.Client.get_single_string_from_marklogic_response")
 @patch("caselawclient.Client.MarklogicApiClient.eval")
 def test_get_properties_for_search_results(send, decode):
     uris = ["judgment/uri"]


### PR DESCRIPTION
This entire client class currently assumes that there is exactly one item coming from MarkLogic in a multipart response, or failing that the only useful part of the response is the first item. This is currently true, but will not necessarily be in the future (and is prone to flakiness in any case).

This moves handling of the multipart response and turning it into text into a distinct function which can be used in future to retrieve a list of results, and simplifies the existing `decode_multipart` function to return only the first result, or fail with a hard exception (because it would mean whatever is calling the method is expecting a single result in a context where multiple results have been returned).

This is potentially a **breaking change** since unexpected multiple returns now raise an exception.