### PR TITLE
Run tests under Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
 
       - uses: abatilo/actions-poetry@v2.3.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,11 +49,11 @@ jobs:
         run: poetry run coverage run -m pytest
 
       - name: Generate coverage XML
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.12' }}
         run: poetry run coverage xml
 
       - name: Upload coverage to CodeClimate
         uses: paambaati/codeclimate-action@v5.0.0
-        if: ${{ matrix.python-version == '3.11' }}
+        if: ${{ matrix.python-version == '3.12' }}
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
We support Python 3.12 as the latest version, so that should probably be included in the testing matrix.