### PR TITLE
(1695) Don't enrich when the document does not validate against a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+- Add an `enriched_recently` property
+- Add a `validates_against_schema` property
+- Add a `can_enrich` property
+- Only enrich if not recently enriched and valid against current schema
+
 ## [Release 22.0.2]
 
 - Add a method to allow fetching press summaries for a given document

--- a/smoketest/smoketest.py
+++ b/smoketest/smoketest.py
@@ -56,3 +56,13 @@ def test_get_press_summaries_for_document_uri():
     result = api_client.get_press_summaries_for_document_uri("/uksc/2023/35")
     assert len(result) == 1
     assert result[0].uri == "uksc/2023/35/press-summary/1"
+
+
+@pytest.mark.write
+@pytest.mark.parametrize(
+    "document_uri,validates_against_schema",
+    [("/ewca/civ/2004/632", False), ("/eat/2023/38", True)],
+)
+def test_invalid_document_is_invalid(document_uri, validates_against_schema):
+    document = api_client.get_document_by_uri(document_uri)
+    assert document.validates_against_schema is validates_against_schema

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -647,6 +647,22 @@ class MarklogicApiClient:
 
         return self._send_to_eval(vars, "get_judgment_version.xqy")
 
+    def validate_document(self, document_uri: DocumentURIString) -> bool:
+        vars: query_dicts.ValidateDocumentDict = {
+            "uri": self._format_uri_for_marklogic(document_uri)
+        }
+        response = self._send_to_eval(vars, "validate_document.xqy")
+        content = decoder.MultipartDecoder.from_response(response).parts[0].text
+        xml = ElementTree.fromstring(content)
+        return (
+            len(
+                xml.findall(
+                    ".//error:error", {"error": "http://marklogic.com/xdmp/error"}
+                ),
+            )
+            == 0
+        )
+
     def eval(
         self, xquery_path: str, vars: str, accept_header: str = "multipart/mixed"
     ) -> requests.Response:

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -517,6 +517,13 @@ class Document:
             return True
         return False
 
+    @cached_property
+    def validates_against_schema(self) -> bool:
+        """
+        Does the document validate against the most recent schema?
+        """
+        return self.api_client.validate_document(self.uri)
+
     def publish(self) -> None:
         """
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as

--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -511,9 +511,18 @@ class Document:
         """
         Is it sensible to enrich this document?
         """
+        if (self.enriched_recently is False) and self.validates_against_schema:
+            return True
+        return False
+
+    @cached_property
+    def enriched_recently(self) -> bool:
+        """
+        Has this document been enriched recently?
+        """
         last_enrichment = self.enrichment_datetime
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        if last_enrichment and now - last_enrichment > MINIMUM_ENRICHMENT_TIME:
+        if last_enrichment and now - last_enrichment < MINIMUM_ENRICHMENT_TIME:
             return True
         return False
 

--- a/src/caselawclient/xquery/validate_document.xqy
+++ b/src/caselawclient/xquery/validate_document.xqy
@@ -1,0 +1,7 @@
+xquery version "1.0-ml";
+
+declare variable $uri as xs:string external;
+
+let $judgment := fn:document($uri)
+
+return xdmp:validate($judgment)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -211,6 +211,11 @@ class UserHasRoleDict(MarkLogicAPIDict):
     user: str
 
 
+# validate_document.xqy
+class ValidateDocumentDict(MarkLogicAPIDict):
+    uri: MarkLogicDocumentURIString
+
+
 # xslt.xqy
 class XsltDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString

--- a/tests/client/test_validate_document.py
+++ b/tests/client/test_validate_document.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+
+from caselawclient.Client import MarklogicApiClient
+
+
+class TestValidateDocument(unittest.TestCase):
+    def setUp(self):
+        self.client = MarklogicApiClient("", "", "", False)
+
+    def test_validation_success(self):
+        with patch.object(self.client, "eval") as mock_eval:
+            mock_eval.return_value.text = "true"
+            mock_eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=c878f7cb55370005"
+            }
+            mock_eval.return_value.content = (
+                b"\r\n--c878f7cb55370005\r\n"
+                b"Content-Type: application/xml\r\n"
+                b"X-Primitive: element()\r\n"
+                b"X-Path: /xdmp:validation-errors\r\n\r\n"
+                b'<xdmp:validation-errors xmlns:xdmp="http://marklogic.com/xdmp"/>\r\n'
+                b"--c878f7cb55370005--\r\n"
+            )
+
+            assert self.client.validate_document("/foo/bar/123") is True
+
+    def test_validation_failure(self):
+        with patch.object(self.client, "eval") as mock_eval:
+            mock_eval.return_value.text = "true"
+            mock_eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=c878f7cb55370005"
+            }
+            mock_eval.return_value.content = (
+                b"\r\n--c878f7cb55370005\r\n"
+                b"Content-Type: application/xml\r\n"
+                b"X-Primitive: element()\r\n"
+                b"X-Path: /xdmp:validation-errors\r\n\r\n"
+                b'<xdmp:validation-errors xmlns:xdmp="http://marklogic.com/xdmp">'
+                b'<error:error xmlns:error="http://marklogic.com/xdmp/error" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+                b"<error:code>XDMP-VALIDATEUNEXPECTED"
+                b"</error:code>"
+                b"<error:name>err:XQDY0027"
+                b"</error:name>"
+                b"<error:xquery-version>1.0-ml"
+                b"</error:xquery-version>"
+                b"<error:message>Invalid node"
+                b"</error:message>"
+                b'<error:format-string>XDMP-VALIDATEUNEXPECTED: (err:XQDY0027) validate full { () } -- Invalid node: Found {http://docs.oasis-open.org/legaldocml/ns/akn/3.0}badger but expected ({http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRWork,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRExpression,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRManifestation,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRItem?) at fn:doc("/ewca/civ/2004/632.xml")/*:akomaNtoso/*:judgment/*:meta/*:identification/*:badger using schema "/akn-modified.xsd"'
+                b"</error:format-string>"
+                b"<error:retryable>false"
+                b"</error:retryable>"
+                b"<error:expr>validate full { () }"
+                b"</error:expr>"
+                b"<error:data></error:data>"
+                b"<error:stack></error:stack>"
+                b"</error:error>"
+                b"</xdmp:validation-errors>\r\n"
+                b"--c878f7cb55370005--\r\n"
+            )
+
+            assert self.client.validate_document("/foo/bar/123") is False

--- a/tests/client/test_validate_document.py
+++ b/tests/client/test_validate_document.py
@@ -38,22 +38,6 @@ class TestValidateDocument(unittest.TestCase):
                 b"X-Path: /xdmp:validation-errors\r\n\r\n"
                 b'<xdmp:validation-errors xmlns:xdmp="http://marklogic.com/xdmp">'
                 b'<error:error xmlns:error="http://marklogic.com/xdmp/error" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
-                b"<error:code>XDMP-VALIDATEUNEXPECTED"
-                b"</error:code>"
-                b"<error:name>err:XQDY0027"
-                b"</error:name>"
-                b"<error:xquery-version>1.0-ml"
-                b"</error:xquery-version>"
-                b"<error:message>Invalid node"
-                b"</error:message>"
-                b'<error:format-string>XDMP-VALIDATEUNEXPECTED: (err:XQDY0027) validate full { () } -- Invalid node: Found {http://docs.oasis-open.org/legaldocml/ns/akn/3.0}badger but expected ({http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRWork,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRExpression,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRManifestation,{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRItem?) at fn:doc("/ewca/civ/2004/632.xml")/*:akomaNtoso/*:judgment/*:meta/*:identification/*:badger using schema "/akn-modified.xsd"'
-                b"</error:format-string>"
-                b"<error:retryable>false"
-                b"</error:retryable>"
-                b"<error:expr>validate full { () }"
-                b"</error:expr>"
-                b"<error:data></error:data>"
-                b"<error:stack></error:stack>"
                 b"</error:error>"
                 b"</xdmp:validation-errors>\r\n"
                 b"--c878f7cb55370005--\r\n"

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -261,6 +261,15 @@ class TestDocument:
 
         assert document.number_of_mentions("some") == 2
 
+    def test_validates_against_schema(self, mock_api_client):
+        mock_api_client.validate_document.return_value = True
+
+        document = Document("test/1234", mock_api_client)
+
+        assert document.validates_against_schema is True
+
+        mock_api_client.validate_document.assert_called_with(document.uri)
+
 
 class TestDocumentValidation:
     def test_judgment_is_failure(self, mock_api_client):


### PR DESCRIPTION
This adds a `validates_against_schema` property to a document, and adds the logic to `can_enrich` to return true if a document was not recently enriched AND it passes schema validation.