### PR TITLE
Neutral citation in search results includes press summaries.

### DIFF
--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -172,15 +172,17 @@ class SearchResult:
     @property
     def neutral_citation(self) -> str:
         """
-        :return: The neutral citation of the search result
+        :return: The neutral citation of the search result, or the judgment it is a press summary of.
         """
 
-        return self._get_xpath_match_string("search:extracted/uk:cite/text()")
+        return self._get_xpath_match_string(
+            "search:extracted/uk:cite/text()"
+        ) or self._get_xpath_match_string("search:extracted/akn:neutralCitation/text()")
 
     @property
     def name(self) -> str:
         """
-        :return: The neutral citation of the search result
+        :return: The title of the search result's document
         """
 
         return self._get_xpath_match_string("search:extracted/akn:FRBRname/@value")


### PR DESCRIPTION
<img width="701" alt="image" src="https://github.com/nationalarchives/ds-caselaw-custom-api-client/assets/85497046/23ed4876-a79c-48f8-af4d-5adeddf1702a">

Note that this changes the neutral citation function to return two arguably different things, but separating those out  feels like overcomplicating it to me.