### PR TITLE
We don't have an element named root before akomaNtoso

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -83,14 +83,14 @@ class Document:
     @cached_property
     def name(self) -> str:
         return self._get_xpath_match_string(
-            "//akn:FRBRname/@value",
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname/@value",
             {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"},
         )
 
     @cached_property
     def court(self) -> str:
         return self._get_xpath_match_string(
-            "/root/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court/text()",
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:court/text()",
             {
                 "uk": "https://caselaw.nationalarchives.gov.uk/akn",
                 "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
@@ -100,7 +100,7 @@ class Document:
     @cached_property
     def document_date_as_string(self) -> str:
         return self._get_xpath_match_string(
-            "/root/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date",
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date",
             {
                 "uk": "https://caselaw.nationalarchives.gov.uk/akn",
                 "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -31,7 +31,7 @@ class Judgment(Document):
     def neutral_citation(self) -> str:
         return get_xpath_match_string(
             self.content_as_xml_tree,
-            "/root/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:cite/text()",
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:cite/text()",
             {
                 "uk": "https://caselaw.nationalarchives.gov.uk/akn",
                 "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -39,9 +39,14 @@ class TestDocument:
 
     def test_judgment_name(self, mock_api_client):
         mock_api_client.get_judgment_xml.return_value = """
-            <root xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <akn:FRBRname value="Test Claimant v Test Defendant"/>
-            </root>
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                        xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <meta><identification><FRBRWork>
+                            <FRBRname value="Test Claimant v Test Defendant"/>
+                    </FRBRWork></identification></meta>
+                </judgment>
+            </akomaNtoso>
         """
 
         document = Document("test/1234", mock_api_client)
@@ -53,9 +58,8 @@ class TestDocument:
 
     def test_judgment_court(self, mock_api_client):
         mock_api_client.get_judgment_xml.return_value = """
-            <root xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                <akn:akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
                 xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <akn:akomaNtoso>
                     <akn:judgment>
                         <akn:meta>
                             <akn:proprietary>
@@ -64,7 +68,6 @@ class TestDocument:
                         </akn:meta>
                     </akn:judgment>
                 </akn:akomaNtoso>
-            </root>
         """
 
         document = Document("test/1234", mock_api_client)
@@ -76,9 +79,9 @@ class TestDocument:
 
     def test_judgment_date_as_string(self, mock_api_client):
         mock_api_client.get_judgment_xml.return_value = """
-            <root xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+
+            <akn:akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
                 xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <akn:akomaNtoso>
                     <akn:judgment>
                         <akn:meta>
                             <akn:identification>
@@ -89,7 +92,6 @@ class TestDocument:
                         </akn:meta>
                     </akn:judgment>
                 </akn:akomaNtoso>
-            </root>
         """
 
         document = Document("test/1234", mock_api_client)
@@ -261,9 +263,12 @@ class TestDocumentValidation:
 
     def test_document_validation_failure_messages_if_no_messages(self, mock_api_client):
         mock_api_client.get_judgment_xml.return_value = """
-            <root xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <akn:FRBRname value="Test Claimant v Test Defendant"/>
-            </root>
+            <akomaNtoso xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                        xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment><meta><identification><FRBRWork>
+                <FRBRname value="Test Claimant v Test Defendant"/>
+                </FRBRWork></identification></meta></judgment>
+            </akomaNtoso>
         """
 
         document = Document("test/1234", mock_api_client)

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -24,18 +24,16 @@ class TestJudgmentValidation:
 
     def test_judgment_neutral_citation(self, mock_api_client):
         mock_api_client.get_judgment_xml.return_value = """
-            <root xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
-                xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <akn:akomaNtoso>
-                    <akn:judgment>
-                        <akn:meta>
-                            <akn:proprietary>
-                                <uk:cite>[2023] TEST 1234</uk:cite>
-                            </akn:proprietary>
-                        </akn:meta>
-                    </akn:judgment>
-                </akn:akomaNtoso>
-            </root>
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                        xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:cite>[2023] TEST 1234</uk:cite>
+                        </proprietary>
+                    </meta>
+                </judgment>
+            </akomaNtoso>
         """
 
         judgment = Judgment("test/1234", mock_api_client)


### PR DESCRIPTION
There seems to be some confusion caused by the tests containing `<root>` elements that these appear in the actual judgments and the XQuery should include them -- we remove these elements, reduce dependency on the judgment element (but we still need to take a look at the `.xqy` files) and make some of the tests more realistic.

(We should probably think about having some sample XML files for testing.)