### PR TITLE
⚠️  Make parameter to set_published non-optional

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -795,7 +795,7 @@ class MarklogicApiClient:
         return content == "true"
 
     def set_published(
-        self, judgment_uri: DocumentURIString, published: bool = False
+        self, judgment_uri: DocumentURIString, published: bool
     ) -> requests.Response:
         return self.set_boolean_property(judgment_uri, "published", published)
 


### PR DESCRIPTION
Technically a breaking change to the API but stops `api_client.set_published()` being a footgun that does nothing.