### PR TITLE
[FCL-176] Tooling configuration audit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '30 13 * * 6'
+    - cron: "30 13 * * 6"
 
 jobs:
   analyze:
@@ -32,43 +32,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: ["python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 __pypackages__
 .coverage
 .gradle
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,20 @@
 exclude: "src/caselawclient/xquery"
-default_stages: [commit]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
     rev: 24.4.2
@@ -39,7 +46,8 @@ repos:
     hooks:
       - id: mypy
         name: mypy-src
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
+        additional_dependencies:
+          [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
         files: ^src/
         args: ["--strict"]
 
@@ -49,11 +57,6 @@ repos:
     hooks:
       - id: mypy
         name: mypy-tests
-        additional_dependencies: [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
+        additional_dependencies:
+          [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
         files: ^tests/
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-  autoupdate_schedule: weekly
-  skip: []
-  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,22 +16,10 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
     hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        args: ["--config=setup.cfg"]
+      - id: ruff-format
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
         additional_dependencies:
           [types-requests, "boto3-stubs[s3,sns]", "types-python-dateutil"]
         files: ^tests/
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [yaml, json, xml, markdown, scss, javascript]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ The format is based on [Keep a Changelog 1.0.0].
 ## Unreleased
 
 ## [Release 23.0.2]
+
 - Remove explicit urllib3 v1 dependency, rely on implicit dependency only
 
 ## [Release 23.0.1]
 
-- Remove fcl_ex_id_ prefix from UUID of reparse execution ID
+- Remove fcl*ex_id* prefix from UUID of reparse execution ID
 - Implement handling of facets received from MarkLogic search results
 
 ## [Release 22.1.0]
@@ -67,12 +68,13 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Feature:** `Document.enrich()` method will send a message to the announce SNS, requesting that a document be enriched.
 
 ## [Release 17.2.0]
+
 - `document.content_as_html` now takes an optional `query=` string parameter, which, when supplied, highlights instances of the query within the document with `<mark>` tags, each of which has a numbered id indicating its sequence in the document.
 - `document.number_of_mentions` method which takes a `query=` string parameter, and returns the number of highlighted mentions in the html.
 
 ## [Release 17.1.0]
-- New `Client.get_combined_stats_table` method to run a combined statistics query against MarkLogic.
 
+- New `Client.get_combined_stats_table` method to run a combined statistics query against MarkLogic.
 
 ## [Release 17.0.0]
 
@@ -87,9 +89,11 @@ The format is based on [Keep a Changelog 1.0.0].
 - BREAKING: All annotations for versions are now mandatory instances of the new `VersionAnnotation` class
 
 ## [Release 15.1.2]
+
 - Expose the creation date of a version
 
 ## [Release 15.1.1]
+
 - Get version annotation for a single document
 - Expose the type of the latest manifestation date of a document
 
@@ -100,6 +104,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Latest manifestation datetime is available for documents (including versions)
 
 ## [Release 15.0.1]
+
 - Bugfix: document_date_as_date shouldn't fail hard if we can't parse it.
 
 ## [Release 15.0.0]
@@ -136,10 +141,12 @@ The format is based on [Keep a Changelog 1.0.0].
 - Generalised the set judgment metadata methods to set document metadata methods specifically for name, court and date.
 
 ## [Release 13.2.1]
- - Fix issues blocking push to PyPI
+
+- Fix issues blocking push to PyPI
 
 ## [Release 13.2.0]
- - Add a "Best human identifier" to Documents
+
+- Add a "Best human identifier" to Documents
 
 ## [Release 13.1.0]
 
@@ -157,8 +164,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - supplemental/anonymous/sensitive getters/setters removed
 - XQueries which return multiple responses will raise an error
 
-
-- Refactored `Document` class' `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously judgment_date_...) on Document class and neutral_citation on Judgment class making use of the new cached `content_as_xml_tree` property.
+- Refactored `Document` class' `name`, `court`, `document_date_as_string` and `document_date_as_date` (previously judgment*date*...) on Document class and neutral_citation on Judgment class making use of the new cached `content_as_xml_tree` property.
 - Renamed `judgment_date_as_string` `judgment_date_as_date` to `document_date_as_string` and `document_date_as_date` respectively.
 - Added `content_as_xml_tree` cached property to `Document` class
 - Changed the `Document` class' `content_as_xml` to be a cached_property also. [Note: this changelog line previously mistakenly referred to `content_as_html`.]
@@ -176,6 +182,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - Check for a valid court, rather than an present one
 - Trim whitespace when trying to set an NCN
+
 ## [Release 11.0.0]
 
 - **Breaking**: Renamed `copy_judgment` to `copy_document`
@@ -186,22 +193,27 @@ The format is based on [Keep a Changelog 1.0.0].
 - `Judgment.validation_failure_messages` method for retrieving a list of strings with reasons a judgment cannot be published.
 
 ## [Release 10.0.1]
+
 - Fixed `insert_document_xml` to pattern match uris with and add documents to `press-summary`, not `press_summary`.
 
 ## [Release 10.0.0]
+
 - **BREAKING**: Renamed `insert_judgment_xml` to `insert_document_xml` and enhanced it to place a document in the appropriate collection (`press_summary` or `judgment`)
 
 ## [Release 9.0.0]
+
 - **BREAKING**: Changed `SearchParameters` dataclass field from `q` to `query`
 - Added `search_helpers` module to allow clients to search and process document search responses in one go.
 
 ## [Release 8.0.0]
+
 - Added `SearchParameters` dataclass for use with search functions using the legacy kwargs from `Client.advanced_search` and new `collections` field for filtering by collections
 - **BREAKING**: Changed `Client.advanced_search` interface to take in `SearchParameters` as opposed to the legacy kwargs.
 - Added `search_and_decode_response` and `search_judgments_and_decode_response` methods to `Client`
 - Added `SearchResponse`, `SearchResult`, `SearchResultMetadata` classes to encapsulate and process document search responses.
 
 ## [Release 7.0.0]
+
 - **BREAKING**: Instantiating a`Judgment` object will now raise a `caselawclient.errors.JudgmentNotFoundError` if the uri passed in does not correspond to a valid Judgment, rather than attempting (and failing) to return a `MarklogicResourceNotFoundError`
 - Added `judgment_exists` method to `Client` class
 - Make version_uri optional in Judgment.content_as_html
@@ -210,80 +222,100 @@ The format is based on [Keep a Changelog 1.0.0].
 - Unlock judgment on Judgment.unpublish() so editors can unpublish immediately after a publish
 
 ## [Release 6.1.0]
+
 - `Judgment.publish` method will now reject publication in more invalid states (must have a name, must have a valid NCN, must have a court code).
 - Less strict version pinning of dependencies to give downstream package users more flexibility in resolving.
 
 ## [Release 6.0.0]
+
 - Significantly more type annotations on `Client` and `Judgment` methods, including some which are stricter than before.
-  This is potentially a *breaking change* if implementations have been relying on duck typing.
+  This is potentially a _breaking change_ if implementations have been relying on duck typing.
 - Automatic generation of strict typing for XQuery files which run against MarkLogic.
 - Improvements to the methods used in content hashing, which will be breaking changes if these are used downstream.
 
 ## [Release 5.3.2]
+
 - Correct import location used in Judgment model, so it's usable when packaged
 
 ## [Release 5.3.1]
+
 - Fix broken build process
 
 ## [Release 5.3.0] (Yanked)
+
 - Dependabot now updates dependencies for all new versions, not just security updates
 - Use Poetry for dependency management, to improve robustness
 - Add a `Judgment` class (copied from Editor Interface) to begin the process of harmonising how various services interface with the data
 
 ## [Release 5.2.6]
+
 - Add code coverage reporting to CI
 - Make a PEP-561 declaration of typing
 
 ## [Release 5.2.5]
+
 - Re-add the code that was pointing the XSLT to the assets
 
 ## [Release 5.2.4]
+
 - This release had a bug, fixed by 5.2.5
 - HTML view: Do not default to current version if the version doesn't exist (cause an error instead)
 
 ## [Release 5.2.3]
+
 - Add content hash validation when we save a locked judgment
 
 ## [Release 5.2.2]
+
 - Bug fix: setting court was not valid XQuery in eval context
 
 ## [Release 5.2.1]
+
 - Improvements to code linting
 - Expose hash of judgment content
 - Unset the court tag where the court is an empty string
 
 ## [Release 5.2.0]
+
 - Clarify release process documentation
 - Add pypi version badge and libraries.io dependency shield
 - Expose MarklogicValidationFailed exception
 
 ## [Release 5.1.4]
+
 - Validate against a schema when priv API document is uploaded
 - Add CodeQL configuration
 - Add a check for secrets
 - Bump certifi from 2021.10.8 to 2022.12.7
 
 ## [Release 5.1.3]
+
 - Don't crash if multipart data is actually an empty bytestring.
 
 ## [Release 5.1.2]
+
 ** This release had a bug where the Editor UI was unusable. **
+
 - Ensure Work Date and Court values are returned as text
 
 ## [Release 5.1.1]
+
 - Get properties for a range of URIs for use in search results
 
 ## [Release 5.1.0]
+
 - Remove a debug `print()` statement that was missed
 - Admin users can't read unpublished judgments
 - Deprecate XMLTools methods
 - Fix `TypeError: 'type' object is not subscriptable`
 
 ## [Release 5.0.0]
+
 - Breaking change: passes a list of zero-or-more courts, rather than a string that might be empty.
 - Search queries: pages less than one are treated as one
 
 ## [Release 4.10.0]
+
 - Add linting
 - Ensure only people who are allowed to view unpublished judgments can view them
 - Refactor tests
@@ -294,6 +326,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Speed up privilege checking
 
 ## [Release 4.9.2]
+
 - Add user_has_privilege method & XQuery to check if a user has a privilege
 - Use `user_has_privilege` to check if a user can see unpublished documents
 - Move error message codes and messages into this client
@@ -301,6 +334,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - New function to save XML for a locked judgment
 
 ## [Release 4.9.1]
+
 - Fix: add external declaration to XQuery parameter
 - Bump version of requests to 2.28.1
 - Raise error if unpublished document is not returned
@@ -308,24 +342,29 @@ The format is based on [Keep a Changelog 1.0.0].
 - Return none if the judgment is not locked, rather than an empty string
 
 ## [Release 4.9.0]
+
 - Add optional annotation parameter to `checkout_judgment` method
 - Add method to get the lock/checkout status of a judgment
 - Judgment checkout may optionally expire at midnight
 
 ## [Release 4.8.0]
+
 - Gracefully handle a null, empty or unexpected error response from Marklogic
 - Rename set_judgment_date to set_judgment_work_expression_date
 - Update the FRBRWork and FRBRExpression dates and @name attributes
 
 ## [Release 4.7.1]
+
 - Fix a typo in setting the internal URI of a judgment
 
 ## [Release 4.7.0]
+
 - Change the XQuery delete method from xdmp:document-delete to dls:document-delete
 - Change the behaviour of 'last-modified' dates to use prop:last-modified rather than xdmp:document-timestamp
 - Set the judgment's internal URI (`FRBRthis` and `FRBRuri` nodes)
 
 ## [Release 4.6.0]
+
 - Allow the xsl filename used in the judgment transformation to vary. We have two xsls available in Marklogic -
   `judgment2` (the accessible version) and `judgment0` (the "as handed down" version). Add two helper methods
   `accessible_judgment_transformation()` and `original_judgment_transformation()` to call these transformations without
@@ -333,58 +372,75 @@ The format is based on [Keep a Changelog 1.0.0].
 - Copy judgment from URI to URI
 
 ## [Release 4.5.4]
+
 - Adds a new `delete_judgment` endpoint, for deleting a judgment from marklogic
 
 ## [Release 4.5.3]
+
 - Create a new `akn:FRBRdate`, `uk:cite` and `uk:court` nodes for the judgment metadata, if they do not exist
 
 ## [Release 4.5.2]
+
 - Create a new `akn:FRBRname` node for the judgment metadata name, if one does not exist
 
 ## [Release 4.5.1]
+
 - Patch release to update `setup.cfg`, which was missed from v4.5.0
 
 ## [Release 4.5.0]
+
 - Allow metadata elements (name, date, court and citation) to be edited in the XML via XQuery, not by deserialising and
   serialising the XML in the implementing client code.
 
 ## [Release 4.4.0]
+
 - If an element doesn't exist in a document, `xml_tools.get_element` tries to return an empty element with the same
   name as the desired element.
 
 ## [Release 4.3.0]
+
 - Add function to retrieve the last time a document or it's properties was updated
 
 ## [Release 4.2.0]
+
 - Add neutral citation and specific keyword search parameters to advanced search
 
 ## [Release 4.1.0]
+
 - Use error code from eval response body to throw MarklogicResourceNotFound errors
 
 ## [Release 4.0.0]
+
 - Parameterize the location of images in the XSLT transformation
 - Use the `invoke` endpoint, and the `search.xqy` stored on Marklogic, to search
 - Remove the `database` parameter in `eval`, it's not required; the db associated with the REST server is used
 
 ## [Release 3.2.0]
+
 - Add flag to advanced_search to enable filtering out published documents from the search
 
 ## [Release 3.1.0]
+
 - Add function to get and set text properties on a document
 
 ## [Release 3.0.1]
+
 - Fix insert_document xquery to call the document-insert-and-manage function
 
 ## [Release 3.0.0]
+
 - Replace LXML with standard library xml for wider compatibility and reduced build times
 
 ## [Release 2.1.2]
+
 - Add a new anonymised content flag
 
 ## [Release 2.1.1]
+
 - Fix intermittently failing XSLT transforms
 
 ## [Release 2.1.0]
+
 - Refactor save_judgment_xml to use the eval endpoint, so that we can introduce versioning via na XQuery.
 - List all versions of a managed judgment
 - Get a version of a managed judgment
@@ -395,13 +451,16 @@ The format is based on [Keep a Changelog 1.0.0].
 - Use document properties on the "original" version of the judgment, not its version, to see if a judgment is published
 
 ## [Release 2.0.1]
+
 - Minor bugfixes
 
 ## [Release 2.0.0]
+
 - Refactored property accessor methods
 - BREAKING CHANGE `is_document_published` changed to `get_published` and `publish_document` changed to `set_published`.
 
 ## [Release 1.0.5]
+
 - Initial tagged release
 
 [Unreleased]: https://github.com/nationalarchives/ds-caselaw-custom-api-client/compare/v23.0.2...HEAD

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ to main alone will **not** trigger a release to PyPI.
 To create a release:
 
 0. Update the version number in `pyproject.toml`
-0. Create a branch `release/v{major}.{minor}.{patch}`
-0. Update `CHANGELOG.md` for the release
-0. Commit and push
-0. Open a PR from that branch to main
-0. Get approval on the PR
-0. Merge the PR to main and push
-0. Tag the merge commit on `main` with `v{major}.{minor}.{patch}` and push the tag
-0. Create a release in [Github releases](https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases)
-using the created tag
+1. Create a branch `release/v{major}.{minor}.{patch}`
+2. Update `CHANGELOG.md` for the release
+3. Commit and push
+4. Open a PR from that branch to main
+5. Get approval on the PR
+6. Merge the PR to main and push
+7. Tag the merge commit on `main` with `v{major}.{minor}.{patch}` and push the tag
+8. Create a release in [Github releases](https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases)
+   using the created tag

--- a/assertions/assert.py
+++ b/assertions/assert.py
@@ -1,9 +1,8 @@
 import glob
 
 import environ
+from caselawclient import Client
 from dotenv import load_dotenv
-
-import caselawclient.Client as Client
 
 load_dotenv()
 env = environ.Env()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,28 @@ build-backend = "poetry.core.masonry.api"
 markers = [
     "write: the test deliberately changes the Marklogic DB')",
 ]
-
 filterwarnings = ["ignore::DeprecationWarning"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
+extend-select = ["W", "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+                 "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
+                 "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
+unfixable = ["ERA"]
+
+# things skipped:
+# N: naming, possibly good
+# D: docstrings missing throughout
+# ANN: annotations missing throughout
+# FBT: not convinced boolean trap worth auto-banning.
+# CPY: copyright at top of each file
+# G: logging warnings -- fstrings bad?
+# ARG: sometimes you need to accept arguments.
+# TD: somewhat finicky details about formatting TODOs
+# FIX: flags todos: possible to add -- skipped for now
+# ERA: lots of false positives, not a good autofix
+# PD, NPY, AIR: ignored, panda / numpy / airflow specific
+# FURB: not yet out of preview

--- a/script/build_xquery_type_dicts
+++ b/script/build_xquery_type_dicts
@@ -85,12 +85,13 @@ with open(DICTS_FILES_PATCH, "w") as dicts_file:
 
 
 # {xquery_file}
-class {class_name}(MarkLogicAPIDict):"""
+class {class_name}(MarkLogicAPIDict):""",
                 )
 
                 for match in sorted(matches):
                     type_declaration = ml_type_to_python_type_declaration(
-                        variable_name=match[0], variable_type=match[1]
+                        variable_name=match[0],
+                        variable_type=match[1],
                     )
                     dicts_file.write(f"\n    {type_declaration}")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,6 @@ where = src
 [options.package_data]
 caselawclient = xquery/*.xqy
 
-[flake8]
-max-line-length = 999
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
-[pycodestyle]
-max-line-length = 999
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
 [mypy]
 python_version = 3.9
 check_untyped_defs = True

--- a/smoketest/smoketest.py
+++ b/smoketest/smoketest.py
@@ -1,10 +1,9 @@
 import environ
 import pytest
-from dotenv import load_dotenv
-
-import caselawclient.Client as Client
+from caselawclient import Client
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.documents import Document
+from dotenv import load_dotenv
 
 load_dotenv()
 env = environ.Env()
@@ -26,7 +25,7 @@ def test_get_document_type_returns_404():
         assert e.status_code == 404
 
 
-@pytest.mark.write
+@pytest.mark.write()
 def test_set_metadata():
     api_client.set_document_court(URI, "EWHC-Chancellery")
     api_client.set_document_name(URI, "cats v dogs")
@@ -37,28 +36,26 @@ def test_set_metadata():
     assert doc.document_date_as_string == "1001-02-03"
 
 
-@pytest.mark.write
+@pytest.mark.write()
 def test_get_version_annotation():
-    assert (
-        api_client.get_version_annotation(FIRST_VERSION_URI) == "this is an annotation"
-    )
+    assert api_client.get_version_annotation(FIRST_VERSION_URI) == "this is an annotation"
     assert Document(FIRST_VERSION_URI, api_client).annotation == "this is an annotation"
 
 
-@pytest.mark.write
+@pytest.mark.write()
 def test_get_highest_enrichment_version():
     value = api_client.get_highest_enrichment_version()
     assert int(value)
 
 
-@pytest.mark.write
+@pytest.mark.write()
 def test_get_press_summaries_for_document_uri():
     result = api_client.get_press_summaries_for_document_uri("/uksc/2023/35")
     assert len(result) == 1
     assert result[0].uri == "uksc/2023/35/press-summary/1"
 
 
-@pytest.mark.write
+@pytest.mark.write()
 @pytest.mark.parametrize(
     "document_uri,validates_against_schema",
     [("/ewca/civ/2004/632", False), ("/eat/2023/38", True)],

--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -79,12 +79,12 @@ class VersionAnnotation:
         """
         if not self.calling_function:
             raise AttributeError(
-                "The name of the calling function has not been set; use set_calling_function()"
+                "The name of the calling function has not been set; use set_calling_function()",
             )
 
         if not self.calling_agent:
             raise AttributeError(
-                "The name of the calling agent has not been set; use set_calling_agent()"
+                "The name of the calling agent has not been set; use set_calling_agent()",
             )
 
         annotation_data: AnnotationDataDict = {

--- a/src/caselawclient/client_helpers/search_helpers.py
+++ b/src/caselawclient/client_helpers/search_helpers.py
@@ -6,7 +6,8 @@ from caselawclient.search_parameters import SearchParameters
 
 
 def search_judgments_and_parse_response(
-    api_client: MarklogicApiClient, search_parameters: SearchParameters
+    api_client: MarklogicApiClient,
+    search_parameters: SearchParameters,
 ) -> SearchResponse:
     """
     Search for judgments using the given search parameters and parse the response into a SearchResponse object.
@@ -18,14 +19,15 @@ def search_judgments_and_parse_response(
     """
     return SearchResponse(
         etree.fromstring(
-            api_client.search_judgments_and_decode_response(search_parameters)
+            api_client.search_judgments_and_decode_response(search_parameters),
         ),
         api_client,
     )
 
 
 def search_and_parse_response(
-    api_client: MarklogicApiClient, search_parameters: SearchParameters
+    api_client: MarklogicApiClient,
+    search_parameters: SearchParameters,
 ) -> SearchResponse:
     """
     Search using the given search parameters and parse the response into a SearchResponse object.

--- a/src/caselawclient/content_hash.py
+++ b/src/caselawclient/content_hash.py
@@ -23,9 +23,7 @@ def get_hashable_text(doc: bytes) -> bytes:
         "//akn:meta",
         namespaces={"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"},
     )
-    for (
-        metadata
-    ) in metadatas:  # there should be no more than one, but handle zero case gracefully
+    for metadata in metadatas:  # there should be no more than one, but handle zero case gracefully
         metadata.getparent().remove(metadata)
     text = "".join(root.itertext())
     spaceless = re.sub(r"\s", "", text)
@@ -57,6 +55,6 @@ def validate_content_hash(doc: bytes) -> str:
     hash_from_tag = get_hash_from_tag(doc)
     if hash_from_document != hash_from_tag:
         raise InvalidContentHashError(
-            f'Hash of existing tag is "{hash_from_tag}" but the hash of the document is "{hash_from_document}"'
+            f'Hash of existing tag is "{hash_from_tag}" but the hash of the document is "{hash_from_document}"',
         )
     return hash_from_document

--- a/src/caselawclient/errors.py
+++ b/src/caselawclient/errors.py
@@ -60,13 +60,12 @@ class MarklogicValidationFailedError(MarklogicAPIError):
 
 class MarklogicCommunicationError(MarklogicAPIError):
     status_code = 500
-    default_message = (
-        "Something unexpected happened when communicating with the Marklogic server."
-    )
+    default_message = "Something unexpected happened when communicating with the Marklogic server."
 
 
 class GatewayTimeoutError(MarklogicAPIError):
     "This will not contain XML, because it is a failure to connect to the Marklogic server."
+
     status_code = 504
     default_message = "The gateway to MarkLogic timed out."
 
@@ -74,9 +73,7 @@ class GatewayTimeoutError(MarklogicAPIError):
 class InvalidContentHashError(MarklogicAPIError):
     # This error does not come from Marklogic, but is an error raised by this API...
     status_code = 422
-    default_message = (
-        "The content hash in the document did not match the hash of the content"
-    )
+    default_message = "The content hash in the document did not match the hash of the content"
 
 
 class DocumentNotFoundError(MarklogicAPIError):

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -45,10 +45,7 @@ class Judgment(NeutralCitationMixin, Document):
         """
         try:
             uri = self.uri + "/press-summary/1"
-            PressSummary = getattr(
-                importlib.import_module("caselawclient.models.press_summaries"),
-                "PressSummary",
-            )
+            PressSummary = importlib.import_module("caselawclient.models.press_summaries").PressSummary
             return PressSummary(uri, self.api_client)  # type: ignore
         except DocumentNotFoundError:
             return None

--- a/src/caselawclient/models/neutral_citation_mixin.py
+++ b/src/caselawclient/models/neutral_citation_mixin.py
@@ -19,21 +19,18 @@ class NeutralCitationMixin:
     """
 
     def __init__(self, document_noun: str, *args: Any, **kwargs: Any) -> None:
-        self.attributes_to_validate: list[tuple[str, bool, str]] = (
-            self.attributes_to_validate
-            + [
-                (
-                    "has_ncn",
-                    True,
-                    f"This {document_noun} has no neutral citation number",
-                ),
-                (
-                    "has_valid_ncn",
-                    True,
-                    f"The neutral citation number of this {document_noun} is not valid",
-                ),
-            ]
-        )
+        self.attributes_to_validate: list[tuple[str, bool, str]] = self.attributes_to_validate + [
+            (
+                "has_ncn",
+                True,
+                f"This {document_noun} has no neutral citation number",
+            ),
+            (
+                "has_valid_ncn",
+                True,
+                f"The neutral citation number of this {document_noun} is not valid",
+            ),
+        ]
 
         super(NeutralCitationMixin, self).__init__(*args, **kwargs)
 

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -40,16 +40,13 @@ class PressSummary(NeutralCitationMixin, Document):
         return self.neutral_citation
 
     @cached_property
-    def linked_document(self) -> Optional["Judgment"]:
+    def linked_document(self) -> Optional[Judgment]:
         """
         Attempt to fetch a linked judgement, and return it, if it exists
         """
         try:
             uri = self.uri.removesuffix("/press-summary/1")
-            Judgment = getattr(
-                importlib.import_module("caselawclient.models.judgments"),
-                "Judgment",
-            )
+            Judgment = importlib.import_module("caselawclient.models.judgments").Judgment
             return Judgment(uri, self.api_client)  # type: ignore
         except DocumentNotFoundError:
             return None

--- a/src/caselawclient/models/utilities/move.py
+++ b/src/caselawclient/models/utilities/move.py
@@ -36,15 +36,15 @@ def overwrite_document(
 
     if new_uri == source_uri:
         raise RuntimeError(
-            f"Attempted to overwrite document {source_uri} with itself, which is not permitted."
+            f"Attempted to overwrite document {source_uri} with itself, which is not permitted.",
         )
     if new_uri is None:
         raise NeutralCitationToUriError(
-            f"Unable to form new URI for {source_uri} from neutral citation: {target_citation}"
+            f"Unable to form new URI for {source_uri} from neutral citation: {target_citation}",
         )
     if not api_client.document_exists(new_uri):
         raise OverwriteJudgmentError(
-            f"The URI {new_uri} generated from {target_citation} does not already exist, so cannot be overwritten"
+            f"The URI {new_uri} generated from {target_citation} does not already exist, so cannot be overwritten",
         )
     old_doc = api_client.get_document_by_uri_or_404(source_uri)
     try:
@@ -60,14 +60,14 @@ def overwrite_document(
         api_client.set_judgment_this_uri(new_uri)
     except MarklogicAPIError as e:
         raise OverwriteJudgmentError(
-            f"Failure when attempting to copy judgment from {source_uri} to {new_uri}: {e}"
+            f"Failure when attempting to copy judgment from {source_uri} to {new_uri}: {e}",
         )
 
     try:
         api_client.delete_judgment(source_uri)
     except MarklogicAPIError as e:
         raise OverwriteJudgmentError(
-            f"Failure when attempting to delete judgment from {source_uri}: {e}"
+            f"Failure when attempting to delete judgment from {source_uri}: {e}",
         )
 
     return new_uri
@@ -86,13 +86,13 @@ def update_document_uri(source_uri: str, target_citation: str, api_client: Any) 
     new_uri: Optional[str] = caselawutils.neutral_url(target_citation.strip())
     if new_uri is None:
         raise NeutralCitationToUriError(
-            f"Unable to form new URI for {source_uri} from neutral citation: {target_citation}"
+            f"Unable to form new URI for {source_uri} from neutral citation: {target_citation}",
         )
 
     if api_client.document_exists(new_uri):
         raise MoveJudgmentError(
             f"The URI {new_uri} generated from {target_citation} already exists, you cannot move this judgment to a"
-            f" pre-existing Neutral Citation Number."
+            f" pre-existing Neutral Citation Number.",
         )
 
     try:
@@ -102,14 +102,14 @@ def update_document_uri(source_uri: str, target_citation: str, api_client: Any) 
         api_client.set_judgment_this_uri(new_uri)
     except MarklogicAPIError as e:
         raise MoveJudgmentError(
-            f"Failure when attempting to copy judgment from {source_uri} to {new_uri}: {e}"
+            f"Failure when attempting to copy judgment from {source_uri} to {new_uri}: {e}",
         )
 
     try:
         api_client.delete_judgment(source_uri)
     except MarklogicAPIError as e:
         raise MoveJudgmentError(
-            f"Failure when attempting to delete judgment from {source_uri}: {e}"
+            f"Failure when attempting to delete judgment from {source_uri}: {e}",
         )
 
     return new_uri
@@ -120,7 +120,8 @@ def set_metadata(old_uri: str, new_uri: str, api_client: Any) -> None:
     source_name = api_client.get_property(old_uri, "source-name")
     source_email = api_client.get_property(old_uri, "source-email")
     transfer_consignment_reference = api_client.get_property(
-        old_uri, "transfer-consignment-reference"
+        old_uri,
+        "transfer-consignment-reference",
     )
     transfer_received_at = api_client.get_property(old_uri, "transfer-received-at")
     for key, value in [

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -31,7 +31,7 @@ class SearchResponse:
         :return: The total number of search results
         """
         return str(
-            self.node.xpath("//search:response/@total", namespaces=self.NAMESPACES)[0]
+            self.node.xpath("//search:response/@total", namespaces=self.NAMESPACES)[0],
         )
 
     @property
@@ -42,7 +42,8 @@ class SearchResponse:
         :return: The list of search results
         """
         results = self.node.xpath(
-            "//search:response/search:result", namespaces=self.NAMESPACES
+            "//search:response/search:result",
+            namespaces=self.NAMESPACES,
         )
         return [SearchResult(result, self.client) for result in results]
 
@@ -58,7 +59,5 @@ class SearchResponse:
             "//search:response/search:facet/search:facet-value",
             namespaces={"search": "http://marklogic.com/appservices/search"},
         )
-        facets_dictionary = {
-            result.attrib["name"]: result.attrib["count"] for result in results
-        }
+        facets_dictionary = {result.attrib["name"]: result.attrib["count"] for result in results}
         return facets_dictionary

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -99,7 +99,8 @@ class SearchResultMetadata:
         """
 
         return self._get_xpath_match_string(
-            "//editor-priority/text()", EditorPriority.MEDIUM.value
+            "//editor-priority/text()",
+            EditorPriority.MEDIUM.value,
         )
 
     @property
@@ -109,7 +110,7 @@ class SearchResultMetadata:
         """
 
         extracted_submission_datetime = self._get_xpath_match_string(
-            "//transfer-received-at/text()"
+            "//transfer-received-at/text()",
         )
         return (
             datetime.strptime(extracted_submission_datetime, "%Y-%m-%dT%H:%M:%SZ")
@@ -164,7 +165,7 @@ class SearchResult:
         """
 
         return DocumentURIString(
-            self._get_xpath_match_string("@uri").lstrip("/").split(".xml")[0]
+            self._get_xpath_match_string("@uri").lstrip("/").split(".xml")[0],
         )
 
     @property
@@ -174,7 +175,7 @@ class SearchResult:
         """
 
         return self._get_xpath_match_string(
-            "search:extracted/uk:cite/text()"
+            "search:extracted/uk:cite/text()",
         ) or self._get_xpath_match_string("search:extracted/akn:neutralCitation/text()")
 
     @property
@@ -195,7 +196,7 @@ class SearchResult:
         court = None
         court_code = self._get_xpath_match_string("search:extracted/uk:court/text()")
         jurisdiction_code = self._get_xpath_match_string(
-            "search:extracted/uk:jurisdiction/text()"
+            "search:extracted/uk:jurisdiction/text()",
         )
         if jurisdiction_code:
             court_code_with_jurisdiction = "%s/%s" % (court_code, jurisdiction_code)
@@ -204,7 +205,7 @@ class SearchResult:
             except CourtNotFoundException:
                 logging.warning(
                     "Court not found with court code %s and jurisdiction code %s for judgment with NCN %s, falling back to court."
-                    % (court_code, jurisdiction_code, self.neutral_citation)
+                    % (court_code, jurisdiction_code, self.neutral_citation),
                 )
         if court is None:
             try:
@@ -212,7 +213,7 @@ class SearchResult:
             except CourtNotFoundException:
                 logging.warning(
                     "Court not found with court code %s for judgment with NCN %s, returning None."
-                    % (court_code, self.neutral_citation)
+                    % (court_code, self.neutral_citation),
                 )
                 court = None
         return court
@@ -224,13 +225,13 @@ class SearchResult:
         """
 
         date_string = self._get_xpath_match_string(
-            "search:extracted/akn:FRBRdate[(@name='judgment' or @name='decision')]/@date"
+            "search:extracted/akn:FRBRdate[(@name='judgment' or @name='decision')]/@date",
         )
         try:
             date = dateparser.parse(date_string)
         except ParserError as e:
             logging.warning(
-                f'Unable to parse document date "{date_string}". Full error: {e}'
+                f'Unable to parse document date "{date_string}". Full error: {e}',
             )
             date = None
         return date
@@ -242,7 +243,7 @@ class SearchResult:
         """
 
         return self._get_xpath_match_string(
-            "search:extracted/akn:FRBRdate[@name='transform']/@date"
+            "search:extracted/akn:FRBRdate[@name='transform']/@date",
         )
 
     @property

--- a/src/caselawclient/xml_helpers.py
+++ b/src/caselawclient/xml_helpers.py
@@ -14,7 +14,9 @@ def get_xpath_match_string(
 
 
 def get_xpath_match_strings(
-    node: etree._Element, path: str, namespaces: Optional[Dict[str, str]] = None
+    node: etree._Element,
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
 ) -> list[str]:
     kwargs = {"namespaces": namespaces} if namespaces else {}
     return [str(x) for x in node.xpath(path, **kwargs)]

--- a/src/caselawclient/xml_tools.py
+++ b/src/caselawclient/xml_tools.py
@@ -31,7 +31,7 @@ def get_element(
 ) -> Element:
     logging.warning(
         "XMLTools is deprecated and will be removed in later versions. "
-        "Use methods from MarklogicApiClient.Client instead."
+        "Use methods from MarklogicApiClient.Client instead.",
     )
     name = xml.find(
         xpath,
@@ -58,7 +58,7 @@ def get_neutral_citation_name_value(xml: ElementTree) -> Optional[str]:
 def get_judgment_date_element(xml: ElementTree) -> Element:
     logging.warning(
         "XMLTools is deprecated and will be removed in later versions. "
-        "Use methods from MarklogicApiClient.Client instead."
+        "Use methods from MarklogicApiClient.Client instead.",
     )
     name = xml.find(
         ".//akn:FRBRWork/akn:FRBRdate",
@@ -102,7 +102,7 @@ def get_metadata_name_value(xml: ElementTree) -> str:
 def get_search_matches(element: ElementTree) -> List[str]:
     logging.warning(
         "XMLTools is deprecated and will be removed in later versions. "
-        "Use methods from MarklogicApiClient.Client instead."
+        "Use methods from MarklogicApiClient.Client instead.",
     )
     nodes = element.findall(".//search:match", namespaces=search_namespace)
     results = []
@@ -115,14 +115,15 @@ def get_search_matches(element: ElementTree) -> List[str]:
 def get_error_code(content_as_xml: Optional[str]) -> str:
     logging.warning(
         "XMLTools is deprecated and will be removed in later versions. "
-        "Use methods from MarklogicApiClient.Client instead."
+        "Use methods from MarklogicApiClient.Client instead.",
     )
     if not content_as_xml:
         return "Unknown error, Marklogic returned a null or empty response"
     try:
         xml = fromstring(content_as_xml)
         return xml.find(
-            "message-code", namespaces={"": "http://marklogic.com/xdmp/error"}
+            "message-code",
+            namespaces={"": "http://marklogic.com/xdmp/error"},
         ).text  # type: ignore
     except (ParseError, TypeError, AttributeError):
         return "Unknown error, Marklogic returned a null or empty response"

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import patch
 
 import pytest
-
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.search_parameters import SearchParameters
 
@@ -46,7 +45,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "only_unpublished": "false",
                         "collections": "",
                         "quoted_phrases": [],
-                    }
+                    },
                 ),
             )
 
@@ -77,7 +76,7 @@ class TestAdvancedSearch(unittest.TestCase):
                     show_unpublished=False,
                     only_unpublished=False,
                     collections=[" foo ", "abc def", " bar"],
-                )
+                ),
             )
 
             self.client.invoke.assert_called_with(
@@ -99,7 +98,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "only_unpublished": "false",
                         "collections": "foo,abcdef,bar",
                         "quoted_phrases": [],
-                    }
+                    },
                 ),
             )
 
@@ -130,7 +129,9 @@ class TestAdvancedSearch(unittest.TestCase):
         """
         with patch.object(self.client, "invoke") as mock_invoke:
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=True
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=True,
             ):
                 self.client.advanced_search(
                     SearchParameters(
@@ -141,7 +142,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         page=2,
                         page_size=20,
                         show_unpublished=False,
-                    )
+                    ),
                 )
 
                 expected_vars = {
@@ -163,7 +164,8 @@ class TestAdvancedSearch(unittest.TestCase):
                 }
 
                 mock_invoke.assert_called_with(
-                    "/judgments/search/search-v2.xqy", json.dumps(expected_vars)
+                    "/judgments/search/search-v2.xqy",
+                    json.dumps(expected_vars),
                 )
 
     def test_user_can_view_unpublished_and_show_unpublished_is_true(
@@ -177,7 +179,9 @@ class TestAdvancedSearch(unittest.TestCase):
         """
         with patch.object(self.client, "invoke"):
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=True
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=True,
             ):
                 self.client.advanced_search(
                     SearchParameters(
@@ -188,11 +192,9 @@ class TestAdvancedSearch(unittest.TestCase):
                         page=2,
                         page_size=20,
                         show_unpublished=True,
-                    )
+                    ),
                 )
-                assert (
-                    '"show_unpublished": "true"' in self.client.invoke.call_args.args[1]
-                )
+                assert '"show_unpublished": "true"' in self.client.invoke.call_args.args[1]
 
     def test_user_cannot_view_unpublished_but_show_unpublished_is_true(
         self,
@@ -205,7 +207,9 @@ class TestAdvancedSearch(unittest.TestCase):
         """
         with patch.object(self.client, "invoke"):
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=False
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=False,
             ):
                 with patch.object(logging, "warning") as mock_logging:
                     self.client.advanced_search(
@@ -217,13 +221,10 @@ class TestAdvancedSearch(unittest.TestCase):
                             page=2,
                             page_size=20,
                             show_unpublished=True,
-                        )
+                        ),
                     )
 
-                    assert (
-                        '"show_unpublished": "false"'
-                        in self.client.invoke.call_args.args[1]
-                    )
+                    assert '"show_unpublished": "false"' in self.client.invoke.call_args.args[1]
                     mock_logging.assert_called()
 
     def test_no_page_0(self):
@@ -237,7 +238,7 @@ class TestAdvancedSearch(unittest.TestCase):
             self.client.advanced_search(
                 SearchParameters(
                     page=0,
-                )
+                ),
             )
 
             assert ', "page": 1,' in self.client.invoke.call_args.args[1]

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -31,7 +31,9 @@ class TestGetCheckoutStatus(unittest.TestCase):
     def test_checkout_judgment_with_timeout(self):
         with patch.object(self.client, "eval") as mock_eval:
             with patch.object(
-                self.client, "calculate_seconds_until_midnight", return_value=3600
+                self.client,
+                "calculate_seconds_until_midnight",
+                return_value=3600,
             ):
                 uri = "/ewca/civ/2004/632"
                 annotation = "locked by A KITTEN"
@@ -43,9 +45,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 }
                 self.client.checkout_judgment(uri, annotation, expires_at_midnight)
 
-                assert mock_eval.call_args.args[0] == (
-                    os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy")
-                )
+                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"))
                 assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_checkin_judgment(self):
@@ -54,9 +54,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
             expected_vars = {"uri": "/ewca/civ/2004/632.xml"}
             self.client.checkin_judgment(uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "checkin_judgment.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkin_judgment.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_get_checkout_status(self):
@@ -65,16 +63,14 @@ class TestGetCheckoutStatus(unittest.TestCase):
             expected_vars = {"uri": "/judgment/uri.xml"}
             self.client.get_judgment_checkout_status(uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "get_judgment_checkout_status.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "get_judgment_checkout_status.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_get_checkout_status_message(self):
         with patch.object(MarklogicApiClient, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -97,7 +93,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
         with patch.object(MarklogicApiClient, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -112,7 +108,8 @@ class TestGetCheckoutStatus(unittest.TestCase):
 
     def test_calculate_seconds_until_midnight(self):
         dt = datetime.strptime(
-            "2020-01-01 23:00", "%Y-%m-%d %H:%M"
+            "2020-01-01 23:00",
+            "%Y-%m-%d %H:%M",
         )  # 1 hour until midnight
         result = self.client.calculate_seconds_until_midnight(dt)
         expected_result = 3600  # 1 hour in seconds

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -6,8 +6,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 import responses
-from requests import Request
-
 from caselawclient.Client import (
     MarklogicApiClient,
     MultipartResponseLongerThanExpected,
@@ -15,6 +13,7 @@ from caselawclient.Client import (
     get_single_string_from_marklogic_response,
 )
 from caselawclient.errors import GatewayTimeoutError
+from requests import Request
 
 
 class TestErrors(unittest.TestCase):
@@ -38,14 +37,15 @@ class TestErrors(unittest.TestCase):
 class TestMarklogicResponseHandlers(unittest.TestCase):
     @patch("caselawclient.Client.decoder.MultipartDecoder.from_response")
     def test_get_multipart_strings_from_marklogic_response(
-        self, mock_multipart_decoder
+        self,
+        mock_multipart_decoder,
     ):
         mock_multipart_decoder.return_value.parts = (
             SimpleNamespace(text="string 1"),
             SimpleNamespace(text="string 2"),
         )
         assert get_multipart_strings_from_marklogic_response(
-            MagicMock(requests.Response)
+            MagicMock(requests.Response),
         ) == ["string 1", "string 2"]
 
     def test_get_multipart_strings_from_marklogic_response_if_no_content(self):
@@ -55,27 +55,24 @@ class TestMarklogicResponseHandlers(unittest.TestCase):
 
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_single_string_from_marklogic_response(
-        self, mock_multipart_strings_handler
+        self,
+        mock_multipart_strings_handler,
     ):
         mock_multipart_strings_handler.return_value = ["test string"]
-        assert (
-            get_single_string_from_marklogic_response(MagicMock(requests.Response))
-            == "test string"
-        )
+        assert get_single_string_from_marklogic_response(MagicMock(requests.Response)) == "test string"
 
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_single_string_from_marklogic_response_if_empty_set(
-        self, mock_multipart_strings_handler
+        self,
+        mock_multipart_strings_handler,
     ):
         mock_multipart_strings_handler.return_value = []
-        assert (
-            get_single_string_from_marklogic_response(MagicMock(requests.Response))
-            == ""
-        )
+        assert get_single_string_from_marklogic_response(MagicMock(requests.Response)) == ""
 
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_single_string_from_marklogic_response_if_multiple_strings(
-        self, mock_multipart_strings_handler
+        self,
+        mock_multipart_strings_handler,
     ):
         mock_multipart_strings_handler.return_value = [
             "test string",
@@ -92,7 +89,7 @@ class ApiClientTest(unittest.TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
     def test_eval_and_decode(self, mock_eval):
         mock_eval.return_value.headers = {
-            "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+            "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
         }
         mock_eval.return_value.content = (
             b"\r\n--595658fa1db1aa98\r\n"
@@ -102,16 +99,15 @@ class ApiClientTest(unittest.TestCase):
             b"true\r\n"
             b"--595658fa1db1aa98--\r\n"
         )
-        assert (
-            self.client._eval_and_decode({"url": "/2029/eat/1"}, "myfile.xqy") == "true"
-        )
+        assert self.client._eval_and_decode({"url": "/2029/eat/1"}, "myfile.xqy") == "true"
 
     @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
     def test_document_exists(self, mock_decode):
         mock_decode.return_value = "true"
         assert self.client.document_exists("/2029/eat/1") is True
         mock_decode.assert_called_with(
-            {"uri": "/2029/eat/1.xml"}, "document_exists.xqy"
+            {"uri": "/2029/eat/1.xml"},
+            "document_exists.xqy",
         )
 
     @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
@@ -119,7 +115,8 @@ class ApiClientTest(unittest.TestCase):
         mock_decode.return_value = "false"
         assert self.client.document_exists("/2029/eat/1") is False
         mock_decode.assert_called_with(
-            {"uri": "/2029/eat/1.xml"}, "document_exists.xqy"
+            {"uri": "/2029/eat/1.xml"},
+            "document_exists.xqy",
         )
 
     @patch("caselawclient.Client.Path")
@@ -178,6 +175,6 @@ class ApiClientTest(unittest.TestCase):
 
     def test_user_agent(self):
         user_agent = self.client.session.prepare_request(
-            Request("GET", "http://example.invalid")
+            Request("GET", "http://example.invalid"),
         ).headers["user-agent"]
         assert re.match(r"^ds-caselaw-marklogic-api-client/\d+", user_agent)

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -16,7 +16,9 @@ class TestEvalXslt(unittest.TestCase):
     def test_eval_xslt_user_can_view_unpublished(self):
         with patch.object(self.client, "eval") as mock_eval:
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=True
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=True,
             ):
                 uri = "/judgment/uri"
                 expected_vars: XsltTransformDict = {
@@ -29,9 +31,7 @@ class TestEvalXslt(unittest.TestCase):
                 }
                 self.client.eval_xslt(uri, show_unpublished=True)
 
-                assert mock_eval.call_args.args[0] == (
-                    os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
-                )
+                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
                 assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
@@ -56,11 +56,9 @@ class TestEvalXslt(unittest.TestCase):
                     }
                     self.client.eval_xslt(uri, show_unpublished=True)
 
-                    assert mock_eval.call_args.args[0] == (
-                        os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
-                    )
+                    assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
                     assert mock_eval.call_args.kwargs["vars"] == json.dumps(
-                        expected_vars
+                        expected_vars,
                     )
                     mock_logging.assert_called()
 
@@ -68,7 +66,9 @@ class TestEvalXslt(unittest.TestCase):
     def test_eval_xslt_with_filename(self):
         with patch.object(self.client, "eval") as mock_eval:
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=True
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=True,
             ):
                 uri = "/judgment/uri"
                 expected_vars: XsltTransformDict = {
@@ -80,19 +80,21 @@ class TestEvalXslt(unittest.TestCase):
                     "query": None,
                 }
                 self.client.eval_xslt(
-                    uri, show_unpublished=True, xsl_filename="as-handed-down.xsl"
+                    uri,
+                    show_unpublished=True,
+                    xsl_filename="as-handed-down.xsl",
                 )
 
-                assert mock_eval.call_args.args[0] == (
-                    os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
-                )
+                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
                 assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_with_query(self):
         with patch.object(self.client, "eval") as mock_eval:
             with patch.object(
-                self.client, "user_can_view_unpublished_judgments", return_value=True
+                self.client,
+                "user_can_view_unpublished_judgments",
+                return_value=True,
             ):
                 uri = "/judgment/uri"
                 query = "the query string"
@@ -111,8 +113,6 @@ class TestEvalXslt(unittest.TestCase):
                     query=query,
                 )
 
-                assert mock_eval.call_args.args[0] == (
-                    os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy")
-                )
+                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
 
                 assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_get_document_by_uri.py
+++ b/tests/client/test_get_document_by_uri.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-
 from caselawclient.Client import (
     DOCUMENT_COLLECTION_URI_JUDGMENT,
     DOCUMENT_COLLECTION_URI_PRESS_SUMMARY,
@@ -37,7 +36,9 @@ class TestGetDocumentTypeFromUri(TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_document_type_from_uri_if_judgment(
-        self, mock_get_marklogic_response, mock_eval
+        self,
+        mock_get_marklogic_response,
+        mock_eval,
     ):
         mock_get_marklogic_response.return_value = [DOCUMENT_COLLECTION_URI_JUDGMENT]
         document_type = self.client.get_document_type_from_uri(uri="test/1234")
@@ -46,10 +47,12 @@ class TestGetDocumentTypeFromUri(TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_document_type_from_uri_if_press_summary(
-        self, mock_get_marklogic_response, mock_eval
+        self,
+        mock_get_marklogic_response,
+        mock_eval,
     ):
         mock_get_marklogic_response.return_value = [
-            DOCUMENT_COLLECTION_URI_PRESS_SUMMARY
+            DOCUMENT_COLLECTION_URI_PRESS_SUMMARY,
         ]
         document_type = self.client.get_document_type_from_uri(uri="test/1234")
         assert document_type == PressSummary
@@ -57,7 +60,9 @@ class TestGetDocumentTypeFromUri(TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_document_type_from_uri_if_no_valid_collection(
-        self, mock_get_marklogic_response, mock_eval
+        self,
+        mock_get_marklogic_response,
+        mock_eval,
     ):
         mock_get_marklogic_response.return_value = []
 

--- a/tests/client/test_get_judgment_and_versions.py
+++ b/tests/client/test_get_judgment_and_versions.py
@@ -14,7 +14,7 @@ class TestGetJudgment(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--6bfe89fc4493c0e3\r\n"
@@ -46,9 +46,7 @@ class TestGetJudgment(unittest.TestCase):
             expected_vars = {"uri": "/ewca/civ/2004/632.xml", "version": "3"}
             self.client.get_judgment_version(uri, version)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "get_judgment_version.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "get_judgment_version.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_list_judgment_versions(self):
@@ -57,7 +55,5 @@ class TestGetJudgment(unittest.TestCase):
             expected_vars = {"uri": "/ewca/civ/2004/632.xml"}
             self.client.list_judgment_versions(uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "list_judgment_versions.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "list_judgment_versions.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_get_press_summaries_for_document_uri.py
+++ b/tests/client/test_get_press_summaries_for_document_uri.py
@@ -12,7 +12,10 @@ class TestGetPressSummariesForDocumentUri(TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._send_to_eval")
     @patch("caselawclient.Client.get_multipart_strings_from_marklogic_response")
     def test_get_press_summaries_for_document_uri(
-        self, mock_get_marklogic_response, mock_eval, mock_press_summary
+        self,
+        mock_get_marklogic_response,
+        mock_eval,
+        mock_press_summary,
     ):
         mock_eval.return_value = "EVAL"
         mock_get_marklogic_response.return_value = ["/foo/bar/baz/1", "/foo/bar/baz/2"]

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -14,13 +14,11 @@ def test_get_properties_for_search_results(send, decode):
     expected_vars = {"uris": ["/judgment/uri.xml"]}
     decode.return_value = "decoded_value"  # The decoder is called
     retval = MarklogicApiClient("", "", "", False).get_properties_for_search_results(
-        uris
+        uris,
     )
     assert retval == "decoded_value"
 
-    assert send.call_args.args[0] == (
-        os.path.join(ROOT_DIR, "xquery", "get_properties_for_search_results.xqy")
-    )
+    assert send.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "get_properties_for_search_results.xqy"))
     assert send.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
 
@@ -35,9 +33,7 @@ class TestGetSetMetadata(unittest.TestCase):
             expected_vars = {"uri": "/judgment/uri.xml", "content": content}
             self.client.set_judgment_citation(uri, content)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_set_judgment_citation_whitespace_stripping(self):
@@ -47,9 +43,7 @@ class TestGetSetMetadata(unittest.TestCase):
             expected_vars = {"uri": "/judgment/uri.xml", "content": "[2033] UKSC 1234"}
             self.client.set_judgment_citation(uri, content)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_citation.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_set_document_court(self):
@@ -59,9 +53,7 @@ class TestGetSetMetadata(unittest.TestCase):
             expected_vars = {"uri": "/judgment/uri.xml", "content": content}
             self.client.set_document_court(uri, content)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_set_document_jurisdiction(self):
@@ -71,9 +63,7 @@ class TestGetSetMetadata(unittest.TestCase):
             expected_vars = {"uri": "/judgment/uri.xml", "content": content}
             self.client.set_document_jurisdiction(uri, content)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_jurisdiction.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_jurisdiction.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_set_document_court_and_jurisdiction_when_both_passed(self):
@@ -90,18 +80,16 @@ class TestGetSetMetadata(unittest.TestCase):
             }
             self.client.set_document_court_and_jurisdiction(uri, "court/jurisdiction")
 
-            assert mock_eval.call_args_list[0].args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
-            )
+            assert mock_eval.call_args_list[0].args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy"))
             assert mock_eval.call_args_list[0].kwargs["vars"] == json.dumps(
-                court_expected_vars
+                court_expected_vars,
             )
 
             assert mock_eval.call_args_list[1].args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "set_metadata_jurisdiction.xqy")
             )
             assert mock_eval.call_args_list[1].kwargs["vars"] == json.dumps(
-                jurisdiction_expected_vars
+                jurisdiction_expected_vars,
             )
 
     def test_set_document_court_and_jurisdiction_when_just_court_passed(self):
@@ -114,18 +102,16 @@ class TestGetSetMetadata(unittest.TestCase):
             jurisdiction_expected_vars = {"uri": "/judgment/uri.xml", "content": ""}
             self.client.set_document_court_and_jurisdiction(uri, content)
 
-            assert mock_eval.call_args_list[0].args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy")
-            )
+            assert mock_eval.call_args_list[0].args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_court.xqy"))
             assert mock_eval.call_args_list[0].kwargs["vars"] == json.dumps(
-                court_expected_vars
+                court_expected_vars,
             )
 
             assert mock_eval.call_args_list[1].args[0] == (
                 os.path.join(ROOT_DIR, "xquery", "set_metadata_jurisdiction.xqy")
             )
             assert mock_eval.call_args_list[1].kwargs["vars"] == json.dumps(
-                jurisdiction_expected_vars
+                jurisdiction_expected_vars,
             )
 
     def test_set_document_date(self):
@@ -137,14 +123,17 @@ class TestGetSetMetadata(unittest.TestCase):
 
             assert mock_eval.call_args.args[0] == (
                 os.path.join(
-                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
+                    ROOT_DIR,
+                    "xquery",
+                    "set_metadata_work_expression_date.xqy",
                 )
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_set_judgment_date_warn(self):
         with patch.object(warnings, "warn") as mock_warn, patch.object(
-            self.client, "eval"
+            self.client,
+            "eval",
         ) as mock_eval:
             uri = "judgment/uri"
             content = "2022-01-01"
@@ -154,7 +143,9 @@ class TestGetSetMetadata(unittest.TestCase):
             assert mock_warn.call_args.kwargs == {"stacklevel": 2}
             assert mock_eval.call_args.args[0] == (
                 os.path.join(
-                    ROOT_DIR, "xquery", "set_metadata_work_expression_date.xqy"
+                    ROOT_DIR,
+                    "xquery",
+                    "set_metadata_work_expression_date.xqy",
                 )
             )
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
@@ -187,7 +178,5 @@ class TestGetSetMetadata(unittest.TestCase):
             }
             self.client.set_judgment_this_uri(uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -53,7 +53,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -72,7 +72,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = "my-content"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -85,14 +85,14 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
             )
             result = self.client.get_property("/judgment/uri", "my-property")
 
-            assert "my-content" == result
+            assert result == "my-content"
 
     def test_get_unset_property(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.content = ""
             result = self.client.get_property("/judgment/uri", "my-property")
 
-            assert "" == result
+            assert result == ""
 
     def test_set_property(self):
         with patch.object(self.client, "eval") as mock_eval:

--- a/tests/client/test_get_version_annotation.py
+++ b/tests/client/test_get_version_annotation.py
@@ -11,7 +11,7 @@ class TestGetVersionAnnotation(unittest.TestCase):
     def test_get_version_annotation(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -24,4 +24,4 @@ class TestGetVersionAnnotation(unittest.TestCase):
             )
             result = self.client.get_version_annotation("/judgment/uri")
 
-            assert "this is an annotation" == result
+            assert result == "this is an annotation"

--- a/tests/client/test_get_version_created_datetime.py
+++ b/tests/client/test_get_version_created_datetime.py
@@ -12,7 +12,7 @@ class TestGetVersionCreatedDatetime(unittest.TestCase):
     def test_get_version_created_datetime(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -4,9 +4,8 @@ import unittest
 from unittest.mock import patch
 from xml.etree import ElementTree
 
-import pytest
-
 import caselawclient.Client
+import pytest
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.errors import InvalidContentHashError
@@ -38,7 +37,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                         "automated": False,
                         "message": "test_update_document_xml",
                         "payload": {"test_payload": True},
-                    }
+                    },
                 ),
             }
             self.client.update_document_xml(
@@ -52,9 +51,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 ),
             )
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "update_document.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "update_document.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_save_locked_judgment_xml(self):
@@ -79,7 +76,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                             "automated": True,
                             "message": "test_save_locked_judgment_xml",
                             "payload": {"test_payload": True},
-                        }
+                        },
                     ),
                 }
                 self.client.save_locked_judgment_xml(
@@ -93,9 +90,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                     ),
                 )
 
-                assert mock_eval.call_args.args[0] == (
-                    os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy")
-                )
+                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy"))
                 assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_save_locked_judgment_xml_checks_content_hash(self):
@@ -105,7 +100,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
         Then the error is raised.
         """
         with patch.object(
-            caselawclient.Client, "validate_content_hash"
+            caselawclient.Client,
+            "validate_content_hash",
         ) as mock_validate_hash:
             uri = "/ewca/civ/2004/632"
             judgment_str = "<root>My updated judgment</root>"
@@ -139,7 +135,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                         "automated": False,
                         "message": "test_insert_document_xml",
                         "payload": {"test_payload": True},
-                    }
+                    },
                 ),
             }
             self.client.insert_document_xml(
@@ -153,9 +149,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 ),
             )
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "insert_document.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "insert_document.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_delete_document(self):
@@ -166,9 +160,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             }
             self.client.delete_judgment(uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "delete_judgment.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "delete_judgment.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_copy_document(self):
@@ -181,7 +173,5 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             }
             self.client.copy_document(old_uri, new_uri)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "copy_document.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "copy_document.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_search_and_decode_response.py
+++ b/tests/client/test_search_and_decode_response.py
@@ -31,7 +31,7 @@ class TestSearchAndDecodeResponse:
         """
         with patch.object(self.client, "advanced_search") as mock_advanced_search:
             mock_advanced_search.return_value = generate_mock_search_response(
-                valid_search_response_xml
+                valid_search_response_xml,
             )
 
             search_response = self.client.search_judgments_and_decode_response(
@@ -46,7 +46,7 @@ class TestSearchAndDecodeResponse:
                     date_to="2022-01-31",
                     page=1,
                     page_size=10,
-                )
+                ),
             )
 
             mock_advanced_search.assert_called_once_with(
@@ -65,7 +65,7 @@ class TestSearchAndDecodeResponse:
                     show_unpublished=False,
                     only_unpublished=False,
                     collections=["judgment"],
-                )
+                ),
             )
 
             assert search_response == valid_search_response_xml

--- a/tests/client/test_search_parameters.py
+++ b/tests/client/test_search_parameters.py
@@ -1,5 +1,4 @@
 import pytest
-
 from caselawclient.search_parameters import SearchParameters
 
 

--- a/tests/client/test_stats.py
+++ b/tests/client/test_stats.py
@@ -12,7 +12,7 @@ class TestStats(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = '[["R1C1","R1C2"],["R2C1","R2C2"]]'
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"

--- a/tests/client/test_user_privileges.py
+++ b/tests/client/test_user_privileges.py
@@ -22,15 +22,13 @@ class TestUserPrivileges(unittest.TestCase):
             }
             self.client.user_has_privilege(user, privilege_uri, privilege_action)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "user_has_privilege.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "user_has_privilege.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_user_can_view_unpublished_judgments_true(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -45,7 +43,7 @@ class TestUserPrivileges(unittest.TestCase):
     def test_user_can_view_unpublished_judgments_false(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"

--- a/tests/client/test_user_roles.py
+++ b/tests/client/test_user_roles.py
@@ -17,15 +17,13 @@ class TestUserRoles(unittest.TestCase):
             expected_vars = {"user": "laura", "role": "admin"}
             self.client.user_has_role(user, role)
 
-            assert mock_eval.call_args.args[0] == (
-                os.path.join(ROOT_DIR, "xquery", "user_has_role.xqy")
-            )
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "user_has_role.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_user_has_admin_role_true(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"
@@ -40,7 +38,7 @@ class TestUserRoles(unittest.TestCase):
     def test_user_has_admin_role_false(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=595658fa1db1aa98"
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
             }
             mock_eval.return_value.content = (
                 b"\r\n--595658fa1db1aa98\r\n"

--- a/tests/client/test_validate_document.py
+++ b/tests/client/test_validate_document.py
@@ -12,7 +12,7 @@ class TestValidateDocument(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=c878f7cb55370005"
+                "content-type": "multipart/mixed; boundary=c878f7cb55370005",
             }
             mock_eval.return_value.content = (
                 b"\r\n--c878f7cb55370005\r\n"
@@ -29,7 +29,7 @@ class TestValidateDocument(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.text = "true"
             mock_eval.return_value.headers = {
-                "content-type": "multipart/mixed; boundary=c878f7cb55370005"
+                "content-type": "multipart/mixed; boundary=c878f7cb55370005",
             }
             mock_eval.return_value.content = (
                 b"\r\n--c878f7cb55370005\r\n"

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -27,7 +27,9 @@ class TestVerifyShowUnpublished(unittest.TestCase):
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments
         with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=True
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
         ):
             result = self.client.verify_show_unpublished(True)
             assert result is True
@@ -39,7 +41,9 @@ class TestVerifyShowUnpublished(unittest.TestCase):
         of show_unpublished first
         """
         with patch.object(
-            self.client, "user_can_view_unpublished_judgments", return_value=True
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
         ) as mock_client:
             result = self.client.verify_show_unpublished(False)
             mock_client.user_can_view_unpublished_judgments.assert_not_called()

--- a/tests/client_helpers/test_search_helpers.py
+++ b/tests/client_helpers/test_search_helpers.py
@@ -1,15 +1,15 @@
 from unittest.mock import Mock
 
-from lxml import etree
-
 from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.search_parameters import SearchParameters
+from lxml import etree
 
 
 def test_search_judgments_and_parse_results(
-    generate_search_response_xml, valid_search_result_xml
+    generate_search_response_xml,
+    valid_search_result_xml,
 ):
     """
     Given the search parameters for search_judgments_and_parse_response are valid
@@ -24,9 +24,7 @@ def test_search_judgments_and_parse_results(
     """
     mock_api_client = Mock()
     search_response_xml = generate_search_response_xml(2 * valid_search_result_xml)
-    mock_api_client.search_judgments_and_decode_response.return_value = (
-        search_response_xml
-    )
+    mock_api_client.search_judgments_and_decode_response.return_value = search_response_xml
 
     search_parameters = SearchParameters(
         query="test query",
@@ -42,13 +40,14 @@ def test_search_judgments_and_parse_results(
     )
 
     search_response = search_judgments_and_parse_response(
-        mock_api_client, search_parameters
+        mock_api_client,
+        search_parameters,
     )
 
     mock_api_client.search_judgments_and_decode_response.assert_called_once_with(
-        search_parameters
+        search_parameters,
     )
 
     assert etree.tostring(search_response.node) == etree.tostring(
-        etree.fromstring(search_response_xml)
+        etree.fromstring(search_response_xml),
     )

--- a/tests/client_helpers/test_version_annotation.py
+++ b/tests/client_helpers/test_version_annotation.py
@@ -1,5 +1,4 @@
 import pytest
-
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 
 
@@ -34,10 +33,7 @@ class TestVersionAnnotation:
         with pytest.raises(AttributeError) as e:
             annotation.structured_annotation_dict
 
-        assert (
-            str(e.value)
-            == "The name of the calling function has not been set; use set_calling_function()"
-        )
+        assert str(e.value) == "The name of the calling function has not been set; use set_calling_function()"
 
     def test_structured_annotation_dict_raises_on_no_calling_agent(self):
         annotation = VersionAnnotation(
@@ -50,7 +46,4 @@ class TestVersionAnnotation:
         with pytest.raises(AttributeError) as e:
             annotation.structured_annotation_dict
 
-        assert (
-            str(e.value)
-            == "The name of the calling agent has not been set; use set_calling_agent()"
-        )
+        assert str(e.value) == "The name of the calling agent has not been set; use set_calling_agent()"

--- a/tests/client_helpers/test_xml_helpers.py
+++ b/tests/client_helpers/test_xml_helpers.py
@@ -1,5 +1,4 @@
 import lxml.etree
-
 from caselawclient.xml_helpers import get_xpath_match_string, get_xpath_match_strings
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ from typing import Callable
 from unittest.mock import Mock
 
 import pytest
-
 from caselawclient.Client import MarklogicApiClient
 
 
@@ -15,7 +14,7 @@ def valid_search_result_xml_fixture() -> str:
         str: Valid search result XML string.
     """
     return (
-        '<search:result xmlns:search="http://marklogic.com/appservices/search" uri="/a/c/2015/20.xml" path="fn:doc(&quot;/a/c/2015/20.xml&quot;)">\n '  # noqa:E501
+        '<search:result xmlns:search="http://marklogic.com/appservices/search" uri="/a/c/2015/20.xml" path="fn:doc(&quot;/a/c/2015/20.xml&quot;)">\n '
         "<search:snippet>"
         "<search:match path=\"fn:doc('/a/c/2015/20.xml')/*:akomaNtoso\">"
         "text from the document that matched the search"
@@ -24,11 +23,11 @@ def valid_search_result_xml_fixture() -> str:
         '<search:extracted kind="element">'
         '<FRBRdate date="2017-08-08" name="judgment" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
         '<FRBRname value="Another made up case name" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
-        '<FRBRdate date="2023-04-09T18:05:45" name="transform" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'  # noqa:E501
+        '<FRBRdate date="2023-04-09T18:05:45" name="transform" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
         '<uk:court xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">A-C</uk:court>'
         '<uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2015] A 20 (C)</uk:cite>'
         '<uk:hash xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">test_content_hash</uk:hash>'
-        '<neutralCitation xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">[2015] A 0020 (C)</neutralCitation>'  # noqa:E501
+        '<neutralCitation xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">[2015] A 0020 (C)</neutralCitation>'
         "</search:extracted>"
         "</search:result>"
     )
@@ -66,7 +65,7 @@ def generate_search_response_xml_fixture() -> Callable:
             str: Generated search response XML string.
         """
         return (
-            '<search:response xmlns:search="http://marklogic.com/appservices/search" total="2">'  # noqa: E501
+            '<search:response xmlns:search="http://marklogic.com/appservices/search" total="2">'
             f"{response_content}"
             f"{facets}"
             "</search:response>"
@@ -77,7 +76,8 @@ def generate_search_response_xml_fixture() -> Callable:
 
 @pytest.fixture(name="valid_search_response_xml")
 def valid_search_response_xml_fixture(
-    generate_search_response_xml, valid_search_result_xml
+    generate_search_response_xml,
+    valid_search_result_xml,
 ) -> str:
     """
     Fixture that provides a valid search response XML string.
@@ -117,16 +117,14 @@ def generate_mock_response_fixture() -> Callable:
         mock_response.content = (
             b"\r\n--foo\r\n"
             b"Content-Type: application/xml\r\n"
-            b"X-Primitive: element()\r\nX-Path: /*:response\r\n\r\n"
-            + search_response_xml.encode()
-            + b"\r\n--foo--\r\n"
+            b"X-Primitive: element()\r\nX-Path: /*:response\r\n\r\n" + search_response_xml.encode() + b"\r\n--foo--\r\n"
         )
         return mock_response
 
     return _generate_mock_response
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_api_client():
     mock_client = Mock(spec=MarklogicApiClient)
     mock_client.get_judgment_xml_bytestring.return_value = b"<xml>content</xml>"

--- a/tests/content_hash/test_content_hash.py
+++ b/tests/content_hash/test_content_hash.py
@@ -1,5 +1,4 @@
 import pytest
-
 from caselawclient.content_hash import (
     get_hash_from_document,
     get_hashable_text,
@@ -26,9 +25,7 @@ VALID_DOC = b"""<?xml version="1.0" encoding="UTF-8"?>
 
 INVALID_DOC = VALID_DOC.replace(b"Do", b"Do not").replace(b"valid", b"invalid")
 
-VALID_DOC_CONTENT_HASH = (
-    "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
-)
+VALID_DOC_CONTENT_HASH = "c4367ebc0937f4dc2d6b372d9a09670e3606a5b3da77a070149755db5f942565"
 
 
 class TestIdentifyHashableString:
@@ -66,6 +63,7 @@ class TestCorrectlyRaisesExceptions:
 
     def test_no_content_hash(self):
         with pytest.raises(
-            InvalidContentHashError, match="Document did not have a content hash tag"
+            InvalidContentHashError,
+            match="Document did not have a content hash tag",
         ):
             validate_content_hash(b"<dog></dog>")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,11 +2,10 @@ import datetime
 from typing import Any
 from unittest.mock import Mock
 
-from typing_extensions import TypeAlias
-
 from caselawclient.models.documents import Document
 from caselawclient.models.judgments import Judgment
 from caselawclient.responses.search_result import SearchResult, SearchResultMetadata
+from typing_extensions import TypeAlias
 
 
 class DocumentFactory:
@@ -38,9 +37,7 @@ class DocumentFactory:
         if "html" in kwargs:
             judgment_mock.return_value.content_as_html.return_value = kwargs.pop("html")
         else:
-            judgment_mock.return_value.content_as_html.return_value = (
-                "<p>This is a judgment.</p>"
-            )
+            judgment_mock.return_value.content_as_html.return_value = "<p>This is a judgment.</p>"
 
         if "xml" in kwargs:
             xml_string = kwargs.pop("xml")
@@ -48,7 +45,7 @@ class DocumentFactory:
             xml_string = "<akomantoso>This is some XML of a judgment.</akomantoso>"
 
         judgment_mock.return_value.xml = Document.XML(
-            xml_bytestring=xml_string.encode(encoding="utf-8")
+            xml_bytestring=xml_string.encode(encoding="utf-8"),
         )
 
         for map_to, map_from in cls.PARAMS_MAP.items():

--- a/tests/models/test_document_xml.py
+++ b/tests/models/test_document_xml.py
@@ -1,7 +1,6 @@
 import pytest
-from lxml import etree
-
 from caselawclient.models.documents import Document, NonXMLDocumentError
+from lxml import etree
 
 
 class TestDocumentXml:
@@ -12,20 +11,17 @@ class TestDocumentXml:
 
     def test_xml_as_tree(self):
         document_xml = Document.XML(
-            b'<?xml version="1.0" encoding="UTF-8"?><xml></xml>'
+            b'<?xml version="1.0" encoding="UTF-8"?><xml></xml>',
         )
 
         assert etree.tostring(document_xml.xml_as_tree) == b"<xml/>"
 
     def test_root_element_akomantoso(self):
         document_xml = Document.XML(
-            b"<akomaNtoso xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>judgment</akomaNtoso>"
+            b"<akomaNtoso xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>judgment</akomaNtoso>",
         )
 
-        assert (
-            document_xml.root_element
-            == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
-        )
+        assert document_xml.root_element == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
 
     def test_root_element_error(self):
         document_xml = Document.XML(b"<error>parser.log contents</error>")

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.judgments import Judgment
+
 from tests.factories import PressSummaryFactory
 
 
@@ -26,7 +26,7 @@ class TestJudgmentValidation:
         assert document_without_ncn.has_ncn is False
 
     def test_judgment_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_xml_bytestring.return_value = """
+        mock_api_client.get_judgment_xml_bytestring.return_value = b"""
             <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
                         xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
                 <judgment>
@@ -37,15 +37,14 @@ class TestJudgmentValidation:
                     </meta>
                 </judgment>
             </akomaNtoso>
-        """.encode(
-            "utf-8"
-        )
+        """
 
         judgment = Judgment("test/1234", mock_api_client)
 
         assert judgment.neutral_citation == "[2023] TEST 1234"
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
-            "test/1234", show_unpublished=True
+            "test/1234",
+            show_unpublished=True,
         )
 
     @pytest.mark.parametrize(
@@ -94,7 +93,7 @@ class TestJudgmentValidation:
                 "This judgment has no neutral citation number",
                 "The neutral citation number of this judgment is not valid",
                 "The court for this judgment is not valid",
-            ]
+            ],
         )
 
 
@@ -108,12 +107,15 @@ class TestLinkedDocuments:
 
         assert judgment.linked_document == press_summary
         document_mock.assert_called_once_with(
-            "test/1234/press-summary/1", mock_api_client
+            "test/1234/press-summary/1",
+            mock_api_client,
         )
 
     @patch("caselawclient.models.press_summaries.PressSummary")
     def test_linked_document_returns_nothing_when_does_not_exist(
-        self, document_mock, mock_api_client
+        self,
+        document_mock,
+        mock_api_client,
     ):
         document_mock.side_effect = DocumentNotFoundError()
 

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.press_summaries import PressSummary
+
 from tests.factories import JudgmentFactory
 
 
@@ -26,7 +26,7 @@ class TestPressSummaryValidation:
         assert document_without_ncn.has_ncn is False
 
     def test_press_summary_neutral_citation(self, mock_api_client):
-        mock_api_client.get_judgment_xml_bytestring.return_value = """
+        mock_api_client.get_judgment_xml_bytestring.return_value = b"""
         <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
             xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
         <doc name="pressSummary">
@@ -43,15 +43,14 @@ class TestPressSummaryValidation:
             </preface>
         </doc>
         </akomaNtoso>
-        """.encode(
-            "utf-8"
-        )
+        """
 
         press_summary = PressSummary("test/1234", mock_api_client)
 
         assert press_summary.neutral_citation == "[2016] TEST 49"
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
-            "test/1234", show_unpublished=True
+            "test/1234",
+            show_unpublished=True,
         )
 
     @pytest.mark.parametrize(
@@ -82,7 +81,8 @@ class TestPressSummaryValidation:
         assert press_summary.has_valid_ncn is valid
 
     def test_press_summary_validation_failure_messages_if_failing(
-        self, mock_api_client
+        self,
+        mock_api_client,
     ):
         press_summary = PressSummary("test/1234", mock_api_client)
         press_summary.failed_to_parse = True
@@ -102,7 +102,7 @@ class TestPressSummaryValidation:
                 "This press summary has no neutral citation number",
                 "The neutral citation number of this press summary is not valid",
                 "The court for this press summary is not valid",
-            ]
+            ],
         )
 
 
@@ -119,7 +119,9 @@ class TestLinkedDocuments:
 
     @patch("caselawclient.models.judgments.Judgment")
     def test_linked_document_returns_nothing_when_does_not_exist(
-        self, document_mock, mock_api_client
+        self,
+        document_mock,
+        mock_api_client,
     ):
         document_mock.side_effect = DocumentNotFoundError()
 

--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -5,14 +5,13 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 import boto3
 import ds_caselaw_utils
 import pytest
-from moto import mock_aws
-
 from caselawclient.models.utilities import extract_version, move, render_versions
 from caselawclient.models.utilities.aws import (
     build_new_key,
     check_docx_exists,
     copy_assets,
 )
+from moto import mock_aws
 
 from ...factories import JudgmentFactory
 
@@ -73,7 +72,7 @@ class TestAWSUtils:
         """
 
         client.return_value.list_objects.return_value = {
-            "Contents": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}]
+            "Contents": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}],
         }
         copy_assets("uksc/2023/1", "ukpc/1999/9")
         client.return_value.copy.assert_called_with(
@@ -103,7 +102,9 @@ class TestOverwrite:
 
         result = move.overwrite_document("old/uri", "[2002] EAT 1", fake_api_client)
         fake_api_client.update_document_xml.assert_called_with(
-            "new/uri", ANY, annotation="overwritten from old/uri"
+            "new/uri",
+            ANY,
+            annotation="overwritten from old/uri",
         )
         fake_api_client.delete_judgment.assert_called_with("old/uri")
         assert result == "new/uri"
@@ -114,7 +115,9 @@ class TestOverwrite:
 
         with pytest.raises(move.NeutralCitationToUriError):
             move.overwrite_document(
-                "old/uri", "Wrong neutral citation", fake_api_client
+                "old/uri",
+                "Wrong neutral citation",
+                fake_api_client,
             )
 
 

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -1,8 +1,7 @@
 import pytest
-from lxml import etree
-
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_response import SearchResponse
+from lxml import etree
 
 
 class TestSearchResponse:
@@ -25,9 +24,9 @@ class TestSearchResponse:
         """
         search_response = SearchResponse(
             etree.fromstring(
-                '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'  # noqa: E501
+                '<search:response xmlns:search="http://marklogic.com/appservices/search" total="5">'
                 "foo"
-                "</search:response>"
+                "</search:response>",
             ),
             self.client,
         )
@@ -54,10 +53,10 @@ class TestSearchResponse:
 
         assert len(results) == 2
         assert etree.tostring(results[0].node) == etree.tostring(
-            etree.fromstring(valid_search_result_xml)
+            etree.fromstring(valid_search_result_xml),
         )
         assert etree.tostring(results[1].node) == etree.tostring(
-            etree.fromstring(valid_search_result_xml)
+            etree.fromstring(valid_search_result_xml),
         )
 
     def test_when_search_namespace_prefix_not_defined_on_response_xml_syntax_error_raised(
@@ -69,7 +68,7 @@ class TestSearchResponse:
         Then a XMLSyntaxError with the expected message should be raised
         """
         xml_without_namespace = (
-            '<search:response xmlns:foo="http://marklogic.com/appservices/search" total="2">'  # noqa: E501
+            '<search:response xmlns:foo="http://marklogic.com/appservices/search" total="2">'
             "<search:result>Result 1</search:result>"
             "<search:result>Result 2</search:result>"
             "</search:response>"
@@ -95,8 +94,9 @@ class TestSearchResponse:
         search_response = SearchResponse(
             etree.fromstring(
                 generate_search_response_xml(
-                    valid_search_result_xml, valid_facets_fixture_xml
-                )
+                    valid_search_result_xml,
+                    valid_facets_fixture_xml,
+                ),
             ),
             self.client,
         )

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -2,9 +2,6 @@ import datetime
 from unittest.mock import patch
 
 import pytest
-from ds_caselaw_utils.courts import Court
-from lxml import etree
-
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_result import (
     EditorPriority,
@@ -12,6 +9,8 @@ from caselawclient.responses.search_result import (
     SearchResult,
     SearchResultMetadata,
 )
+from ds_caselaw_utils.courts import Court
+from lxml import etree
 
 
 class TestSearchResult:
@@ -32,7 +31,8 @@ class TestSearchResult:
         """
         with (
             patch.object(
-                self.client, "get_properties_for_search_results"
+                self.client,
+                "get_properties_for_search_results",
             ) as mock_get_properties_for_search_results,
             patch.object(self.client, "get_last_modified") as mock_get_last_modified,
         ):
@@ -112,10 +112,7 @@ class TestSearchResult:
         search_result = SearchResult(node, self.client)
 
         assert isinstance(search_result.court, Court)
-        assert (
-            search_result.court.name
-            == "First-tier Tribunal (General Regulatory Chamber) – Information Rights"
-        )
+        assert search_result.court.name == "First-tier Tribunal (General Regulatory Chamber) – Information Rights"
 
     def test_create_from_node_with_invalid_court_code(self):
         """
@@ -153,10 +150,7 @@ class TestSearchResult:
         node = etree.fromstring(xml)
         search_result = SearchResult(node, self.client)
 
-        assert (
-            search_result.court.name
-            == "First-tier Tribunal (General Regulatory Chamber)"
-        )
+        assert search_result.court.name == "First-tier Tribunal (General Regulatory Chamber)"
 
 
 class TestSearchResultMeta:
@@ -178,7 +172,7 @@ class TestSearchResultMeta:
             "<published>true</published>"
             "<transfer-received-at>2023-01-26T14:17:02Z</transfer-received-at>"
             "</property-result>"
-            "</property-results>"
+            "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
 
@@ -199,10 +193,7 @@ class TestSearchResultMeta:
         THEN all properties are set correctly
         """
         node = etree.fromstring(
-            "<property-results>"
-            "<property-result>"
-            "</property-result>"
-            "</property-results>"
+            "<property-results>" "<property-result>" "</property-result>" "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
 
@@ -230,7 +221,11 @@ class TestSearchResultMeta:
         ],
     )
     def test_editor_status(
-        self, published_string, assigned_to, editor_hold, expected_editor_status
+        self,
+        published_string,
+        assigned_to,
+        editor_hold,
+        expected_editor_status,
     ):
         """
         GIVEN editor_hold and assigned_to values
@@ -244,7 +239,7 @@ class TestSearchResultMeta:
             f"<editor-hold>{editor_hold}</editor-hold>"
             f"<published>{published_string}</published>"
             "</property-result>"
-            "</property-results>"
+            "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="foo")
 
@@ -262,7 +257,7 @@ class TestSearchResultMeta:
             "<property-result>"
             "<transfer-received-at></transfer-received-at>"
             "</property-result>"
-            "</property-results>"
+            "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="foo")
 

--- a/tests/xml_tools/test_xml_tools.py
+++ b/tests/xml_tools/test_xml_tools.py
@@ -3,7 +3,7 @@ import unittest
 import xml.etree.ElementTree as ET
 from unittest.mock import patch
 
-import caselawclient.xml_tools as xml_tools
+from caselawclient import xml_tools
 
 
 class XmlToolsTests(unittest.TestCase):
@@ -66,7 +66,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_neutral_citation_element(xml)
         self.assertEqual(
-            result.tag, "{https://caselaw.nationalarchives.gov.uk/akn}cite"
+            result.tag,
+            "{https://caselaw.nationalarchives.gov.uk/akn}cite",
         )
         self.assertEqual(result.text, "[2022] EWHC 482 (QB)")
 
@@ -113,7 +114,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_metadata_name_element(xml)
         self.assertEqual(
-            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRname"
+            result.tag,
+            "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRname",
         )
         self.assertEqual(result.attrib, {"value": "My Judgment Name"})
 
@@ -130,7 +132,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_metadata_name_element(xml)
         self.assertEqual(
-            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRname"
+            result.tag,
+            "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRname",
         )
         self.assertEqual(result.attrib, {"value": ""})
 
@@ -186,7 +189,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_judgment_date_element(xml)
         self.assertEqual(
-            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRdate"
+            result.tag,
+            "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRdate",
         )
         self.assertEqual(result.attrib, {"date": "2022-03-10", "name": "judgment"})
 
@@ -206,7 +210,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_judgment_date_element(xml)
         self.assertEqual(
-            result.tag, "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRdate"
+            result.tag,
+            "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRdate",
         )
         self.assertEqual(result.attrib, {"date": "", "name": "judgment"})
 
@@ -253,7 +258,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_court_element(xml)
         self.assertEqual(
-            result.tag, "{https://caselaw.nationalarchives.gov.uk/akn}court"
+            result.tag,
+            "{https://caselaw.nationalarchives.gov.uk/akn}court",
         )
         self.assertEqual(result.text, "EWHC-QBD")
 
@@ -270,7 +276,8 @@ class XmlToolsTests(unittest.TestCase):
         xml = ET.ElementTree(ET.fromstring(xml_string))
         result = xml_tools.get_court_element(xml)
         self.assertEqual(
-            result.tag, "{https://caselaw.nationalarchives.gov.uk/akn}court"
+            result.tag,
+            "{https://caselaw.nationalarchives.gov.uk/akn}court",
         )
         self.assertEqual(result.text, None)
 
@@ -322,21 +329,24 @@ class XmlToolsTests(unittest.TestCase):
         """
         result = xml_tools.get_error_code(xml_string)
         self.assertEqual(
-            result, "Unknown error, Marklogic returned a null or empty response"
+            result,
+            "Unknown error, Marklogic returned a null or empty response",
         )
 
     def test_get_error_code_xml_empty_string(self):
         xml_string = ""
         result = xml_tools.get_error_code(xml_string)
         self.assertEqual(
-            result, "Unknown error, Marklogic returned a null or empty response"
+            result,
+            "Unknown error, Marklogic returned a null or empty response",
         )
 
     def test_get_error_code_xml_none(self):
         xml_string = None
         result = xml_tools.get_error_code(xml_string)
         self.assertEqual(
-            result, "Unknown error, Marklogic returned a null or empty response"
+            result,
+            "Unknown error, Marklogic returned a null or empty response",
         )
 
     def test_deprecation_warning(self):
@@ -357,5 +367,5 @@ class XmlToolsTests(unittest.TestCase):
             self.assertEqual(result, "My Judgment Name")
             mock_logging.assert_called_with(
                 "XMLTools is deprecated and will be removed in later versions. "
-                "Use methods from MarklogicApiClient.Client instead."
+                "Use methods from MarklogicApiClient.Client instead.",
             )


### PR DESCRIPTION
A series of commits which together make all of FCL's repositories behave more consistently with regard to tooling.

## Jira

FCL-176

## What?

- [x] `.pre-commit-config.yaml` does not exclude directories which don't exist, doesn't set default hooks where they aren't needed, and doesn't specify auto-update behaviour
- [x] The `pre-commit-hooks` repo includes the new, broader set of recommended checks
- [x] Python formatting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] `detect-secrets` is removed (deprecated in favour of GitHub's more comprehensive approach)
- [x] prettier config has been harmonised