### PR TITLE
Bugfix: Ensure marklogic responses are treated as unencoded bytes

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -156,7 +156,7 @@ class Document:
             return []
 
     @cached_property
-    def content_as_xml(self) -> str:
+    def content_as_xml(self) -> bytes:
         return self.api_client.get_judgment_xml(self.uri, show_unpublished=True)
 
     @cached_property

--- a/src/caselawclient/models/utilities/__init__.py
+++ b/src/caselawclient/models/utilities/__init__.py
@@ -12,9 +12,9 @@ akn_namespace = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
 uk_namespace = {"uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 
 
-def get_judgment_root(judgment_xml: str) -> str:
+def get_judgment_root(judgment_xml: bytes) -> str:
     try:
-        parsed_xml = ET.XML(bytes(judgment_xml, encoding="utf-8"))
+        parsed_xml = ET.XML(judgment_xml)
         return parsed_xml.tag
     except ET.ParseError:
         return "error"

--- a/tests/client/test_get_judgment_and_versions.py
+++ b/tests/client/test_get_judgment_and_versions.py
@@ -31,11 +31,11 @@ class TestGetJudgment(unittest.TestCase):
             result = self.client.get_judgment_xml("/judgment/uri")
 
             expected = (
-                '<?xml version="1.0" encoding="UTF-8"?>\n'
-                '<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n'
-                '<judgment name="judgment" contains="originalVersion">\n'
-                "</judgment>\n"
-                "</akomaNtoso>"
+                b'<?xml version="1.0" encoding="UTF-8"?>\n'
+                b'<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">\n'
+                b'<judgment name="judgment" contains="originalVersion">\n'
+                b"</judgment>\n"
+                b"</akomaNtoso>"
             )
             assert result == expected
 

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -182,6 +182,16 @@ class TestDocument:
             "test/1234", show_unpublished=True
         )
 
+    def test_judgment_content_as_xml_tree(self, mock_api_client):
+        mock_api_client.get_judgment_xml.return_value = (
+            b'<?xml version="1.0" encoding="UTF-8"?><xml></xml>'
+        )
+        try:
+            document = Document("test/1234", mock_api_client)
+            document.content_as_xml_tree
+        except ValueError as ex:
+            assert False, f"document.content_as_xml_tree raised a ValueError: {ex}"
+
     def test_document_status(self, mock_api_client):
         in_progress_document = Document("test/1234", mock_api_client)
         in_progress_document.is_held = False


### PR DESCRIPTION
## Changes in this PR:

Tiny bugfix release for a problem I uncovered when attempting to upgrade the editor UI to v13.0.0.

Marklogic returns strings with an encoding declaration, which are unsupported by lxml (which gives precedence to the encoding declaration in the xml itself - see [this stack overflow answer](https://stackoverflow.com/questions/28534460/lxml-etree-xml-valueerror-for-unicode-string)), and raises an ValueError with message "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration." - this can be verified by attempting to access any judgment on staging markdown with version 13.0.0 of the client.

Instead, we can just preserve the marklogic response as bytes and pass them directly to lxml rather than decoding (and re-encoding later).