### PR TITLE
Fix datetime bug in last_enriched/last_parsed

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -464,9 +464,9 @@ class Document:
         """
         Request enrichment of the document
         """
-
+        now = datetime.datetime.now(datetime.timezone.utc)
         self.api_client.set_property(
-            self.uri, "last_sent_to_enrichment", datetime.datetime.now().isoformat()
+            self.uri, "last_sent_to_enrichment", now.isoformat()
         )
 
         announce_document_event(
@@ -536,9 +536,8 @@ class Document:
     def reparse(self) -> None:
         "Send an SNS notification that triggers reparsing, also sending all editor-modifiable metadata and URI"
 
-        self.api_client.set_property(
-            self.uri, "last_sent_to_parser", datetime.datetime.now().isoformat()
-        )
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
 
         parser_type_noun = {"judgment": "judgment", "press summary": "pressSummary"}[
             self.document_noun

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -421,7 +421,7 @@ class TestDocumentEnrich:
         document.enrich()
 
         mock_api_client.set_property.assert_called_once_with(
-            "test/1234", "last_sent_to_enrichment", "1955-11-05T06:00:00"
+            "test/1234", "last_sent_to_enrichment", "1955-11-05T06:00:00+00:00"
         )
 
         mock_announce_document_event.assert_called_once_with(
@@ -697,7 +697,7 @@ class TestDocumentMetadata:
         Judgment.reparse(document)
 
         mock_api_client.set_property.assert_called_once_with(
-            "test/2023/123", "last_sent_to_parser", "1955-11-05T06:00:00"
+            "test/2023/123", "last_sent_to_parser", "1955-11-05T06:00:00+00:00"
         )
 
         # first call, second argument (the kwargs), so [0][1]
@@ -744,7 +744,7 @@ class TestDocumentMetadata:
         Judgment.reparse(document)
 
         mock_api_client.set_property.assert_called_once_with(
-            "test/2023/123", "last_sent_to_parser", "1955-11-05T06:00:00"
+            "test/2023/123", "last_sent_to_parser", "1955-11-05T06:00:00+00:00"
         )
 
         # first call, second argument (the kwargs), so [0][1]


### PR DESCRIPTION
## Changes in this PR:

Discovered while running the tests while in GMT+1 - we should probably persist these dates in a timezone-agnostic format
