### PR TITLE
Be more strict about the flavours of strings

### DIFF
--- a/script/build_xquery_type_dicts
+++ b/script/build_xquery_type_dicts
@@ -12,8 +12,12 @@ These classes are automatically generated using the `script/build_xquery_type_di
 checks. They are used to enforce appropriately typed variables being passed in to MarkLogic XQuery functions.
 \"\"\"
 
-from typing import Any, Optional, TypedDict
+from typing import Any, NewType, Optional, TypedDict
 
+MarkLogicDocumentURIString = NewType("MarkLogicDocumentURIString", str)
+MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)
+
+MarkLogicPrivilegeURIString = NewType("MarkLogicPrivilegeURIString", str)
 
 class MarkLogicAPIDict(TypedDict):
     pass"""
@@ -38,12 +42,26 @@ def file_name_to_class_name(file_name: str):
     return file_name.split(".")[0].title().replace("_", "") + "Dict"
 
 
-def ml_type_to_python_type(type: str):
-    if type[-1] == "?":
-        type = ML_TYPES_TO_PYTHON_TYPES_DICT[type[:-1]]
-        return f"Optional[{type}]"
+def ml_type_to_python_type_declaration(variable_name: str, variable_type: str):
+    if variable_type[-1] == "?":
+        variable_optional = True
+        variable_type = variable_type[:-1]
     else:
-        return ML_TYPES_TO_PYTHON_TYPES_DICT[type]
+        variable_optional = False
+
+    if variable_name == "version_uri":
+        variable_type = "MarkLogicDocumentVersionURIString"
+    elif variable_name == "privilege_uri":
+        variable_type = "MarkLogicPrivilegeURIString"
+    elif variable_name == "uri" or variable_name.endswith("_uri"):
+        variable_type = "MarkLogicDocumentURIString"
+    else:
+        variable_type = ML_TYPES_TO_PYTHON_TYPES_DICT[variable_type]
+
+    if variable_optional:
+        variable_type = f"Optional[{variable_type}]"
+
+    return f"{variable_name}: {variable_type}"
 
 
 xquery_files = [f for f in listdir(XQY_FILES_PATCH) if f.endswith(".xqy")]
@@ -68,8 +86,9 @@ class {class_name}(MarkLogicAPIDict):"""
                 )
 
                 for match in sorted(matches):
-                    variable_name = match[0]
-                    variable_type = ml_type_to_python_type(match[1])
-                    dicts_file.write(f"\n    {variable_name}: {variable_type}")
+                    type_declaration = ml_type_to_python_type_declaration(
+                        variable_name=match[0], variable_type=match[1]
+                    )
+                    dicts_file.write(f"\n    {type_declaration}")
 
     dicts_file.write("\n")

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -10,6 +10,7 @@ from ds_caselaw_utils.courts import Court, CourtNotFoundException, courts
 from lxml import etree
 
 from caselawclient.Client import api_client
+from caselawclient.models.documents import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
 
 
@@ -43,7 +44,7 @@ class SearchResultMetadata:
         self.last_modified = last_modified
 
     @staticmethod
-    def create_from_uri(uri: str) -> "SearchResultMetadata":
+    def create_from_uri(uri: DocumentURIString) -> "SearchResultMetadata":
         """
         Create a SearchResultMetadata instance from a search result URI.
 
@@ -159,12 +160,14 @@ class SearchResult:
         self.node = node
 
     @property
-    def uri(self) -> str:
+    def uri(self) -> DocumentURIString:
         """
         :return: The URI of the search result
         """
 
-        return self._get_xpath_match_string("@uri").lstrip("/").split(".xml")[0]
+        return DocumentURIString(
+            self._get_xpath_match_string("@uri").lstrip("/").split(".xml")[0]
+        )
 
     @property
     def neutral_citation(self) -> str:

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -6,8 +6,12 @@ These classes are automatically generated using the `script/build_xquery_type_di
 checks. They are used to enforce appropriately typed variables being passed in to MarkLogic XQuery functions.
 """
 
-from typing import Any, Optional, TypedDict
+from typing import Any, NewType, Optional, TypedDict
 
+MarkLogicDocumentURIString = NewType("MarkLogicDocumentURIString", str)
+MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)
+
+MarkLogicPrivilegeURIString = NewType("MarkLogicPrivilegeURIString", str)
 
 class MarkLogicAPIDict(TypedDict):
     pass
@@ -15,63 +19,63 @@ class MarkLogicAPIDict(TypedDict):
 
 # break_judgment_checkout.xqy
 class BreakJudgmentCheckoutDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # checkin_judgment.xqy
 class CheckinJudgmentDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # checkout_judgment.xqy
 class CheckoutJudgmentDict(MarkLogicAPIDict):
     annotation: str
     timeout: int
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # copy_document.xqy
 class CopyDocumentDict(MarkLogicAPIDict):
-    new_uri: str
-    old_uri: str
+    new_uri: MarkLogicDocumentURIString
+    old_uri: MarkLogicDocumentURIString
 
 
 # delete_judgment.xqy
 class DeleteJudgmentDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # document_collections.xqy
 class DocumentCollectionsDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # document_exists.xqy
 class DocumentExistsDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # get_judgment.xqy
 class GetJudgmentDict(MarkLogicAPIDict):
     show_unpublished: Optional[bool]
-    uri: str
-    version_uri: Optional[str]
+    uri: MarkLogicDocumentURIString
+    version_uri: Optional[MarkLogicDocumentVersionURIString]
 
 
 # get_judgment_checkout_status.xqy
 class GetJudgmentCheckoutStatusDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # get_judgment_version.xqy
 class GetJudgmentVersionDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
     version: str
 
 
 # get_last_modified.xqy
 class GetLastModifiedDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # get_properties_for_search_results.xqy
@@ -82,43 +86,43 @@ class GetPropertiesForSearchResultsDict(MarkLogicAPIDict):
 # get_property.xqy
 class GetPropertyDict(MarkLogicAPIDict):
     name: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # insert_document.xqy
 class InsertDocumentDict(MarkLogicAPIDict):
     document: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # list_judgment_versions.xqy
 class ListJudgmentVersionsDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_boolean_property.xqy
 class SetBooleanPropertyDict(MarkLogicAPIDict):
     name: str
-    uri: str
+    uri: MarkLogicDocumentURIString
     value: str
 
 
 # set_metadata_citation.xqy
 class SetMetadataCitationDict(MarkLogicAPIDict):
     content: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_metadata_court.xqy
 class SetMetadataCourtDict(MarkLogicAPIDict):
     content: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_metadata_name.xqy
 class SetMetadataNameDict(MarkLogicAPIDict):
     content: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_metadata_this_uri.xqy
@@ -126,19 +130,19 @@ class SetMetadataThisUriDict(MarkLogicAPIDict):
     content_with_id: str
     content_with_xml: str
     content_without_id: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_metadata_work_expression_date.xqy
 class SetMetadataWorkExpressionDateDict(MarkLogicAPIDict):
     content: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # set_property.xqy
 class SetPropertyDict(MarkLogicAPIDict):
     name: str
-    uri: str
+    uri: MarkLogicDocumentURIString
     value: str
 
 
@@ -146,20 +150,20 @@ class SetPropertyDict(MarkLogicAPIDict):
 class UpdateJudgmentDict(MarkLogicAPIDict):
     annotation: str
     judgment: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # update_locked_judgment.xqy
 class UpdateLockedJudgmentDict(MarkLogicAPIDict):
     annotation: str
     judgment: str
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # user_has_privilege.xqy
 class UserHasPrivilegeDict(MarkLogicAPIDict):
     privilege_action: str
-    privilege_uri: str
+    privilege_uri: MarkLogicPrivilegeURIString
     user: str
 
 
@@ -171,13 +175,13 @@ class UserHasRoleDict(MarkLogicAPIDict):
 
 # xslt.xqy
 class XsltDict(MarkLogicAPIDict):
-    uri: str
+    uri: MarkLogicDocumentURIString
 
 
 # xslt_transform.xqy
 class XsltTransformDict(MarkLogicAPIDict):
     img_location: Optional[str]
     show_unpublished: Optional[bool]
-    uri: str
-    version_uri: Optional[str]
+    uri: MarkLogicDocumentURIString
+    version_uri: Optional[MarkLogicDocumentVersionURIString]
     xsl_filename: Optional[str]


### PR DESCRIPTION
There is currently ambiguity about the types of strings which are being passed around, particularly with the overloaded term "URI". This uses `typing.NewType` to create some new types of `str` so we can be explicit in what we mean. These are:

- `Document.DocumentURIString`: Our generally accepted concept of a document's unique identifier
- `xquery_type_dicts.MarkLogicDocumentURIString`: A URI referring to a concrete document within MarkLogic
- `xquery_type_dicts.MarkLogicDocumentVersionURIString`: A subclass of the above, referring to a specific version of a document in MarkLogic
- `xquery_type_dicts.MarkLogicPrivilegeURIString`: A URI referring to a user privilege within MarkLogic.

To allow for this, the `build_xquery_type_dicts` script will interpret some variable names as always meaning a specific type of URI, either document, version or privilege as above. These are then reflected in the typed dicts.