### PR TITLE
Change `is_failure` behaviour to rely on `failed_to_parse`

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -70,11 +70,6 @@ class Document:
             "This document failed to parse",
         ),
         (
-            "is_failure",
-            False,
-            "This {document_noun} does not have a valid URI",
-        ),
-        (
             "is_parked",
             False,
             "This {document_noun} is currently parked at a temporary URI",
@@ -240,7 +235,14 @@ class Document:
 
     @cached_property
     def is_failure(self) -> bool:
-        if "failures" in self.uri:
+        """
+        Is this document in a 'failure' state from which no recovery is possible? This is considered to be the case if:
+
+        - The document entirely failed to parse
+
+        :return: `True` if this document is in a 'failure' state, otherwise `False`
+        """
+        if self.failed_to_parse:
             return True
         return False
 

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -175,6 +175,9 @@ class TestDocumentValidation:
         successful_document = Document("test/1234", mock_api_client)
         failing_document = Document("failures/test/1234", mock_api_client)
 
+        successful_document.failed_to_parse = False
+        failing_document.failed_to_parse = True
+
         assert successful_document.is_failure is False
         assert failing_document.is_failure is True
 


### PR DESCRIPTION
The `is_failure` parameter previously relied on checking the URI to determine if a failure state existed. This is a hangover from previous behaviour, but not one we want.

Change the behaviour so that it instead relies on checking other parameters which are indicative of a failure. At the moment this is only `failed_to_parse`, but this list may be expanded in the future.