### PR TITLE
Nested parser instructions

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -550,13 +550,14 @@ class Document:
         # values are "" from the API, we should pass None instead in this case.
 
         parser_instructions: ParserInstructionsDict = {
-            "name": self.name or None,
-            "cite": self.best_human_identifier or None,
-            "court": self.court or None,
-            "date": checked_date,
-            "uri": self.uri,
             "documentType": parser_type_noun,
-            "published": self.is_published,
+            "metadata": {
+                "name": self.name or None,
+                "cite": self.best_human_identifier or None,
+                "court": self.court or None,
+                "date": checked_date,
+                "uri": self.uri,
+            },
         }
 
         request_parse(

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -16,14 +16,17 @@ from typing_extensions import NotRequired
 env = environ.Env()
 
 
-class ParserInstructionsDict(TypedDict):
+class ParserInstructionsMetadataDict(TypedDict):
     name: NotRequired[Optional[str]]
     cite: NotRequired[Optional[str]]
     court: NotRequired[Optional[str]]
     date: NotRequired[Optional[str]]
     uri: NotRequired[Optional[str]]
+
+
+class ParserInstructionsDict(TypedDict):
     documentType: NotRequired[Optional[str]]
-    published: NotRequired[bool]
+    metadata: NotRequired[ParserInstructionsMetadataDict]
 
 
 @overload

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -17,11 +17,11 @@ env = environ.Env()
 
 
 class ParserInstructionsMetadataDict(TypedDict):
-    name: NotRequired[Optional[str]]
-    cite: NotRequired[Optional[str]]
-    court: NotRequired[Optional[str]]
-    date: NotRequired[Optional[str]]
-    uri: NotRequired[Optional[str]]
+    name: Optional[str]
+    cite: Optional[str]
+    court: Optional[str]
+    date: Optional[str]
+    uri: Optional[str]
 
 
 class ParserInstructionsDict(TypedDict):

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -697,10 +697,8 @@ class TestDocumentMetadata:
         assert returned_message == {
             "properties": {
                 "messageType": "uk.gov.nationalarchives.da.messages.request.courtdocument.parse.RequestCourtDocumentParse",
-                # "timestamp":
                 "function": "fcl-judgment-parse-request",
                 "producer": "FCL",
-                # "executionId":
                 "parentExecutionId": None,
             },
             "parameters": {
@@ -709,13 +707,14 @@ class TestDocumentMetadata:
                 "reference": "TDR-12345",
                 "originator": "FCL",
                 "parserInstructions": {
-                    "name": None,
-                    "cite": None,
-                    "court": None,
-                    "date": None,
-                    "uri": "test/2023/123",
                     "documentType": "judgment",
-                    "published": False,
+                    "metadata": {
+                        "name": None,
+                        "cite": None,
+                        "court": None,
+                        "date": None,
+                        "uri": "test/2023/123",
+                    },
                 },
             },
         }
@@ -738,10 +737,8 @@ class TestDocumentMetadata:
         assert returned_message == {
             "properties": {
                 "messageType": "uk.gov.nationalarchives.da.messages.request.courtdocument.parse.RequestCourtDocumentParse",
-                # "timestamp":
                 "function": "fcl-judgment-parse-request",
                 "producer": "FCL",
-                # "executionId":
                 "parentExecutionId": None,
             },
             "parameters": {
@@ -750,13 +747,14 @@ class TestDocumentMetadata:
                 "reference": "TDR-12345",
                 "originator": "FCL",
                 "parserInstructions": {
-                    "name": "Judgment v Judgement",
-                    "cite": "[2023] Test 123",
-                    "court": "Court of Testing",
-                    "date": "2023-02-03",
-                    "uri": "test/2023/123",
                     "documentType": "judgment",
-                    "published": True,
+                    "metadata": {
+                        "name": "Judgment v Judgement",
+                        "cite": "[2023] Test 123",
+                        "court": "Court of Testing",
+                        "date": "2023-02-03",
+                        "uri": "test/2023/123",
+                    },
                 },
             },
         }


### PR DESCRIPTION
Remove "published" as a thing that we send, we should check locally on import.
Reformat to nested format.