### PR TITLE
Remove `is_editable` in favour of `failed_to_parse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- **Breaking:**: Removed `document.is_editable` in favour of the more descriptive and better-tested `document.failed_to_parse`.
+
 ## [Release 13.2.1]
  - Fix issues blocking push to PyPI
 

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -62,9 +62,14 @@ class Document:
 
     attributes_to_validate: list[tuple[str, bool, str]] = [
         (
+            "failed_to_parse",
+            False,
+            "This document failed to parse",
+        ),
+        (
             "is_failure",
             False,
-            "This {document_noun} has failed to parse",
+            "This {document_noun} does not have a valid URI",
         ),
         (
             "is_parked",
@@ -241,10 +246,15 @@ class Document:
         return False
 
     @cached_property
-    def is_editable(self) -> bool:
+    def failed_to_parse(self) -> bool:
+        """
+        Did this document entirely fail to parse?
+
+        :return: `True` if there was a complete parser failure, otherwise `False`
+        """
         if "error" in self._get_root():
-            return False
-        return True
+            return True
+        return False
 
     def _get_root(self) -> str:
         return get_judgment_root(self.content_as_xml_bytestring)

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -81,6 +81,7 @@ class TestJudgmentValidation:
 
     def test_judgment_validation_failure_messages_if_failing(self, mock_api_client):
         judgment = Judgment("test/1234", mock_api_client)
+        judgment.failed_to_parse = True
         judgment.is_parked = True
         judgment.is_held = True
         judgment.has_name = False
@@ -90,6 +91,7 @@ class TestJudgmentValidation:
 
         assert judgment.validation_failure_messages == sorted(
             [
+                "This document failed to parse",
                 "This judgment is currently parked at a temporary URI",
                 "This judgment is currently on hold",
                 "This judgment has no name",

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -89,6 +89,7 @@ class TestPressSummaryValidation:
         self, mock_api_client
     ):
         press_summary = PressSummary("test/1234", mock_api_client)
+        press_summary.failed_to_parse = True
         press_summary.is_parked = True
         press_summary.is_held = True
         press_summary.has_name = False
@@ -98,6 +99,7 @@ class TestPressSummaryValidation:
 
         assert press_summary.validation_failure_messages == sorted(
             [
+                "This document failed to parse",
                 "This press summary is currently parked at a temporary URI",
                 "This press summary is currently on hold",
                 "This press summary has no name",


### PR DESCRIPTION
The old `is_editable` property was very unclear. The new `failed_to_parse` property describes what it actually checks, as well as being tested.

As part of this, a document which has failed to parse is now unpublishable.