### PR TITLE
Function to get current schema XML text

### DIFF
--- a/smoketest/smoketest.py
+++ b/smoketest/smoketest.py
@@ -45,7 +45,11 @@ def test_get_version_annotation():
     assert Document(FIRST_VERSION_URI, api_client).annotation == "this is an annotation"
 
 
-@pytest.mark.write
-def test_get_highest_enrichment_version():
-    value = api_client.get_highest_enrichment_version()
-    assert int(value)
+# @pytest.mark.write
+# def test_get_highest_enrichment_version():
+#     value = api_client.get_highest_enrichment_version()
+#     assert int(value)
+
+
+def test_get_schema():
+    assert "tna-enrichment-engine" in api_client.get_schema("/caselaw.xsd")

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1017,3 +1017,17 @@ class MarklogicApiClient:
         )
 
         return results
+
+    def get_schema(self, schema_uri: str) -> str:
+        """Retrieve contents of schema from the schema database."""
+        vars: query_dicts.GetSchema = {
+            "schema_uri": schema_uri,
+        }
+        results: str = get_single_string_from_marklogic_response(
+            self._send_to_eval(
+                vars,
+                "get_schema.xqy",
+            )
+        )
+
+        return results

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -101,6 +101,11 @@ class GetPropertyDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString
 
 
+# get_schema.xqy
+class GetSchemaDict(MarkLogicAPIDict):
+    schema_uri: MarkLogicDocumentURIString
+
+
 # get_version_annotation.xqy
 class GetVersionAnnotationDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString


### PR DESCRIPTION
Doesn't work because it doesn't have the required priviledge, I think
from https://docs.marklogic.com/xdmp:eval 
 
> To use the database option to specify a content database other than the default database for the current App Server, you must have the following privilege: http://marklogic.com/xdmp/privileges/xdmp-eval-in