### PR TITLE
Make the PR template more useful

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary of changes
+
+<!-- Replace this with a short summary of changes in this PR -->
+
+## Checklist
+
+- [ ] I have created/updated method docstrings (if necessary)
+- [ ] I have considered if this is a breaking change
+- [ ] I have updated the changelog (if necessary)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,0 @@
-<!-- Amend as appropriate -->
-
-## Changes in this PR:
-
-## Trello card / Rollbar error (etc)
-
-<!-- Have you updated the changelog? -->
-
-- [ ] Requires env variable(s) to be updated


### PR DESCRIPTION
## Summary of changes

The old PR template wasn't particularly helpful, and was regularly just being wiped.

This replaces it with a new one, which uses the checklist to guide people through necessary considerations so that things aren't missed. It also moves it to the `.github` directory so it's not cluttering the root.

## Checklist

- [x] I have created/updated method docstrings as necessary
- [x] I have considered if this is a breaking change
