### PR TITLE
Tidy up error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- BREAKING: Remove `Document.get_root`.
+
 ## [Release 17.2.0]
 - `document.content_as_html` now takes an optional `query=` string parameter, which, when supplied, highlights instances of the query within the document with `<mark>` tags, each of which has a numbered id indicating its sequence in the document.
 - `document.number_of_mentions` method which takes a `query=` string parameter, and returns the number of highlighted mentions in the html.

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -391,12 +391,9 @@ class Document:
 
         :return: `True` if there was a complete parser failure, otherwise `False`
         """
-        if "error" in self._get_root():
+        if "error" in get_judgment_root(self.content_as_xml_bytestring):
             return True
         return False
-
-    def _get_root(self) -> str:
-        return get_judgment_root(self.content_as_xml_bytestring)
 
     @cached_property
     def has_name(self) -> bool:


### PR DESCRIPTION
The handling of documents which doesn't parse is currently done by catching a parse exception and then returning a specific string as part of reading a `Document`'s contents. This can be done more elegantly, giving us more robustness in future.