### PR TITLE
Do not set ACL because ACLs are deprecated

### DIFF
--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -110,7 +110,7 @@ def publish_documents(uri: str) -> None:
 
         if not key.endswith("parser.log") and not key.endswith(".tar.gz"):
             source: CopySourceTypeDef = {"Bucket": private_bucket, "Key": key}
-            extra_args = {"ACL": "public-read"}
+            extra_args: dict[str, str] = {}
             try:
                 client.copy(source, public_bucket, key, extra_args)
             except botocore.client.ClientError as e:


### PR DESCRIPTION
New judgments do not appear on staging. We suspect this may be due to the ACL issue encountered in ingestion.