### PR TITLE
Add default user agent string to custom api client

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import json
 import logging
 import os
@@ -46,6 +47,12 @@ from .errors import (
 env = environ.Env()
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
+
+try:
+    VERSION = importlib.metadata.version("ds-caselaw-marklogic-api-client")
+except importlib.metadata.PackageNotFoundError:
+    VERSION = "0"
+DEFAULT_USER_AGENT = f"ds-caselaw-marklogic-api-client/{VERSION}"
 
 
 class MultipartResponseLongerThanExpected(Exception):
@@ -167,7 +174,12 @@ class MarklogicApiClient:
     default_http_error_class = MarklogicCommunicationError
 
     def __init__(
-        self, host: str, username: str, password: str, use_https: bool
+        self,
+        host: str,
+        username: str,
+        password: str,
+        use_https: bool,
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         self.host = host
         self.username = username
@@ -176,6 +188,7 @@ class MarklogicApiClient:
         # Apply auth / common headers to the session
         self.session = requests.Session()
         self.session.auth = HTTPBasicAuth(username, password)
+        self.session.headers.update({"User-Agent": user_agent})
 
     def get_document_by_uri(self, uri: str) -> Document:
         document_type_class = self.get_document_type_from_uri(uri)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -5,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 import responses
+from requests import Request
 
 from caselawclient.Client import (
     MarklogicApiClient,
@@ -173,3 +175,9 @@ class ApiClientTest(unittest.TestCase):
     def test_format_uri_all_the_slashes(self):
         uri = "/ewca/2022/123/"
         assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
+
+    def test_user_agent(self):
+        user_agent = self.client.session.prepare_request(
+            Request("GET", "http://example.invalid")
+        ).headers["user-agent"]
+        assert re.match(r"^ds-caselaw-marklogic-api-client/\d+", user_agent)


### PR DESCRIPTION
Set the default user agent string to give the version of the custom api client, and have it overriddable by users of the client.