### PR TITLE
Expose how the latest version came into being

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -216,6 +216,16 @@ class Document:
         else:
             return max(events)
 
+    def get_latest_manifestation_type(self) -> Optional[str]:
+        return max(
+            (
+                (type, time)
+                for type in ["transform", "tna-enriched"]
+                if (time := self.get_latest_manifestation_datetime(type))
+            ),
+            key=lambda x: x[1],
+        )[0]
+
     @cached_property
     def transformation_datetime(self) -> Optional[datetime.datetime]:
         return self.get_latest_manifestation_datetime("transform")

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -575,6 +575,7 @@ class TestDocumentMetadata:
         assert document.enrichment_datetime.year == 2024
         assert document.transformation_datetime.year == 2026
         assert document.get_latest_manifestation_datetime().year == 2026
+        assert document.get_latest_manifestation_type() == "transform"
         assert [
             x.year for x in document.get_manifestation_datetimes("tna-enriched")
         ] == [2024, 2023]


### PR DESCRIPTION

## Changes in this PR:

a new `document.get_latest_manifestation_type` method which returns either "tna-enrich" or "transform" depending on the "name" property of the most recent manifestation date.

This is used in the versions table in the editor UI to annotate each version with it's 'version type', which helps editors better understand where each version came from.


## Trello card / Rollbar error (etc)

https://trello.com/c/jyTZaNMi/1359-eui-version-history-add-column-to-table-to-indicate-type-of-version

