### PR TITLE
Run pdoc via poetry

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: poetry install --only docs
 
-      - run: pdoc -o docs/ src/caselawclient
+      - run: poetry run pdoc -o docs/ src/caselawclient
 
       - uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
We installed pdoc and its dependencies, but didn't actually run them within the Poetry environment, causing the action to fail.