### PR TITLE
💔 Generalise set document metadata methods to deal with press summaries

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -317,13 +317,13 @@ class MarklogicApiClient:
 
     def set_judgment_date(self, judgment_uri: str, content: str) -> requests.Response:
         warnings.warn(
-            "set_judgment_date() is deprecated, use set_judgment_work_expression_date()",
+            "set_judgment_date() is deprecated, use set_document_work_expression_date()",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.set_judgment_work_expression_date(judgment_uri, content)
+        return self.set_document_work_expression_date(judgment_uri, content)
 
-    def set_judgment_work_expression_date(
+    def set_document_work_expression_date(
         self, judgment_uri: str, content: str
     ) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -310,8 +310,8 @@ class MarklogicApiClient:
 
         return self._eval_and_decode(vars, "get_judgment.xqy")
 
-    def set_judgment_name(self, judgment_uri: str, content: str) -> requests.Response:
-        uri = self._format_uri_for_marklogic(judgment_uri)
+    def set_document_name(self, document_uri: str, content: str) -> requests.Response:
+        uri = self._format_uri_for_marklogic(document_uri)
         vars: query_dicts.SetMetadataNameDict = {"uri": uri, "content": content}
         return self._send_to_eval(vars, "set_metadata_name.xqy")
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -345,7 +345,7 @@ class MarklogicApiClient:
 
         return self._send_to_eval(vars, "set_metadata_citation.xqy")
 
-    def set_judgment_court(self, judgment_uri: str, content: str) -> requests.Response:
+    def set_document_court(self, judgment_uri: str, content: str) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.SetMetadataCourtDict = {"uri": uri, "content": content}
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -324,9 +324,9 @@ class MarklogicApiClient:
         return self.set_document_work_expression_date(judgment_uri, content)
 
     def set_document_work_expression_date(
-        self, judgment_uri: str, content: str
+        self, document_uri: str, content: str
     ) -> requests.Response:
-        uri = self._format_uri_for_marklogic(judgment_uri)
+        uri = self._format_uri_for_marklogic(document_uri)
         vars: query_dicts.SetMetadataWorkExpressionDateDict = {
             "uri": uri,
             "content": content,
@@ -345,8 +345,8 @@ class MarklogicApiClient:
 
         return self._send_to_eval(vars, "set_metadata_citation.xqy")
 
-    def set_document_court(self, judgment_uri: str, content: str) -> requests.Response:
-        uri = self._format_uri_for_marklogic(judgment_uri)
+    def set_document_court(self, document_uri: str, content: str) -> requests.Response:
+        uri = self._format_uri_for_marklogic(document_uri)
         vars: query_dicts.SetMetadataCourtDict = {"uri": uri, "content": content}
 
         return self._send_to_eval(vars, "set_metadata_court.xqy")

--- a/src/caselawclient/xquery/set_metadata_court.xqy
+++ b/src/caselawclient/xquery/set_metadata_court.xqy
@@ -2,14 +2,18 @@ xquery version "1.0-ml";
 
 declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+
+let $proprietary-node := document($uri)/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:court
+let $court-node := $proprietary-node/uk:court
+
 declare function local:delete($uri)
 {
-   xdmp:node-delete(document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court)
+   xdmp:node-delete($court-node)
 };
 declare function local:edit($uri, $content)
 {
    xdmp:node-replace(
-     document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court,
+     ,
      <uk:court>{$content}</uk:court>
    )
 };
@@ -17,7 +21,7 @@ declare function local:add($uri, $content)
 {
 
    xdmp:node-insert-child(
-     document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary,
+     $proprietary-node,
      <uk:court>{$content}</uk:court>
    )
 };

--- a/src/caselawclient/xquery/set_metadata_name.xqy
+++ b/src/caselawclient/xquery/set_metadata_name.xqy
@@ -4,15 +4,27 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-if (fn:boolean(
+declare function local:get-name-node($root-node)
+{
+  if ($root-node//akn:judgment) then
+    $root-node//akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname
+  else if ($root-node//akn:doc[@name = "pressSummary"]) then
+    $root-node//akn:doc[@name = "pressSummary"]/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname
+  else ()
+};
+
+let $doc := fn:doc($uri)
+let $name-node := local:get-name-node($doc)
+
+return if (fn:boolean(
 cts:search(doc($uri),
 cts:element-query(xs:QName('akn:FRBRname'),cts:and-query(()))))) then
     xdmp:node-replace(
-    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname,
+    $name-node,
     <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
     )
 else
     xdmp:node-insert-child(
-    document($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork,
+    $name-node,
     <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
     )

--- a/src/caselawclient/xquery/set_metadata_name.xqy
+++ b/src/caselawclient/xquery/set_metadata_name.xqy
@@ -4,27 +4,20 @@ declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare variable $uri as xs:string external;
 declare variable $content as xs:string external;
 
-declare function local:get-name-node($root-node)
-{
-  if ($root-node//akn:judgment) then
-    $root-node//akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname
-  else if ($root-node//akn:doc[@name = "pressSummary"]) then
-    $root-node//akn:doc[@name = "pressSummary"]/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname
-  else ()
-};
-
 let $doc := fn:doc($uri)
-let $name-node := local:get-name-node($doc)
+
+let $work-node := $doc//akn:*/akn:meta/akn:identification/akn:FRBRWork
+let $name-node := $work-node/akn:FRBRname
 
 return if (fn:boolean(
 cts:search(doc($uri),
 cts:element-query(xs:QName('akn:FRBRname'),cts:and-query(()))))) then
     xdmp:node-replace(
-    $name-node,
-    <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+      $name-node,
+      <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
     )
 else
     xdmp:node-insert-child(
-    $name-node,
-    <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+      $work-node,
+      <akn:FRBRname value="{$content}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
     )

--- a/src/caselawclient/xquery/set_metadata_work_expression_date.xqy
+++ b/src/caselawclient/xquery/set_metadata_work_expression_date.xqy
@@ -6,14 +6,18 @@ declare variable $content as xs:string external;
 
 let $date_attr_name := doc($uri)/akn:akomaNtoso/akn:judgment/@name
 
+
+let $work-date-node := doc($uri)/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate
+let $expression-date-node := doc($uri)/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRExpression/akn:FRBRdate
+
 (: https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/doc/adr/0008-how-frbrdates-are-managed.md :)
 (: Keep these two dates in sync for now as per our ADR :)
 return (
     xdmp:node-replace(
-    doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate,
+    $work-date-node,
     <akn:FRBRdate date="{$content}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>),
 
     xdmp:node-replace(
-    doc($uri)/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRExpression/akn:FRBRdate,
+    $expression-date-node,
     <akn:FRBRdate date="{$content}" name="{$date_attr_name}" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>)
 )

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -64,12 +64,12 @@ class TestGetSetMetadata(unittest.TestCase):
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
-    def test_set_judgment_date(self):
+    def test_set_document_date(self):
         with patch.object(self.client, "eval") as mock_eval:
             uri = "judgment/uri"
             content = "01-01-2023"
             expected_vars = {"uri": "/judgment/uri.xml", "content": content}
-            self.client.set_judgment_work_expression_date(uri, content)
+            self.client.set_document_work_expression_date(uri, content)
 
             assert mock_eval.call_args.args[0] == (
                 os.path.join(

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -52,12 +52,12 @@ class TestGetSetMetadata(unittest.TestCase):
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
-    def test_set_judgment_court(self):
+    def test_set_document_court(self):
         with patch.object(self.client, "eval") as mock_eval:
             uri = "judgment/uri"
             content = "new court"
             expected_vars = {"uri": "/judgment/uri.xml", "content": content}
-            self.client.set_judgment_court(uri, content)
+            self.client.set_document_court(uri, content)
 
             assert mock_eval.call_args.args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")


### PR DESCRIPTION
## Changes in this PR:
- Generalised the set judgment metadata Client methods to set document metadata methods
- specifically for name, court and date

Haven't done it for neutral citation as it's a bit more complicated. I think I will leave that for a followup PR.

Have tested manually by copying and pasting into my local marklogic server. Have considered moving these xqy files into our marklogic repo so we can test them there, which I still think is worth doing but we have considered setting up some sort of suite of E2E tests to make sure things are actually working when hooked up together.

### 💔 Breaking change
The `set_judgment_name` and `set_judgment_court` methods have been renamed.

## Trello card / Rollbar error (etc)
https://trello.com/c/lppwqc94/1169-api-client-tidy-up-allow-press-summary-metadata-name-court-date-and-related-ncn-to-be-edited
