### PR TITLE
VersionAnnotation now records user agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - BREAKING: `VersionAnnotation` now requires a statement of if the action is automated or not
 - `VersionAnnotation` can now accept an optional dict of structured `payload` data
+- `VersionAnnotation` can now record a user agent string
 
 ## [Release 16.0.0]
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -197,6 +197,7 @@ class MarklogicApiClient:
         self.session = requests.Session()
         self.session.auth = HTTPBasicAuth(username, password)
         self.session.headers.update({"User-Agent": user_agent})
+        self.user_agent = user_agent
 
     def get_document_by_uri(self, uri: DocumentURIString) -> Document:
         document_type_class = self.get_document_type_from_uri(uri)
@@ -468,6 +469,7 @@ class MarklogicApiClient:
         uri = self._format_uri_for_marklogic(judgment_uri)
 
         annotation.set_calling_function("save_locked_judgment_xml")
+        annotation.set_calling_agent(self.user_agent)
 
         vars: query_dicts.UpdateLockedJudgmentDict = {
             "uri": uri,
@@ -497,6 +499,7 @@ class MarklogicApiClient:
         uri = self._format_uri_for_marklogic(document_uri)
 
         annotation.set_calling_function("insert_document_xml")
+        annotation.set_calling_agent(self.user_agent)
 
         vars: query_dicts.InsertDocumentDict = {
             "uri": uri,
@@ -528,6 +531,7 @@ class MarklogicApiClient:
         uri = self._format_uri_for_marklogic(document_uri)
 
         annotation.set_calling_function("update_document_xml")
+        annotation.set_calling_agent(self.user_agent)
 
         vars: query_dicts.UpdateDocumentDict = {
             "uri": uri,

--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -8,6 +8,7 @@ from typing_extensions import NotRequired
 class AnnotationDataDict(TypedDict):
     type: str
     calling_function: str
+    calling_agent: str
     message: NotRequired[str]
     payload: NotRequired[dict[str, Any]]
     automated: bool
@@ -57,21 +58,36 @@ class VersionAnnotation:
         """
         self.calling_function = calling_function
 
+    def set_calling_agent(self, calling_agent: str) -> None:
+        """
+        Set the name of the calling agent for tracing purposes
+
+        :param calling_agent: The name of the agent which is performing the database write
+        """
+        self.calling_agent = calling_agent
+
     @property
     def structured_annotation_dict(self) -> AnnotationDataDict:
         """
         :return: A structured dict representing this `VersionAnnotation`
 
         :raises AttributeError: The name of the calling function has not been set; use `set_calling_function()`
+        :raises AttributeError: The name of the calling agent has not been set; use `set_calling_agent()`
         """
         if not self.calling_function:
             raise AttributeError(
                 "The name of the calling function has not been set; use set_calling_function()"
             )
 
+        if not self.calling_agent:
+            raise AttributeError(
+                "The name of the calling agent has not been set; use set_calling_agent()"
+            )
+
         annotation_data: AnnotationDataDict = {
             "type": self.version_type.value,
             "calling_function": self.calling_function,
+            "calling_agent": self.calling_agent,
             "automated": self.automated,
         }
 

--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -50,6 +50,9 @@ class VersionAnnotation:
         self.message = message
         self.payload = payload
 
+        self.calling_function: Optional[str] = None
+        self.calling_agent: Optional[str] = None
+
     def set_calling_function(self, calling_function: str) -> None:
         """
         Set the name of the calling function for tracing purposes

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -14,7 +14,13 @@ from caselawclient.errors import InvalidContentHashError
 
 class TestSaveCopyDeleteJudgment(unittest.TestCase):
     def setUp(self):
-        self.client = MarklogicApiClient("", "", "", False)
+        self.client = MarklogicApiClient(
+            host="",
+            username="",
+            password="",
+            use_https=False,
+            user_agent="marklogic-api-client-test",
+        )
 
     def test_update_document_xml(self):
         with patch.object(self.client, "eval") as mock_eval:
@@ -28,6 +34,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     {
                         "type": "edit",
                         "calling_function": "update_document_xml",
+                        "calling_agent": "marklogic-api-client-test",
                         "automated": False,
                         "message": "test_update_document_xml",
                         "payload": {"test_payload": True},
@@ -68,6 +75,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                         {
                             "type": "enrichment",
                             "calling_function": "save_locked_judgment_xml",
+                            "calling_agent": "marklogic-api-client-test",
                             "automated": True,
                             "message": "test_save_locked_judgment_xml",
                             "payload": {"test_payload": True},
@@ -127,6 +135,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     {
                         "type": "submission",
                         "calling_function": "insert_document_xml",
+                        "calling_agent": "marklogic-api-client-test",
                         "automated": False,
                         "message": "test_insert_document_xml",
                         "payload": {"test_payload": True},

--- a/tests/client_helpers/test_version_annotation.py
+++ b/tests/client_helpers/test_version_annotation.py
@@ -3,11 +3,54 @@ import pytest
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 
 
-class TestSaveCopyDeleteJudgment:
+class TestVersionAnnotation:
+    def test_structured_annotation_dict_returns_expected_values(self):
+        annotation = VersionAnnotation(
+            VersionType.SUBMISSION,
+            message="test_structured_annotation_dict_returns_expected_values",
+            payload={"test_payload": True},
+            automated=False,
+        )
+        annotation.set_calling_agent("marklogic-api-client-test")
+        annotation.set_calling_function("update_xml")
+
+        assert annotation.structured_annotation_dict == {
+            "automated": False,
+            "calling_agent": "marklogic-api-client-test",
+            "calling_function": "update_xml",
+            "message": "test_structured_annotation_dict_returns_expected_values",
+            "payload": {"test_payload": True},
+            "type": "submission",
+        }
+
     def test_structured_annotation_dict_raises_on_no_calling_function_name(self):
-        with pytest.raises(AttributeError):
-            VersionAnnotation(
-                VersionType.SUBMISSION,
-                message="test_structured_annotation_dict_raises_on_no_calling_function_name",
-                automated=False,
-            ).structured_annotation_dict
+        annotation = VersionAnnotation(
+            VersionType.SUBMISSION,
+            message="test_structured_annotation_dict_raises_on_no_calling_function_name",
+            automated=False,
+        )
+        annotation.set_calling_agent("marklogic-api-client-test")
+
+        with pytest.raises(AttributeError) as e:
+            annotation.structured_annotation_dict
+
+        assert (
+            str(e.value)
+            == "The name of the calling function has not been set; use set_calling_function()"
+        )
+
+    def test_structured_annotation_dict_raises_on_no_calling_agent(self):
+        annotation = VersionAnnotation(
+            VersionType.SUBMISSION,
+            message="test_structured_annotation_dict_raises_on_no_calling_agent",
+            automated=False,
+        )
+        annotation.set_calling_function("update_xml")
+
+        with pytest.raises(AttributeError) as e:
+            annotation.structured_annotation_dict
+
+        assert (
+            str(e.value)
+            == "The name of the calling agent has not been set; use set_calling_agent()"
+        )


### PR DESCRIPTION
For better audit purposes, we now record the user agent string in use when a new version is created.