### PR TITLE
Refactor search to get rid of dependency on static `api_client` instance

### DIFF
--- a/src/caselawclient/client_helpers/search_helpers.py
+++ b/src/caselawclient/client_helpers/search_helpers.py
@@ -1,3 +1,5 @@
+from lxml import etree
+
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_response import SearchResponse
 from caselawclient.search_parameters import SearchParameters
@@ -14,8 +16,10 @@ def search_judgments_and_parse_response(
 
     :return: The parsed search response as a SearchResponse object
     """
-    return SearchResponse.from_response_string(
-        api_client.search_judgments_and_decode_response(search_parameters)
+    return SearchResponse(
+        etree.fromstring(
+            api_client.search_judgments_and_decode_response(search_parameters)
+        )
     )
 
 
@@ -30,6 +34,6 @@ def search_and_parse_response(
 
     :return: The parsed search response as a SearchResponse object
     """
-    return SearchResponse.from_response_string(
-        api_client.search_and_decode_response(search_parameters)
+    return SearchResponse(
+        etree.fromstring(api_client.search_and_decode_response(search_parameters))
     )

--- a/src/caselawclient/client_helpers/search_helpers.py
+++ b/src/caselawclient/client_helpers/search_helpers.py
@@ -19,7 +19,8 @@ def search_judgments_and_parse_response(
     return SearchResponse(
         etree.fromstring(
             api_client.search_judgments_and_decode_response(search_parameters)
-        )
+        ),
+        api_client,
     )
 
 
@@ -35,5 +36,6 @@ def search_and_parse_response(
     :return: The parsed search response as a SearchResponse object
     """
     return SearchResponse(
-        etree.fromstring(api_client.search_and_decode_response(search_parameters))
+        etree.fromstring(api_client.search_and_decode_response(search_parameters)),
+        api_client,
     )

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -21,15 +21,6 @@ class SearchResponse:
         """
         self.node = node
 
-    @staticmethod
-    def from_response_string(xml: str) -> "SearchResponse":
-        """
-        Constructs a SearchResponse instance from an xml response string.
-
-        :param xml: The XML data as a string
-        """
-        return SearchResponse(etree.fromstring(xml))
-
     @property
     def total(self) -> str:
         """

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -2,6 +2,7 @@ from typing import List
 
 from lxml import etree
 
+from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_result import SearchResult
 
 
@@ -13,13 +14,14 @@ class SearchResponse:
     NAMESPACES = {"search": "http://marklogic.com/appservices/search"}
     """ Namespaces used in XPath expressions."""
 
-    def __init__(self, node: etree._Element) -> None:
+    def __init__(self, node: etree._Element, client: MarklogicApiClient) -> None:
         """
         Initializes a SearchResponse instance from an xml node.
 
         :param node: The XML data as an etree element
         """
         self.node = node
+        self.client = client
 
     @property
     def total(self) -> str:
@@ -42,9 +44,4 @@ class SearchResponse:
         results = self.node.xpath(
             "//search:response/search:result", namespaces=self.NAMESPACES
         )
-        return [
-            SearchResult(
-                result,
-            )
-            for result in results
-        ]
+        return [SearchResult(result, self.client) for result in results]

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -10,7 +10,7 @@ from dateutil.parser import ParserError
 from ds_caselaw_utils.courts import Court, CourtNotFoundException, courts
 from lxml import etree
 
-from caselawclient.Client import api_client
+from caselawclient.Client import MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
 
@@ -149,12 +149,13 @@ class SearchResult:
     }
     """ Namespace mappings used in XPath expressions. """
 
-    def __init__(self, node: etree._Element):
+    def __init__(self, node: etree._Element, client: MarklogicApiClient):
         """
         :param node: The XML element representing the search result
         """
 
         self.node = node
+        self.client = client
 
     @property
     def uri(self) -> DocumentURIString:
@@ -251,8 +252,8 @@ class SearchResult:
         """
         :return: A `SearchResultMetadata` instance representing the metadata of this result
         """
-        response_text = api_client.get_properties_for_search_results([self.uri])
-        last_modified = api_client.get_last_modified(self.uri)
+        response_text = self.client.get_properties_for_search_results([self.uri])
+        last_modified = self.client.get_last_modified(self.uri)
         root = etree.fromstring(response_text)
         return SearchResultMetadata(root, last_modified)
 

--- a/tests/client/test_search_and_decode_response.py
+++ b/tests/client/test_search_and_decode_response.py
@@ -1,61 +1,71 @@
 from unittest.mock import patch
 
-from caselawclient.Client import api_client
+from caselawclient.Client import MarklogicApiClient
 from caselawclient.search_parameters import SearchParameters
 
 
-@patch("caselawclient.Client.api_client.advanced_search")
-def test_search_judgments_and_decode_response(
-    mock_advanced_search,
-    valid_search_response_xml,
-    generate_mock_search_response,
-):
-    """
-    Given the search parameters for search_judgments_and_decode_response are valid
-    And a mocked api_client response with search results
-    When search_judgments_and_decode_response function is called with the mocked API client
-        and input parameters
-    Then the API client's advanced_search method should be called once with the
-        appropriate parameters
-    And the search_judgments_and_decode_response function should return the response
-        xml string with all the search results
-    """
-    mock_advanced_search.return_value = generate_mock_search_response(
-        valid_search_response_xml
-    )
-
-    search_response = api_client.search_judgments_and_decode_response(
-        SearchParameters(
-            query="test query",
-            court="test court",
-            judge="test judge",
-            party="test party",
-            neutral_citation="test citation",
-            specific_keyword="test keyword",
-            date_from="2022-01-01",
-            date_to="2022-01-31",
-            page=1,
-            page_size=10,
+class TestSearchAndDecodeResponse:
+    def setup_method(self):
+        self.client = MarklogicApiClient(
+            host="",
+            username="",
+            password="",
+            use_https=False,
+            user_agent="marklogic-api-client-test",
         )
-    )
 
-    mock_advanced_search.assert_called_once_with(
-        SearchParameters(
-            query="test query",
-            court="test court",
-            judge="test judge",
-            party="test party",
-            neutral_citation="test citation",
-            specific_keyword="test keyword",
-            order=None,
-            date_from="2022-01-01",
-            date_to="2022-01-31",
-            page=1,
-            page_size=10,
-            show_unpublished=False,
-            only_unpublished=False,
-            collections=["judgment"],
-        )
-    )
+    def test_search_judgments_and_decode_response(
+        self,
+        valid_search_response_xml,
+        generate_mock_search_response,
+    ):
+        """
+        Given the search parameters for search_judgments_and_decode_response are valid
+        And a mocked MarklogicApiClient.advanced_search response with search results
+        When search_judgments_and_decode_response function is called with the mocked API client
+            and input parameters
+        Then the API client's advanced_search method should be called once with the
+            appropriate parameters
+        And the search_judgments_and_decode_response function should return the response
+            xml string with all the search results
+        """
+        with patch.object(self.client, "advanced_search") as mock_advanced_search:
+            mock_advanced_search.return_value = generate_mock_search_response(
+                valid_search_response_xml
+            )
 
-    assert search_response == valid_search_response_xml
+            search_response = self.client.search_judgments_and_decode_response(
+                SearchParameters(
+                    query="test query",
+                    court="test court",
+                    judge="test judge",
+                    party="test party",
+                    neutral_citation="test citation",
+                    specific_keyword="test keyword",
+                    date_from="2022-01-01",
+                    date_to="2022-01-31",
+                    page=1,
+                    page_size=10,
+                )
+            )
+
+            mock_advanced_search.assert_called_once_with(
+                SearchParameters(
+                    query="test query",
+                    court="test court",
+                    judge="test judge",
+                    party="test party",
+                    neutral_citation="test citation",
+                    specific_keyword="test keyword",
+                    order=None,
+                    date_from="2022-01-01",
+                    date_to="2022-01-31",
+                    page=1,
+                    page_size=10,
+                    show_unpublished=False,
+                    only_unpublished=False,
+                    collections=["judgment"],
+                )
+            )
+
+            assert search_response == valid_search_response_xml

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -1,10 +1,20 @@
 import pytest
 from lxml import etree
 
+from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_response import SearchResponse
 
 
 class TestSearchResponse:
+    def setup_method(self):
+        self.client = MarklogicApiClient(
+            host="",
+            username="",
+            password="",
+            use_https=False,
+            user_agent="marklogic-api-client-test",
+        )
+
     def test_total(
         self,
     ):
@@ -18,7 +28,8 @@ class TestSearchResponse:
                 '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501
                 "foo"
                 "</search:response>"
-            )
+            ),
+            self.client,
         )
 
         assert search_response.total == "5"
@@ -35,7 +46,8 @@ class TestSearchResponse:
         And each element's node attribute should be as expected
         """
         search_response = SearchResponse(
-            etree.fromstring(generate_search_response_xml(2 * valid_search_result_xml))
+            etree.fromstring(generate_search_response_xml(2 * valid_search_result_xml)),
+            self.client,
         )
 
         results = search_response.results
@@ -66,4 +78,4 @@ class TestSearchResponse:
             etree.XMLSyntaxError,
             match="Namespace prefix search on response is not defined",
         ):
-            SearchResponse(etree.fromstring(xml_without_namespace))
+            SearchResponse(etree.fromstring(xml_without_namespace), self.client)

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -13,10 +13,12 @@ class TestSearchResponse:
         When calling 'total' on it
         Then it should return a string representing the total number of results
         """
-        search_response = SearchResponse.from_response_string(
-            '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501
-            "foo"
-            "</search:response>"
+        search_response = SearchResponse(
+            etree.fromstring(
+                '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501
+                "foo"
+                "</search:response>"
+            )
         )
 
         assert search_response.total == "5"
@@ -32,8 +34,8 @@ class TestSearchResponse:
         Then it should return a list of n SearchResult elements
         And each element's node attribute should be as expected
         """
-        search_response = SearchResponse.from_response_string(
-            generate_search_response_xml(2 * valid_search_result_xml)
+        search_response = SearchResponse(
+            etree.fromstring(generate_search_response_xml(2 * valid_search_result_xml))
         )
 
         results = search_response.results
@@ -64,4 +66,4 @@ class TestSearchResponse:
             etree.XMLSyntaxError,
             match="Namespace prefix search on response is not defined",
         ):
-            SearchResponse.from_response_string(xml_without_namespace)
+            SearchResponse(etree.fromstring(xml_without_namespace))

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -188,36 +188,6 @@ class TestSearchResultMeta:
 
         assert meta.editor_status == expected_editor_status.value
 
-    @patch("caselawclient.responses.search_result.api_client")
-    def test_create_from_uri(self, mock_api_client):
-        """
-        GIVEN a uri and a mock API client
-        WHEN SearchResultMetadata.create_from_uri is called with the uri
-        THEN a SearchResultMetadata object is returned with expected attributes
-        """
-        mock_api_client.get_properties_for_search_results.return_value = (
-            "<property-results>"
-            "<property-result>"
-            "<assigned-to>test_assigned_to</assigned-to>"
-            "<source-name>test_author</source-name>"
-            "<source-email>test_author_email</source-email>"
-            "<transfer-consignment-reference>test_consignment_reference</transfer-consignment-reference>"
-            "<editor-hold>false</editor-hold>"
-            "<editor-priority>30</editor-priority>"
-            "<transfer-received-at>2023-01-26T14:17:02Z</transfer-received-at>"
-            "</property-result>"
-            "</property-results>"
-        )
-        mock_api_client.get_last_modified.return_value = "test_last_modified"
-
-        meta = SearchResultMetadata.create_from_uri("test_uri")
-
-        assert (
-            etree.tostring(meta.node).decode()
-            == mock_api_client.get_properties_for_search_results.return_value
-        )
-        assert meta.last_modified == "test_last_modified"
-
     def test_submission_date_is_min_when_transfer_received_at_empty(self):
         """
         GIVEN a node where the `transfer-received-at` element is empty


### PR DESCRIPTION
Searching currently relies on the static instance of `api_client` which is initialised at `Client` load-time to interface with the database and retrieve metadata.

This instance is deprecated and due for removal, so we need to fix this behaviour. Search should only ever use the `Client` instance it was called with, so we need to either inject the dependency down or refactor the behaviour so it can directly access the `Client`.

As part of this, we move factory methods out of `SearchResultMetadata` and `SearchResult`, which provides a cleaner separation of concerns and reduces the depth to which we need to make changes to account for removing `api_client`.

There should be no functional changes as a result of this PR, and it should be non-breaking for EUI and PUI.