### PR TITLE
Add write permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ To create a release:
 7. Tag the merge commit on `main` with `v{major}.{minor}.{patch}` and push the tag
 8. Create a release in [Github releases](https://github.com/nationalarchives/ds-caselaw-custom-api-client/releases)
    using the created tag
+
+If the release fails to push to PyPI, you can delete the tag with `git pull`, `git push --delete origin v1.2.3` and try again.


### PR DESCRIPTION
Following on from https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/653 it looks like the bit about id-token: write wasn't added to the code.