### PR TITLE
Get linked document inside Document class

### DIFF
--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -1,10 +1,17 @@
-from functools import cached_property
-from typing import Any
+from __future__ import annotations
 
+import importlib
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, Optional
+
+from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 from caselawclient.xml_helpers import get_xpath_match_string
 
 from .documents import Document
+
+if TYPE_CHECKING:
+    from caselawclient.models.judgments import Judgment
 
 
 class PressSummary(NeutralCitationMixin, Document):
@@ -31,3 +38,18 @@ class PressSummary(NeutralCitationMixin, Document):
     @property
     def best_human_identifier(self) -> str:
         return self.neutral_citation
+
+    @cached_property
+    def linked_document(self) -> Optional["Judgment"]:
+        """
+        Attempt to fetch a linked judgement, and return it, if it exists
+        """
+        try:
+            uri = self.uri.removesuffix("/press-summary/1")
+            Judgment = getattr(
+                importlib.import_module("caselawclient.models.judgments"),
+                "Judgment",
+            )
+            return Judgment(uri, self.api_client)  # type: ignore
+        except DocumentNotFoundError:
+            return None

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -108,3 +108,7 @@ class SearchResultFactory(SimpleFactory):
 
 class JudgmentFactory(DocumentFactory):
     pass
+
+
+class PressSummaryFactory(DocumentFactory):
+    pass

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -1,6 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 
+from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.judgments import Judgment
+from tests.factories import PressSummaryFactory
 
 
 class TestJudgment:
@@ -92,3 +96,26 @@ class TestJudgmentValidation:
                 "The court for this judgment is not valid",
             ]
         )
+
+
+class TestLinkedDocuments:
+    @patch("caselawclient.models.press_summaries.PressSummary")
+    def test_linked_document(self, document_mock, mock_api_client):
+        press_summary = PressSummaryFactory.build()
+        document_mock.return_value = press_summary
+
+        judgment = Judgment("/test/1234", mock_api_client)
+
+        assert judgment.linked_document == press_summary
+        document_mock.assert_called_once_with(
+            "test/1234/press-summary/1", mock_api_client
+        )
+
+    @patch("caselawclient.models.press_summaries.PressSummary")
+    def test_linked_document_returns_nothing_when_does_not_exist(
+        self, document_mock, mock_api_client
+    ):
+        document_mock.side_effect = DocumentNotFoundError()
+
+        judgment = Judgment("/test/1234", mock_api_client)
+        assert judgment.linked_document is None


### PR DESCRIPTION
This adds the logic to get a linked document to the individual document class. At the moment this is done in the Public UI, which

a) Is hard to mock; and
b) Gives us more to do at the UI end

Keeping the responsibility in the client makes the behaviour more predictable, as well as means we have a “real” document object to get things like the title etc from.

I’ve had to do some jiggery pokery to avoid cyclic imports and return the correct document type, but the tests seem happy