### PR TITLE
Fixed PressSummary `neutral_citation` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- Fixed `neutral_citation` property to look within `preface` tag rather than `mainBody` for press summaries, due to updated parsing resulting in updated press summary xml structure.
+
 ## [Release 14.0.1]
 
 - Fixed `Client.set_document_court` method

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -22,7 +22,7 @@ class PressSummary(NeutralCitationMixin, Document):
     def neutral_citation(self) -> str:
         return get_xpath_match_string(
             self.content_as_xml_tree,
-            "/akn:akomaNtoso/akn:doc/akn:mainBody/akn:p/akn:neutralCitation/text()",
+            "/akn:akomaNtoso/akn:doc/akn:preface/akn:p/akn:neutralCitation/text()",
             {
                 "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
             },

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -34,7 +34,7 @@ class TestPressSummaryValidation:
         <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
             xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
         <doc name="pressSummary">
-            <mainBody>
+            <preface>
             <p>
                 some paragraph
             </p>
@@ -44,7 +44,7 @@ class TestPressSummaryValidation:
                 </docTitle>
                 <neutralCitation style="font-weight:bold;font-family:Garamond">[2016] TEST 49</neutralCitation>
             </p>
-            </mainBody>
+            </preface>
         </doc>
         </akomaNtoso>
         """.encode(


### PR DESCRIPTION
## Changes in this PR:

- Fixed `neutral_citation` property to look within `preface` tag rather than `mainBody` for press summaries, due to updated parsing resulting in updated press summary xml structure.

## Trello card / Rollbar error (etc)
https://trello.com/c/uJiohuAM/1269-eui-spelling-of-press-summary