### PR TITLE
Return the highest enrichment version seen on MarkLogic

### DIFF
--- a/smoketest/smoketest.py
+++ b/smoketest/smoketest.py
@@ -43,3 +43,9 @@ def test_get_version_annotation():
         api_client.get_version_annotation(FIRST_VERSION_URI) == "this is an annotation"
     )
     assert Document(FIRST_VERSION_URI, api_client).annotation == "this is an annotation"
+
+
+@pytest.mark.write
+def test_get_highest_enrichment_version():
+    value = api_client.get_highest_enrichment_version()
+    assert int(value)

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -952,6 +952,21 @@ class MarklogicApiClient:
 
         return results
 
+    def get_highest_enrichment_version(self) -> int:
+        """This gets the highest enrichment version in the database,
+        so if nothing has been enriched with the most recent version of enrichment,
+        this won't reflect that change."""
+        table = json.loads(
+            get_single_string_from_marklogic_response(
+                self._send_to_eval(
+                    {},
+                    "get_highest_enrichment_version.xqy",
+                )
+            )
+        )
+
+        return int(table[1][1])
+
     def get_pending_enrichment_for_version(
         self, target_version: int
     ) -> list[list[Any]]:

--- a/src/caselawclient/xquery/get_highest_enrichment_version.xqy
+++ b/src/caselawclient/xquery/get_highest_enrichment_version.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+xdmp:to-json(xdmp:sql(
+  "SELECT enrich_version_string, enrich_major_version
+   FROM documents.process_data
+   ORDER BY enrich_major_version DESC
+   LIMIT 1",
+  "array"
+))


### PR DESCRIPTION
Does not necessarily reflect the version number in Enrichment. This might lead to scenarios where bulk enrichment is stalled until a single successful manual or new-document enrichment occurs.