### PR TITLE
Bump version v22.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+## [Release 22.1.0]
+
 - Add an `enriched_recently` property
 - Add a `validates_against_schema` property
 - Add a `can_enrich` property
 - Only enrich if not recently enriched and valid against current schema
+- Allow fetching linked docuements for `Judgement`s and `PressSummary`s
 
 ## [Release 22.0.2]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "22.0.2"
+version = "22.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## Summary of changes

- Add an `enriched_recently` property
- Add a `validates_against_schema` property
- Add a `can_enrich` property
- Only enrich if not recently enriched and valid against current schema
- Allow fetching linked docuements for `Judgement`s and `PressSummary`s

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
