### PR TITLE
Document.enrich()

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -227,6 +227,13 @@ class Document:
 
         return DOCUMENT_STATUS_IN_PROGRESS
 
+    def enrich(self) -> None:
+        notify_changed(
+            uri=self.uri,
+            status="published",
+            enrich=True,
+        )
+
     def publish(self) -> None:
         if not self.is_publishable:
             raise CannotPublishUnpublishableDocument


### PR DESCRIPTION
To support re-sending enrichment messages either in bulk or individually, add a document.enrich() method that doesn't publish the judgment.

This might help support a /enrich editor endpoint or a "mass-enrich all these documents" tool.