### PR TITLE
Speculative: Remove old auth from PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,5 +22,3 @@ jobs:
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Having successfully pushed utils up with a password and trusted publisher, I deleted the old API keys as the email told me to. 

> An API token belonging to user dxw was used to upload files to the project ds-caselaw-utils, even though the project has a Trusted Publisher configured. This may have been in error. We recommend removing the API token and only using the Trusted Publisher to publish.
> If you are the owner of this token, you can delete it by going to your API tokens configuration and deleting the token named ds-caselaw-utils.

Now api-client won't upload with a:

```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading ds_caselaw_marklogic_api_client-24.0.1-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Invalid or non-existent authentication information. See                
         https://pypi.org/help/#invalid-auth for more information.   
```

https://github.com/pypa/gh-action-pypi-publish says:
> To enter the trusted publishing flow, configure this action's job with the `id-token: write` permission and without an explicit username or password

So let's try that.