### PR TITLE
Add `automated` and `payload` to `VersionAnnotation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- BREAKING: `VersionAnnotation` now requires a statement of if the action is automated or not
+- `VersionAnnotation` can now accept an optional dict of structured `payload` data
+
 ## [Release 16.0.0]
 
 - New versions of a document created with `insert_document_xml` can now be annotated

--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -9,6 +9,8 @@ class AnnotationDataDict(TypedDict):
     type: str
     calling_function: str
     message: NotRequired[str]
+    payload: NotRequired[dict[str, Any]]
+    automated: bool
 
 
 class VersionType(Enum):
@@ -27,14 +29,25 @@ class VersionType(Enum):
 class VersionAnnotation:
     """A class holding structured data about the reason for a version."""
 
-    def __init__(self, version_type: VersionType, message: Optional[str] = None):
+    def __init__(
+        self,
+        version_type: VersionType,
+        automated: bool,
+        message: Optional[str] = None,
+        payload: Optional[dict[str, Any]] = None,
+    ):
         """
         :param version_type: The type of version being created
+        :param automated: `True` if this action has happened as the result of an automated process, rather than a human
+            action
         :param message: A human-readable string containing information about the version which can't be expressed in the
             structured data.
+        :param payload: A dict containing additional information relevant to this version change
         """
         self.version_type = version_type
+        self.automated = automated
         self.message = message
+        self.payload = payload
 
     def set_calling_function(self, calling_function: str) -> None:
         """
@@ -59,10 +72,14 @@ class VersionAnnotation:
         annotation_data: AnnotationDataDict = {
             "type": self.version_type.value,
             "calling_function": self.calling_function,
+            "automated": self.automated,
         }
 
         if self.message:
             annotation_data["message"] = self.message
+
+        if self.payload:
+            annotation_data["payload"] = self.payload
 
         return annotation_data
 

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -28,7 +28,9 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     {
                         "type": "edit",
                         "calling_function": "update_document_xml",
+                        "automated": False,
                         "message": "test_update_document_xml",
+                        "payload": {"test_payload": True},
                     }
                 ),
             }
@@ -38,6 +40,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 VersionAnnotation(
                     VersionType.EDIT,
                     message="test_update_document_xml",
+                    automated=False,
+                    payload={"test_payload": True},
                 ),
             )
 
@@ -64,7 +68,9 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                         {
                             "type": "enrichment",
                             "calling_function": "save_locked_judgment_xml",
+                            "automated": True,
                             "message": "test_save_locked_judgment_xml",
+                            "payload": {"test_payload": True},
                         }
                     ),
                 }
@@ -74,6 +80,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     VersionAnnotation(
                         VersionType.ENRICHMENT,
                         message="test_save_locked_judgment_xml",
+                        automated=True,
+                        payload={"test_payload": True},
                     ),
                 )
 
@@ -102,6 +110,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     VersionAnnotation(
                         VersionType.SUBMISSION,
                         message="test_save_locked_judgment_xml_checks_content_hash",
+                        automated=False,
+                        payload={"test_payload": True},
                     ),
                 )
 
@@ -117,7 +127,9 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     {
                         "type": "submission",
                         "calling_function": "insert_document_xml",
+                        "automated": False,
                         "message": "test_insert_document_xml",
+                        "payload": {"test_payload": True},
                     }
                 ),
             }
@@ -127,6 +139,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 VersionAnnotation(
                     VersionType.SUBMISSION,
                     message="test_insert_document_xml",
+                    automated=False,
+                    payload={"test_payload": True},
                 ),
             )
 

--- a/tests/client_helpers/test_version_annotation.py
+++ b/tests/client_helpers/test_version_annotation.py
@@ -9,4 +9,5 @@ class TestSaveCopyDeleteJudgment:
             VersionAnnotation(
                 VersionType.SUBMISSION,
                 message="test_structured_annotation_dict_raises_on_no_calling_function_name",
+                automated=False,
             ).structured_annotation_dict


### PR DESCRIPTION
`automated` is a required boolean, indicating if the version is the result of an automated process or a human action.

`payload` is an optional structured dict of additional information, which may be parsed by other tools such as EUI to expose relevant details.