### PR TITLE
Enable triggering of enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- **Feature:** `Document.enrich()` method will send a message to the announce SNS, requesting that a document be enriched.
+
 ## [Release 17.2.0]
 - `document.content_as_html` now takes an optional `query=` string parameter, which, when supplied, highlights instances of the query within the document with `<mark>` tags, each of which has a numbered id indicating its sequence in the document.
 - `document.number_of_mentions` method which takes a `query=` string parameter, and returns the number of highlighted mentions in the html.

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -21,10 +21,10 @@ from ..xml_helpers import get_xpath_match_string, get_xpath_match_strings
 from .utilities import VersionsDict, get_judgment_root, render_versions
 from .utilities.aws import (
     ParserInstructionsDict,
+    announce_document_event,
     delete_documents_from_private_bucket,
     generate_docx_url,
     generate_pdf_url,
-    notify_changed,
     publish_documents,
     request_parse,
     unpublish_documents,
@@ -450,7 +450,7 @@ class Document:
         return DOCUMENT_STATUS_NEW
 
     def enrich(self) -> None:
-        notify_changed(
+        announce_document_event(
             uri=self.uri,
             status="published",
             enrich=True,
@@ -466,7 +466,7 @@ class Document:
 
         publish_documents(uri_for_s3(self.uri))
         self.api_client.set_published(self.uri, True)
-        notify_changed(
+        announce_document_event(
             uri=self.uri,
             status="published",
             enrich=True,
@@ -476,7 +476,7 @@ class Document:
         self.api_client.break_checkout(self.uri)
         unpublish_documents(uri_for_s3(self.uri))
         self.api_client.set_published(self.uri, False)
-        notify_changed(
+        announce_document_event(
             uri=self.uri,
             status="not published",
             enrich=False,

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -450,9 +450,12 @@ class Document:
         return DOCUMENT_STATUS_NEW
 
     def enrich(self) -> None:
+        """
+        Announces to the ANNOUNCE SNS that the document is waiting to be enriched.
+        """
         announce_document_event(
             uri=self.uri,
-            status="published",
+            status="enrich",
             enrich=True,
         )
 
@@ -468,9 +471,9 @@ class Document:
         self.api_client.set_published(self.uri, True)
         announce_document_event(
             uri=self.uri,
-            status="published",
-            enrich=True,
+            status="publish",
         )
+        self.enrich()
 
     def unpublish(self) -> None:
         self.api_client.break_checkout(self.uri)
@@ -478,8 +481,7 @@ class Document:
         self.api_client.set_published(self.uri, False)
         announce_document_event(
             uri=self.uri,
-            status="not published",
-            enrich=False,
+            status="unpublish",
         )
 
     def hold(self) -> None:

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -144,7 +144,7 @@ def delete_documents_from_private_bucket(uri: str) -> None:
     delete_from_bucket(uri, env("PRIVATE_ASSET_BUCKET"))
 
 
-def notify_changed(uri: str, status: str, enrich: bool = False) -> None:
+def announce_document_event(uri: str, status: str, enrich: bool = False) -> None:
     client = create_sns_client()
 
     message_attributes: dict[str, MessageAttributeValueTypeDef] = {}

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -362,31 +362,31 @@ class TestDocumentPublication:
             document.publish()
             mock_api_client.set_published.assert_not_called()
 
-    @patch("caselawclient.models.documents.notify_changed")
+    @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.publish_documents")
     def test_publish(
-        self, mock_publish_documents, mock_notify_changed, mock_api_client
+        self, mock_publish_documents, mock_announce_document_event, mock_api_client
     ):
         document = Document("test/1234", mock_api_client)
         document.is_publishable = True
         document.publish()
         mock_publish_documents.assert_called_once_with("test/1234")
         mock_api_client.set_published.assert_called_once_with("test/1234", True)
-        mock_notify_changed.assert_called_once_with(
+        mock_announce_document_event.assert_called_once_with(
             uri="test/1234", status="published", enrich=True
         )
 
-    @patch("caselawclient.models.documents.notify_changed")
+    @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.unpublish_documents")
     def test_unpublish(
-        self, mock_unpublish_documents, mock_notify_changed, mock_api_client
+        self, mock_unpublish_documents, mock_announce_document_event, mock_api_client
     ):
         document = Document("test/1234", mock_api_client)
         document.unpublish()
         mock_unpublish_documents.assert_called_once_with("test/1234")
         mock_api_client.set_published.assert_called_once_with("test/1234", False)
         mock_api_client.break_checkout.assert_called_once_with("test/1234")
-        mock_notify_changed.assert_called_once_with(
+        mock_announce_document_event.assert_called_once_with(
             uri="test/1234", status="not published", enrich=False
         )
 


### PR DESCRIPTION
Tidy up some behaviours which allow us to manually request a document be enriched via the API.