### PR TITLE
Test whether the database obeys our own integrity rules

### DIFF
--- a/assertions/README.md
+++ b/assertions/README.md
@@ -1,0 +1,3 @@
+Each of these xqueries should detect anomalies in the live marklogic database, returning URIs of records which do not fulfil the expected criteria.
+
+You should probably copy-paste them into the console rather than using production credentials locally.

--- a/assertions/all_latest_versions.xqy
+++ b/assertions/all_latest_versions.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+(: All documents at sensible urls are a part of dls:latest-version :)
+
+for $uri in cts:uris(
+    (),
+    (),
+    cts:not-query(cts:collection-query(("http://marklogic.com/collections/dls/latest-version"))))
+
+
+return if (fn:contains($uri, '_xml_versions')) then () else $uri

--- a/assertions/assert.py
+++ b/assertions/assert.py
@@ -1,0 +1,24 @@
+import glob
+
+import environ
+from dotenv import load_dotenv
+
+import caselawclient.Client as Client
+
+load_dotenv()
+env = environ.Env()
+
+api_client = Client.MarklogicApiClient(
+    host=env("MARKLOGIC_HOST"),
+    username=env("MARKLOGIC_USER"),
+    password=env("MARKLOGIC_PASSWORD"),
+    use_https=env("MARKLOGIC_USE_HTTPS", default=None),
+)
+
+files = glob.glob("*.xqy")
+
+for file in files:
+    path = f"../../../assertions/{file}"
+    print(path)
+    response = api_client._send_to_eval({}, path)
+    print(Client.get_multipart_strings_from_marklogic_response(response))

--- a/assertions/must_have_collection.xqy
+++ b/assertions/must_have_collection.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+(: All documents must have at least one document collection (from judgment, press-summary) :)
+
+cts:uris(
+    (),
+    (),
+    cts:not-query(cts:collection-query(("judgment", "press-summary")))
+)

--- a/assertions/not_two_collections.xqy
+++ b/assertions/not_two_collections.xqy
@@ -1,0 +1,12 @@
+xquery version "1.0-ml";
+
+(: All documents must not have more than one document collection :)
+
+cts:uris(
+    (),
+    (),
+    cts:and-query(
+      (cts:collection-query(("judgment")),
+      (cts:collection-query(("press-summary"))))
+    )
+)


### PR DESCRIPTION
https://trello.com/c/e1Dgn4o4/1314-add-a-simple-quick-marklogic-validation-so-that-docs-have-to-be-in-a-doctype-collection-press-summary-judgment

I think we should have a good, long think about whether we want to set up a read-only user for making these sorts of queries against a potentially production database.