### PR TITLE
Release v26.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,6 @@
-exclude: "src/caselawclient/xquery"
-
+exclude: src/caselawclient/xquery
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
+  - hooks:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-json
@@ -15,54 +12,61 @@ repos:
       - id: mixed-line-ending
       - id: no-commit-to-branch
       - id: trailing-whitespace
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.7
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+    repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+  - hooks:
+      - args:
+          - --fix
+          - --exit-non-zero-on-fix
+        id: ruff
       - id: ruff-format
-
-  - repo: local
-    hooks:
-      - id: build-xquery-type-dicts
-        name: build-xquery-type-dicts
+    repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.7
+  - hooks:
+      - entry: script/build_xquery_type_dicts
+        id: build-xquery-type-dicts
         language: python
-        entry: script/build_xquery_type_dicts
-
-  # Check the library itself in strict mode
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        name: mypy-src
-        additional_dependencies:
-          [
-            types-requests,
-            "boto3-stubs[s3,sns]",
-            "types-python-dateutil",
-            "types-pytz",
-          ]
+        name: build-xquery-type-dicts
+    repo: local
+  - hooks:
+      - additional_dependencies:
+          - types-requests
+          - boto3-stubs[s3,sns]
+          - types-python-dateutil
+          - types-pytz
+        args:
+          - --strict
         files: ^src/
-        args: ["--strict"]
-
-  # Check the tests in regular mode
-  - repo: https://github.com/pre-commit/mirrors-mypy
+        id: mypy
+        name: mypy-src
+    repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2
-    hooks:
-      - id: mypy
-        name: mypy-tests
-        additional_dependencies:
-          [
-            types-requests,
-            "boto3-stubs[s3,sns]",
-            "types-python-dateutil",
-            "types-pytz",
-          ]
+  - hooks:
+      - additional_dependencies:
+          - types-requests
+          - boto3-stubs[s3,sns]
+          - types-python-dateutil
+          - types-pytz
         files: ^tests/
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
+        id: mypy
+        name: mypy-tests
+    repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+  - hooks:
       - id: prettier
-        types_or: [yaml, json, xml, markdown, scss, javascript]
+        types_or:
+          - yaml
+          - json
+          - xml
+          - markdown
+          - scss
+          - javascript
+    repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+  - hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages:
+          - push
+    repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v26.0.0 (2024-09-25)
+
+### BREAKING CHANGE
+
+- Multiple methods which used to be within `Document` are now in `Document.body`
+
+### Feat
+
+- **FCL-268**: break functions which rely on the document body into their own subclass
+
+### Fix
+
+- **FCL-268**: update factory behaviour to match new document body model
+- **FCL-268**: use real date when testing if document date should be sent in reparse payload
+- **deps**: update dependency boto3 to v1.35.23
+
+### Refactor
+
+- **FCL-268**: move document statuses to their own submodule
+- **FCL-268**: move document exceptions into their own submodule
+- **FCL-268**: move XML manipulation into its own file
+- **FCL-268**: move the documents module in readiness for better code separation
+
 ## [Release 25.0.0]
 
 - **Breaking:** Remove xml_tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "25.0.0"
+version = "26.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 pdoc = "^14.0.0"
 
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_scheme = "semver2"
+version_provider = "poetry"
+update_changelog_on_bump = true
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### BREAKING CHANGE

- Multiple methods which used to be within `Document` are now in `Document.body`

### Feat

- **FCL-268**: break functions which rely on the document body into their own subclass

### Fix

- **FCL-268**: update factory behaviour to match new document body model
- **FCL-268**: use real date when testing if document date should be sent in reparse payload
- **deps**: update dependency boto3 to v1.35.23

### Refactor

- **FCL-268**: move document statuses to their own submodule
- **FCL-268**: move document exceptions into their own submodule
- **FCL-268**: move XML manipulation into its own file
- **FCL-268**: move the documents module in readiness for better code separation