### PR TITLE
Provide publication information when getting metadata for search results

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -39,7 +39,12 @@ DOCUMENT_STATUS_PUBLISHED = "Published"
 """ This document has been published and should be considered publicly visible. """
 
 DOCUMENT_STATUS_IN_PROGRESS = "In progress"
-""" This document has not been published or put on hold, and should be progressing through the document pipeline. """
+""" This document has not been published or put on hold, and has been picked up by an editor and
+    should be progressing through the document pipeline. """
+
+DOCUMENT_STATUS_NEW = "New"
+""" This document isn't published, on hold, or assigned, and can be picked up by an editor in the future. """
+
 
 DOCUMENT_COLLECTION_URI_JUDGMENT = "judgment"
 DOCUMENT_COLLECTION_URI_PRESS_SUMMARY = "press-summary"
@@ -386,7 +391,10 @@ class Document:
         if self.is_held:
             return DOCUMENT_STATUS_HOLD
 
-        return DOCUMENT_STATUS_IN_PROGRESS
+        if self.assigned_to:
+            return DOCUMENT_STATUS_IN_PROGRESS
+
+        return DOCUMENT_STATUS_NEW
 
     def enrich(self) -> None:
         notify_changed(

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -22,6 +22,7 @@ class EditorStatus(Enum):
     NEW = "new"
     IN_PROGRESS = "in progress"
     HOLD = "hold"
+    PUBLISHED = "published"
 
 
 class EditorPriority(Enum):
@@ -98,6 +99,13 @@ class SearchResultMetadata:
         return self._get_xpath_match_string("//editor-hold/text()")
 
     @property
+    def is_published(self) -> bool:
+        """
+        :return:
+        """
+        return self._get_xpath_match_string("//published/text()") == "true"
+
+    @property
     def editor_priority(self) -> str:
         """
         :return: The editor priority
@@ -130,6 +138,8 @@ class SearchResultMetadata:
         :return: The editor status based on the metadata
         """
 
+        if self.is_published:
+            return EditorStatus.PUBLISHED.value
         if self.editor_hold == "true":
             return EditorStatus.HOLD.value
         if self.assigned_to:

--- a/src/caselawclient/xquery/get_properties_for_search_results.xqy
+++ b/src/caselawclient/xquery/get_properties_for_search_results.xqy
@@ -8,7 +8,8 @@ let $properties := (
     fn:QName("", 'source-name'),
     fn:QName("", 'source-email'),
     fn:QName("", 'transfer-consignment-reference'),
-    fn:QName("", 'transfer-received-at')
+    fn:QName("", 'transfer-received-at'),
+    fn:QName("", 'published')
 )
 
 return <property-results>{

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -13,6 +13,7 @@ from caselawclient.errors import (
 from caselawclient.models.documents import (
     DOCUMENT_STATUS_HOLD,
     DOCUMENT_STATUS_IN_PROGRESS,
+    DOCUMENT_STATUS_NEW,
     DOCUMENT_STATUS_PUBLISHED,
     CannotPublishUnpublishableDocument,
     Document,
@@ -155,19 +156,28 @@ class TestDocument:
         assert etree.tostring(document.content_as_xml_tree) == b"<xml/>"
 
     def test_document_status(self, mock_api_client):
+        new_document = Document("test/1234", mock_api_client)
+        new_document.is_held = False
+        new_document.is_published = False
+        new_document.assigned_to = ""
+        assert new_document.status == DOCUMENT_STATUS_NEW
+
         in_progress_document = Document("test/1234", mock_api_client)
         in_progress_document.is_held = False
         in_progress_document.is_published = False
+        in_progress_document.assigned_to = "duck"
         assert in_progress_document.status == DOCUMENT_STATUS_IN_PROGRESS
 
         on_hold_document = Document("test/1234", mock_api_client)
         on_hold_document.is_held = True
         on_hold_document.is_published = False
+        on_hold_document.assigned_to = "duck"
         assert on_hold_document.status == DOCUMENT_STATUS_HOLD
 
         published_document = Document("test/1234", mock_api_client)
         published_document.is_held = False
         published_document.is_published = True
+        published_document.assigned_to = "duck"
         assert published_document.status == DOCUMENT_STATUS_PUBLISHED
 
     def test_document_best_identifier(self, mock_api_client):

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -113,6 +113,7 @@ class TestSearchResultMeta:
             "<transfer-consignment-reference>test_consignment_reference</transfer-consignment-reference>"
             "<editor-hold>false</editor-hold>"
             "<editor-priority>30</editor-priority>"
+            "<published>true</published>"
             "<transfer-received-at>2023-01-26T14:17:02Z</transfer-received-at>"
             "</property-result>"
             "</property-results>"
@@ -127,6 +128,7 @@ class TestSearchResultMeta:
         assert meta.editor_priority == "30"
         assert meta.submission_datetime == datetime.datetime(2023, 1, 26, 14, 17, 2)
         assert meta.last_modified == "test_last_modified"
+        assert meta.is_published is True
 
     def test_empty_properties_init(self):
         """
@@ -150,17 +152,24 @@ class TestSearchResultMeta:
         assert meta.editor_priority == EditorPriority.MEDIUM.value
         assert meta.submission_datetime == datetime.datetime.min
         assert meta.last_modified == "test_last_modified"
+        assert meta.is_published is False
 
     @pytest.mark.parametrize(
-        "editor_hold, assigned_to, expected_editor_status",
+        "published_string, editor_hold, assigned_to, expected_editor_status",
         [
-            ("false", "", EditorStatus.NEW),
-            ("false", "TestEditor", EditorStatus.IN_PROGRESS),
-            ("true", "", EditorStatus.HOLD),
-            ("true", "TestEditor", EditorStatus.HOLD),
+            ("", "false", "", EditorStatus.NEW),
+            ("", "false", "TestEditor", EditorStatus.IN_PROGRESS),
+            ("", "true", "", EditorStatus.HOLD),
+            ("", "true", "TestEditor", EditorStatus.HOLD),
+            ("true", "false", "", EditorStatus.PUBLISHED),
+            ("true", "false", "TestEditor", EditorStatus.PUBLISHED),
+            ("true", "true", "", EditorStatus.PUBLISHED),
+            ("true", "true", "TestEditor", EditorStatus.PUBLISHED),
         ],
     )
-    def test_editor_status(self, assigned_to, editor_hold, expected_editor_status):
+    def test_editor_status(
+        self, published_string, assigned_to, editor_hold, expected_editor_status
+    ):
         """
         GIVEN editor_hold and assigned_to values
         WHEN creating a SearchResultMetadata instance
@@ -171,6 +180,7 @@ class TestSearchResultMeta:
             "<property-result>"
             f"<assigned-to>{assigned_to}</assigned-to>"
             f"<editor-hold>{editor_hold}</editor-hold>"
+            f"<published>{published_string}</published>"
             "</property-result>"
             "</property-results>"
         )


### PR DESCRIPTION

<img width="160" alt="image" src="https://github.com/nationalarchives/ds-caselaw-custom-api-client/assets/85497046/7769ed20-1242-4815-a711-8b87350edbf3">

<img width="677" alt="image" src="https://github.com/nationalarchives/ds-caselaw-custom-api-client/assets/85497046/a74ae567-1a77-4413-8c06-f7c5dd2557a6">

This is potentially breaking behaviour since there is a new `published` value editor_status can emit or `new` for Document.status.
https://linear.app/tna/issue/FCL-82/status-in-search-results-doesnt-match-the-actual-status-of-the

But it turns out that the editor just displays this value, never really parsing it; seems to be true for the Document too.


Editor could do with a colour tweak for "new"