### PR TITLE
Bugfix: Ensure marklogic responses are treated as unencoded bytes

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -81,6 +81,17 @@ def get_multipart_strings_from_marklogic_response(
     return [part.text for part in multipart_data.parts]
 
 
+def get_multipart_bytes_from_marklogic_response(
+    response: requests.Response,
+) -> list[bytes]:
+    if not (response.content):
+        return []
+
+    multipart_data = decoder.MultipartDecoder.from_response(response)
+
+    return [part.content for part in multipart_data.parts]
+
+
 def get_single_string_from_marklogic_response(
     response: requests.Response,
 ) -> str:
@@ -101,6 +112,25 @@ def get_single_string_from_marklogic_response(
         # TODO: This should strictly speaking be None, but fixing this involves refactoring a lot of other stuff which
         # relies on "" being falsy.
         return ""
+
+    elif part_count > 1:
+        raise MultipartResponseLongerThanExpected(
+            f"Response returned {part_count} multipart items, expected 1"
+        )
+
+    return parts[0]
+
+
+def get_single_bytestring_from_marklogic_response(
+    response: requests.Response,
+) -> bytes:
+    parts = get_multipart_bytes_from_marklogic_response(response)
+    part_count = len(parts)
+
+    if part_count == 0:
+        # TODO: This should strictly speaking be None, but fixing this involves refactoring a lot of other stuff which
+        # relies on "" being falsy.
+        return b""
 
     elif part_count > 1:
         raise MultipartResponseLongerThanExpected(
@@ -228,6 +258,12 @@ class MarklogicApiClient:
         response = self._send_to_eval(vars, xquery_file_name)
         return get_single_string_from_marklogic_response(response)
 
+    def _eval_as_bytes(
+        self, vars: query_dicts.MarkLogicAPIDict, xquery_file_name: str
+    ) -> bytes:
+        response = self._send_to_eval(vars, xquery_file_name)
+        return get_single_bytestring_from_marklogic_response(response)
+
     def prepare_request_kwargs(
         self,
         method: str,
@@ -284,12 +320,12 @@ class MarklogicApiClient:
             return False
         raise RuntimeError("Marklogic response was neither true nor false")
 
-    def get_judgment_xml(
+    def get_judgment_xml_bytestring(
         self,
         judgment_uri: str,
         version_uri: Optional[str] = None,
         show_unpublished: bool = False,
-    ) -> str:
+    ) -> bytes:
         uri = self._format_uri_for_marklogic(judgment_uri)
         show_unpublished = self.verify_show_unpublished(show_unpublished)
         if version_uri:
@@ -300,15 +336,23 @@ class MarklogicApiClient:
             "show_unpublished": show_unpublished,
         }
 
-        decoded_response = self._eval_and_decode(vars, "get_judgment.xqy")
-        if not decoded_response:
+        response = self._eval_as_bytes(vars, "get_judgment.xqy")
+        if not response:
             raise MarklogicNotPermittedError(
                 "The document is not published and show_unpublished was not set"
             )
 
-        return decoded_response
+        return response
 
-        return self._eval_and_decode(vars, "get_judgment.xqy")
+    def get_judgment_xml(
+        self,
+        judgment_uri: str,
+        version_uri: Optional[str] = None,
+        show_unpublished: bool = False,
+    ) -> str:
+        return self.get_judgment_xml_bytestring(
+            judgment_uri, version_uri, show_unpublished
+        ).decode(encoding="utf-8")
 
     def set_judgment_name(self, judgment_uri: str, content: str) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -195,8 +195,14 @@ class Document:
         return self.api_client.get_judgment_xml(self.uri, show_unpublished=True)
 
     @cached_property
+    def content_as_xml_bytestring(self) -> bytes:
+        return self.api_client.get_judgment_xml_bytestring(
+            self.uri, show_unpublished=True
+        )
+
+    @cached_property
     def content_as_xml_tree(self) -> Any:
-        return etree.fromstring(self.content_as_xml)
+        return etree.fromstring(self.content_as_xml_bytestring)
 
     def content_as_html(self, version_uri: Optional[str] = None) -> str:
         results = self.api_client.eval_xslt(
@@ -224,7 +230,7 @@ class Document:
         return True
 
     def _get_root(self) -> str:
-        return get_judgment_root(self.content_as_xml)
+        return get_judgment_root(self.content_as_xml_bytestring)
 
     @cached_property
     def has_name(self) -> bool:

--- a/src/caselawclient/models/utilities/__init__.py
+++ b/src/caselawclient/models/utilities/__init__.py
@@ -12,9 +12,9 @@ akn_namespace = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
 uk_namespace = {"uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 
 
-def get_judgment_root(judgment_xml: str) -> str:
+def get_judgment_root(judgment_xml: bytes) -> str:
     try:
-        parsed_xml = ET.XML(bytes(judgment_xml, encoding="utf-8"))
+        parsed_xml = ET.XML(judgment_xml)
         return parsed_xml.tag
     except ET.ParseError:
         return "error"

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -23,7 +23,7 @@ class TestJudgmentValidation:
         assert document_without_ncn.has_ncn is False
 
     def test_judgment_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_xml.return_value = """
+        mock_api_client.get_judgment_xml_bytestring.return_value = """
             <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
                         xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
                 <judgment>
@@ -34,12 +34,14 @@ class TestJudgmentValidation:
                     </meta>
                 </judgment>
             </akomaNtoso>
-        """
+        """.encode(
+            "utf-8"
+        )
 
         judgment = Judgment("test/1234", mock_api_client)
 
         assert judgment.neutral_citation == "[2023] TEST 1234"
-        mock_api_client.get_judgment_xml.assert_called_once_with(
+        mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
             "test/1234", show_unpublished=True
         )
 

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -23,7 +23,7 @@ class TestPressSummaryValidation:
         assert document_without_ncn.has_ncn is False
 
     def test_press_summary_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_xml.return_value = """
+        mock_api_client.get_judgment_xml_bytestring.return_value = """
         <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
             xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
         <doc name="pressSummary">
@@ -40,12 +40,14 @@ class TestPressSummaryValidation:
             </mainBody>
         </doc>
         </akomaNtoso>
-        """
+        """.encode(
+            "utf-8"
+        )
 
         press_summary = PressSummary("test/1234", mock_api_client)
 
         assert press_summary.neutral_citation == "[2016] TEST 49"
-        mock_api_client.get_judgment_xml.assert_called_once_with(
+        mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
             "test/1234", show_unpublished=True
         )
 


### PR DESCRIPTION

## Changes in this PR:

Tiny bugfix release for a problem I uncovered when attempting to upgrade the editor UI to v13.0.0.

Marklogic returns strings with an encoding declaration, which are unsupported by lxml (which gives precedence to the encoding declaration in the xml itself - see [this stack overflow answer](https://stackoverflow.com/questions/28534460/lxml-etree-xml-valueerror-for-unicode-string)), and raises an ValueError with message "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration." - this can be verified by attempting to access any judgment on staging markdown with version 13.0.0 of the client.

Instead, we can just preserve the marklogic response as bytes and pass them directly to lxml rather than decoding (and re-encoding later).
