### PR TITLE
Prioritise quoted phrases in search snippets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+- Add support for quoted phrase prioritisation in result snippets
+
 ## [Release 19.0.0]
 
 - **Breaking**: `Client.set_published` no longer has a default argument; you must always be explicit.

--- a/src/caselawclient/responses/xsl/search_match.xsl
+++ b/src/caselawclient/responses/xsl/search_match.xsl
@@ -17,10 +17,13 @@
         <xsl:apply-templates select="search:match"/>
     </xsl:template>
 
-    <xsl:template match="search:match">
+    <xsl:template match="search:match[position() &lt; 5]">
         <p data-path="{@path}">
             <xsl:apply-templates/>
         </p>
+    </xsl:template>
+
+    <xsl:template match="search:match[position() &gt;= 5]">
     </xsl:template>
 
     <xsl:template match="search:highlight">

--- a/src/caselawclient/search_parameters.py
+++ b/src/caselawclient/search_parameters.py
@@ -1,7 +1,9 @@
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set
 
 RESULTS_PER_PAGE = 10
+QUOTED_PHRASE_REGEX = '"([^"]*)"'
 
 
 @dataclass
@@ -43,6 +45,7 @@ class SearchParameters:
             "show_unpublished": str(self.show_unpublished).lower(),
             "only_unpublished": str(self.only_unpublished).lower(),
             "collections": self._marklogic_collections,
+            "quoted_phrases": self._quoted_phrases,
         }
 
     @property
@@ -57,6 +60,12 @@ class SearchParameters:
         courts = self._court_list_splitter(court_text)
         alternative_court_names = self._get_alternative_court_names(courts)
         return list(courts | alternative_court_names)
+
+    @property
+    def _quoted_phrases(self) -> List[str]:
+        if self.query is None:
+            return []
+        return re.findall(QUOTED_PHRASE_REGEX, self.query)
 
     @staticmethod
     def _join_court_text(court_text: str) -> str:

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -45,6 +45,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "show_unpublished": "false",
                         "only_unpublished": "false",
                         "collections": "",
+                        "quoted_phrases": [],
                     }
                 ),
             )
@@ -97,6 +98,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "show_unpublished": "false",
                         "only_unpublished": "false",
                         "collections": "foo,abcdef,bar",
+                        "quoted_phrases": [],
                     }
                 ),
             )
@@ -157,6 +159,7 @@ class TestAdvancedSearch(unittest.TestCase):
                     "show_unpublished": "false",
                     "only_unpublished": "false",
                     "collections": "",
+                    "quoted_phrases": [],
                 }
 
                 mock_invoke.assert_called_with(


### PR DESCRIPTION

## Changes in this PR:
This goes with a [marklogic PR](https://github.com/nationalarchives/ds-caselaw-marklogic/pull/50) which ensures that snippets containing quoted phrases in the query are given priority when they're displayed to users.

This PR provides the list of quoted phrases to marklogic (essentially impossible to do with marklogic's own regex engine), and also limits the number of matched phrases returned to 4 (the current default), as the number returned by marklogic itself has necessarily increased (we need to generate a larger amount of matches before prioritisation to ensure we catch any mentions of the quoted phrase).

## Trello card / Rollbar error (etc)

https://trello.com/c/IQK3v7c5/1560-search-matching-text-should-reflect-search-query-in-quotations-over-other-words-in-search-results