### PR TITLE
Get a list of documents waiting for enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+- **Feature:** New `Client.get_pending_enrichment_for_version` method finds documents which are not yet enriched with a given version, and which haven't recently been sent for enrichment.
+
 ## [Release 18.0.0]
 
 - **Breaking:** Fully remove the deprecated `caselawclient.api_client` instance.

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -951,3 +951,21 @@ class MarklogicApiClient:
         )
 
         return results
+
+    def get_pending_enrichment_for_version(
+        self, target_version: int
+    ) -> list[list[Any]]:
+        """Retrieve documents which are not yet enriched with a given version."""
+        vars: query_dicts.GetPendingEnrichmentForVersionDict = {
+            "target_version": target_version
+        }
+        results: list[list[Any]] = json.loads(
+            get_single_string_from_marklogic_response(
+                self._send_to_eval(
+                    vars,
+                    "get_pending_enrichment_for_version.xqy",
+                )
+            )
+        )
+
+        return results

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -458,8 +458,13 @@ class Document:
 
     def enrich(self) -> None:
         """
-        Announces to the ANNOUNCE SNS that the document is waiting to be enriched.
+        Request enrichment of the document
         """
+
+        self.api_client.set_property(
+            self.uri, "last_sent_to_enrichment", datetime.datetime.now().isoformat()
+        )
+
         announce_document_event(
             uri=self.uri,
             status="enrich",

--- a/src/caselawclient/xquery/get_pending_enrichment_for_version.xqy
+++ b/src/caselawclient/xquery/get_pending_enrichment_for_version.xqy
@@ -1,0 +1,18 @@
+xquery version "1.0-ml";
+
+declare variable $target_version as xs:int external;
+
+xdmp:to-json(xdmp:sql(
+  "SELECT process_data.uri, enrich_version_string, minutes_since_enrichment_request
+  FROM (
+    SELECT process_data.uri, enrich_version_string, enrich_major_version, DATEDIFF('minute', last_sent_to_enrichment, CURRENT_TIMESTAMP) AS minutes_since_enrichment_request
+    FROM documents.process_data
+    JOIN documents.process_property_data ON process_data.uri = process_property_data.uri
+  )
+  WHERE ((enrich_version_string IS NULL) OR (enrich_major_version < @target_version))
+  AND (minutes_since_enrichment_request > 43200 OR minutes_since_enrichment_request IS NULL)
+  ORDER BY enrich_major_version ASC NULLS FIRST",
+  "array",
+  map:new(map:entry("target_version", $target_version))
+))
+

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -78,6 +78,11 @@ class GetLastModifiedDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString
 
 
+# get_pending_enrichment_for_version.xqy
+class GetPendingEnrichmentForVersionDict(MarkLogicAPIDict):
+    target_version: int
+
+
 # get_properties_for_search_results.xqy
 class GetPropertiesForSearchResultsDict(MarkLogicAPIDict):
     uris: list[Any]


### PR DESCRIPTION
MarkLogic uses TDE to extract relevant fields and pop them into an SQL database, which we then query to get a report on documents waiting to be enriched.