### PR TITLE
Add new `Document.delete()` method

### DIFF
--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -118,6 +118,10 @@ def unpublish_documents(uri: str) -> None:
     delete_from_bucket(uri, env("PUBLIC_ASSET_BUCKET"))
 
 
+def delete_documents_from_private_bucket(uri: str) -> None:
+    delete_from_bucket(uri, env("PRIVATE_ASSET_BUCKET"))
+
+
 def notify_changed(uri: str, status: str, enrich: bool = False) -> None:
     client = create_sns_client()
 


### PR DESCRIPTION
Running this against an instance of a `Document` (or subclass like `Judgment` or `PressSummary`) will remove the document from MarkLogic and S3.

A document _cannot_ be deleted if it is published, since this implies it as already been given a publicly accessible URI. A document must first be unpublished (hopefully triggering appropriate workflows for hadnling depublication with data reusers etc) before it can be deleted.