### PR TITLE
Always set last sent to parser

### DIFF
--- a/src/caselawclient/models/documents.py
+++ b/src/caselawclient/models/documents.py
@@ -635,6 +635,10 @@ class Document:
         )
 
     def reparse(self) -> bool:
+        # note that we set 'last_sent_to_parser' even if we can't send it to the parser
+        # it means 'last tried to reparse' much more consistently.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
         if self.can_reparse:
             self.force_reparse()
             return True

--- a/tests/models/test_documents.py
+++ b/tests/models/test_documents.py
@@ -979,3 +979,25 @@ class TestReparse:
                 },
             },
         }
+
+    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29))
+    def test_reparse_sets_last_sent_if_no_docx(self, mock_api_client):
+        document = JudgmentFactory().build(is_published=True)
+        document.api_client = mock_api_client
+        document.can_reparse = False
+        assert Judgment.reparse(document) is False
+        mock_api_client.set_property.assert_called_once_with(
+            "test/2023/123", "last_sent_to_parser", "2015-10-21T16:29:00+00:00"
+        )
+
+    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29))
+    def test_reparse_sets_last_sent_if_docx(self, mock_api_client):
+        document = JudgmentFactory().build(is_published=True)
+        document.api_client = mock_api_client
+        document.can_reparse = True
+        assert Judgment.reparse(document) is True
+        # set_property is only called once because document.reparse isn't real
+        assert "Mock" in str(type(document.reparse))
+        mock_api_client.set_property.assert_called_once_with(
+            "test/2023/123", "last_sent_to_parser", "2015-10-21T16:29:00+00:00"
+        )


### PR DESCRIPTION
Whilst changing the editor to send at least one document with the crontab, discovered that the process will fail because if a document is rejected (e.g. doesn't have a docx) it never gets the "I tried to send" message.

(We did never send this to the parser, though...)

"We should rename all occurances of last_sent_to_parser" is a fair comment; this would involve changing sql_properties_extract in marklogic and get_pending_parse_for_version.xqy in this repo.