### PR TITLE
Not found error for collections

### DIFF
--- a/smoketest.py
+++ b/smoketest.py
@@ -18,7 +18,6 @@ api_client = Client.MarklogicApiClient(
 )
 
 
-@pytest.mark.xfail
 def test_get_document_type_returns_404():
     with pytest.raises(DocumentNotFoundError) as e:
         api_client.get_document_type_from_uri("/not/a/real/url")

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -29,6 +29,7 @@ from . import xquery_type_dicts as query_dicts
 from .content_hash import validate_content_hash
 from .errors import MarklogicAPIError  # noqa: F401
 from .errors import (
+    DocumentNotFoundError,
     GatewayTimeoutError,
     MarklogicBadRequestError,
     MarklogicCheckoutConflictError,
@@ -160,6 +161,7 @@ class MarklogicApiClient:
         "DLS-CHECKOUTCONFLICT": MarklogicCheckoutConflictError,
         "SEC-PRIVDNE": MarklogicNotPermittedError,
         "XDMP-VALIDATE.*": MarklogicValidationFailedError,
+        "FCL-DOCUMENTNOTFOUND.*": DocumentNotFoundError,
     }
 
     default_http_error_class = MarklogicCommunicationError

--- a/src/caselawclient/xquery/document_collections.xqy
+++ b/src/caselawclient/xquery/document_collections.xqy
@@ -2,4 +2,5 @@ xquery version "1.0-ml";
 
 declare variable $uri as xs:string external;
 
-xdmp:document-get-collections($uri)
+let $error := if (not(fn:doc-available($uri))) then (fn:error(xs:QName("FCL-DOCUMENTNOTFOUND"), "FCL-DOCUMENTNOTFOUND No document at "||$uri )) else ()
+return xdmp:document-get-collections($uri)


### PR DESCRIPTION
I'm not entirely happy with this.

Raising `fn:error(xs:QName("FCL_ERRORCODE"), "Description of Error"))` doesn't actually emit the error code in the 500 error that the API client receives. So we have to put that into the description.

The Python error currently is also not customised, looking like:

```E           caselawclient.errors.DocumentNotFoundError: 500 Server Error: Internal Server Error for url: ...:8011/LATEST/eval. Response body:
E           <error-response xmlns="http://marklogic.com/xdmp/error">
E             <status-code>500</status-code>
E             <status>Internal Server Error</status>
E             <message-code>FCL-DOCUMENTNOTFOUND No document at /not/a/real/url.xml</message-code>
E             <message>FCL-DOCUMENTNOTFOUND No document at /not/a/real/url.xml:</message>
E             <message-detail>
E               <message-title>FCL-DOCUMENTNOTFOUND No document at /not/a/real/url.xml</message-title>
E             </message-detail>
E           </error-response>
```