### PR TITLE
[FCL-340] Add code simplification rules to ruff in API Client and make necessary adjustments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF"]
+extend-select = ["W", "I", "SLF", "SIM"]
 # extend-select = [ "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
-#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
+#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -800,10 +800,7 @@ class MarklogicApiClient:
             else None
         )
 
-        if os.getenv("XSLT_IMAGE_LOCATION"):
-            image_location = os.getenv("XSLT_IMAGE_LOCATION")
-        else:
-            image_location = ""
+        image_location = os.getenv("XSLT_IMAGE_LOCATION", "")
 
         show_unpublished = self.verify_show_unpublished(show_unpublished)
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -281,22 +281,15 @@ class Document:
 
         :return: `True` if this document is in a 'failure' state, otherwise `False`
         """
-        if self.body.failed_to_parse:
-            return True
-        return False
+        return self.body.failed_to_parse
 
     @cached_property
     def is_parked(self) -> bool:
-        if "parked" in self.uri:
-            return True
-        return False
+        return "parked" in self.uri
 
     @cached_property
     def has_name(self) -> bool:
-        if not self.body.name:
-            return False
-
-        return True
+        return bool(self.body.name)
 
     @cached_property
     def has_valid_court(self) -> bool:
@@ -373,9 +366,7 @@ class Document:
         """
         Is it sensible to enrich this document?
         """
-        if (self.enriched_recently is False) and self.validates_against_schema:
-            return True
-        return False
+        return (self.enriched_recently is False) and self.validates_against_schema
 
     @cached_property
     def enriched_recently(self) -> bool:
@@ -388,9 +379,8 @@ class Document:
             return False
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        if now - last_enrichment < MINIMUM_ENRICHMENT_TIME:
-            return True
-        return False
+
+        return now - last_enrichment < MINIMUM_ENRICHMENT_TIME
 
     @cached_property
     def validates_against_schema(self) -> bool:
@@ -506,6 +496,4 @@ class Document:
         """
         Is it sensible to reparse this document?
         """
-        if self.docx_exists():
-            return True
-        return False
+        return self.docx_exists()

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -137,6 +137,4 @@ class DocumentBody:
 
         :return: `True` if there was a complete parser failure, otherwise `False`
         """
-        if "error" in self._xml.root_element:
-            return True
-        return False
+        return "error" in self._xml.root_element

--- a/src/caselawclient/models/neutral_citation_mixin.py
+++ b/src/caselawclient/models/neutral_citation_mixin.py
@@ -40,14 +40,8 @@ class NeutralCitationMixin:
 
     @cached_property
     def has_ncn(self) -> bool:
-        if not self.neutral_citation:
-            return False
-
-        return True
+        return bool(self.neutral_citation)
 
     @cached_property
     def has_valid_ncn(self) -> bool:
-        if not self.has_ncn or not neutral_url(self.neutral_citation):
-            return False
-
-        return True
+        return self.has_ncn and neutral_url(self.neutral_citation) is not None

--- a/src/caselawclient/models/utilities/dates.py
+++ b/src/caselawclient/models/utilities/dates.py
@@ -9,11 +9,7 @@ def parse_string_date_as_utc(iso_string: str, timezone: tzinfo.BaseTzInfo) -> da
     ensure that it is converted to a UTC-aware datetime"""
 
     mixed_date = isoparse(iso_string)
-    if not mixed_date.tzinfo:
-        # it is an unaware time
-        aware_date = timezone.localize(mixed_date)
-    else:
-        aware_date = mixed_date
+    aware_date = mixed_date if mixed_date.tzinfo else timezone.localize(mixed_date)
 
     # make UTC
     utc_date = aware_date.astimezone(UTC)

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -128,46 +128,45 @@ class TestAdvancedSearch(unittest.TestCase):
         When the advanced_search method is called with the show_unpublished parameter set to False
         Then it should call the MarkLogic module with the expected query parameters
         """
-        with patch.object(self.client, "invoke") as mock_invoke:
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=True,
-            ):
-                self.client.advanced_search(
-                    SearchParameters(
-                        query="my-query",
-                        court="ewhc",
-                        judge="a. judge",
-                        party="a party",
-                        page=2,
-                        page_size=20,
-                        show_unpublished=False,
-                    ),
-                )
+        with patch.object(self.client, "invoke") as mock_invoke, patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
+        ):
+            self.client.advanced_search(
+                SearchParameters(
+                    query="my-query",
+                    court="ewhc",
+                    judge="a. judge",
+                    party="a party",
+                    page=2,
+                    page_size=20,
+                    show_unpublished=False,
+                ),
+            )
 
-                expected_vars = {
-                    "court": ["ewhc"],
-                    "judge": "a. judge",
-                    "page": 2,
-                    "page-size": 20,
-                    "q": "my-query",
-                    "party": "a party",
-                    "neutral_citation": "",
-                    "specific_keyword": "",
-                    "order": "",
-                    "from": "",
-                    "to": "",
-                    "show_unpublished": "false",
-                    "only_unpublished": "false",
-                    "collections": "",
-                    "quoted_phrases": [],
-                }
+            expected_vars = {
+                "court": ["ewhc"],
+                "judge": "a. judge",
+                "page": 2,
+                "page-size": 20,
+                "q": "my-query",
+                "party": "a party",
+                "neutral_citation": "",
+                "specific_keyword": "",
+                "order": "",
+                "from": "",
+                "to": "",
+                "show_unpublished": "false",
+                "only_unpublished": "false",
+                "collections": "",
+                "quoted_phrases": [],
+            }
 
-                mock_invoke.assert_called_with(
-                    "/judgments/search/search-v2.xqy",
-                    json.dumps(expected_vars),
-                )
+            mock_invoke.assert_called_with(
+                "/judgments/search/search-v2.xqy",
+                json.dumps(expected_vars),
+            )
 
     def test_user_can_view_unpublished_and_show_unpublished_is_true(
         self,
@@ -178,24 +177,23 @@ class TestAdvancedSearch(unittest.TestCase):
         When the advanced_search method is called with the show_unpublished parameter set to True
         Then it should call the MarkLogic module with the expected query parameters
         """
-        with patch.object(self.client, "invoke"):
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=True,
-            ):
-                self.client.advanced_search(
-                    SearchParameters(
-                        query="my-query",
-                        court="ewhc",
-                        judge="a. judge",
-                        party="a party",
-                        page=2,
-                        page_size=20,
-                        show_unpublished=True,
-                    ),
-                )
-                assert '"show_unpublished": "true"' in self.client.invoke.call_args.args[1]
+        with patch.object(self.client, "invoke"), patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
+        ):
+            self.client.advanced_search(
+                SearchParameters(
+                    query="my-query",
+                    court="ewhc",
+                    judge="a. judge",
+                    party="a party",
+                    page=2,
+                    page_size=20,
+                    show_unpublished=True,
+                ),
+            )
+            assert '"show_unpublished": "true"' in self.client.invoke.call_args.args[1]
 
     def test_user_cannot_view_unpublished_but_show_unpublished_is_true(
         self,
@@ -206,27 +204,25 @@ class TestAdvancedSearch(unittest.TestCase):
         When the advanced_search method is called with the show_unpublished parameter set to True
         Then it should call the MarkLogic module with the show_unpublished parameter set to False and log a warning
         """
-        with patch.object(self.client, "invoke"):
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=False,
-            ):
-                with patch.object(logging, "warning") as mock_logging:
-                    self.client.advanced_search(
-                        SearchParameters(
-                            query="my-query",
-                            court="ewhc",
-                            judge="a. judge",
-                            party="a party",
-                            page=2,
-                            page_size=20,
-                            show_unpublished=True,
-                        ),
-                    )
+        with patch.object(self.client, "invoke"), patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=False,
+        ), patch.object(logging, "warning") as mock_logging:
+            self.client.advanced_search(
+                SearchParameters(
+                    query="my-query",
+                    court="ewhc",
+                    judge="a. judge",
+                    party="a party",
+                    page=2,
+                    page_size=20,
+                    show_unpublished=True,
+                ),
+            )
 
-                    assert '"show_unpublished": "false"' in self.client.invoke.call_args.args[1]
-                    mock_logging.assert_called()
+            assert '"show_unpublished": "false"' in self.client.invoke.call_args.args[1]
+            mock_logging.assert_called()
 
     def test_no_page_0(self):
         """

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -29,24 +29,23 @@ class TestGetCheckoutStatus(unittest.TestCase):
             )
 
     def test_checkout_judgment_with_timeout(self):
-        with patch.object(self.client, "eval") as mock_eval:
-            with patch.object(
-                self.client,
-                "calculate_seconds_until_midnight",
-                return_value=3600,
-            ):
-                uri = "/ewca/civ/2004/632"
-                annotation = "locked by A KITTEN"
-                expires_at_midnight = True
-                expected_vars = {
-                    "uri": "/ewca/civ/2004/632.xml",
-                    "annotation": "locked by A KITTEN",
-                    "timeout": 3600,
-                }
-                self.client.checkout_judgment(uri, annotation, expires_at_midnight)
+        with patch.object(self.client, "eval") as mock_eval, patch.object(
+            self.client,
+            "calculate_seconds_until_midnight",
+            return_value=3600,
+        ):
+            uri = "/ewca/civ/2004/632"
+            annotation = "locked by A KITTEN"
+            expires_at_midnight = True
+            expected_vars = {
+                "uri": "/ewca/civ/2004/632.xml",
+                "annotation": "locked by A KITTEN",
+                "timeout": 3600,
+            }
+            self.client.checkout_judgment(uri, annotation, expires_at_midnight)
 
-                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"))
-                assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_checkin_judgment(self):
         with patch.object(self.client, "eval") as mock_eval:

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -14,105 +14,100 @@ class TestEvalXslt(unittest.TestCase):
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_user_can_view_unpublished(self):
-        with patch.object(self.client, "eval") as mock_eval:
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=True,
-            ):
-                uri = "/judgment/uri"
-                expected_vars: XsltTransformDict = {
-                    "uri": "/judgment/uri.xml",
-                    "version_uri": None,
-                    "show_unpublished": True,
-                    "img_location": "imagepath",
-                    "xsl_filename": "accessible-html.xsl",
-                    "query": None,
-                }
-                self.client.eval_xslt(uri, show_unpublished=True)
+        with patch.object(self.client, "eval") as mock_eval, patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
+        ):
+            uri = "/judgment/uri"
+            expected_vars: XsltTransformDict = {
+                "uri": "/judgment/uri.xml",
+                "version_uri": None,
+                "show_unpublished": True,
+                "img_location": "imagepath",
+                "xsl_filename": "accessible-html.xsl",
+                "query": None,
+            }
+            self.client.eval_xslt(uri, show_unpublished=True)
 
-                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
-                assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_user_cannot_view_unpublished(self):
         """The user is not permitted to see unpublished judgments but is attempting to view them
         Set `show_unpublished` to false and log a warning"""
-        with patch.object(self.client, "eval") as mock_eval:
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=False,
-            ):
-                with patch.object(logging, "warning") as mock_logging:
-                    uri = "/judgment/uri"
-                    expected_vars: XsltTransformDict = {
-                        "uri": "/judgment/uri.xml",
-                        "version_uri": None,
-                        "show_unpublished": False,
-                        "img_location": "imagepath",
-                        "xsl_filename": "accessible-html.xsl",
-                        "query": None,
-                    }
-                    self.client.eval_xslt(uri, show_unpublished=True)
+        with patch.object(self.client, "eval") as mock_eval, patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=False,
+        ), patch.object(logging, "warning") as mock_logging:
+            uri = "/judgment/uri"
+            expected_vars: XsltTransformDict = {
+                "uri": "/judgment/uri.xml",
+                "version_uri": None,
+                "show_unpublished": False,
+                "img_location": "imagepath",
+                "xsl_filename": "accessible-html.xsl",
+                "query": None,
+            }
+            self.client.eval_xslt(uri, show_unpublished=True)
 
-                    assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
-                    assert mock_eval.call_args.kwargs["vars"] == json.dumps(
-                        expected_vars,
-                    )
-                    mock_logging.assert_called()
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(
+                expected_vars,
+            )
+            mock_logging.assert_called()
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_with_filename(self):
-        with patch.object(self.client, "eval") as mock_eval:
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=True,
-            ):
-                uri = "/judgment/uri"
-                expected_vars: XsltTransformDict = {
-                    "uri": "/judgment/uri.xml",
-                    "version_uri": None,
-                    "show_unpublished": True,
-                    "img_location": "imagepath",
-                    "xsl_filename": "as-handed-down.xsl",
-                    "query": None,
-                }
-                self.client.eval_xslt(
-                    uri,
-                    show_unpublished=True,
-                    xsl_filename="as-handed-down.xsl",
-                )
+        with patch.object(self.client, "eval") as mock_eval, patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
+        ):
+            uri = "/judgment/uri"
+            expected_vars: XsltTransformDict = {
+                "uri": "/judgment/uri.xml",
+                "version_uri": None,
+                "show_unpublished": True,
+                "img_location": "imagepath",
+                "xsl_filename": "as-handed-down.xsl",
+                "query": None,
+            }
+            self.client.eval_xslt(
+                uri,
+                show_unpublished=True,
+                xsl_filename="as-handed-down.xsl",
+            )
 
-                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
-                assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_with_query(self):
-        with patch.object(self.client, "eval") as mock_eval:
-            with patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=True,
-            ):
-                uri = "/judgment/uri"
-                query = "the query string"
-                expected_vars: XsltTransformDict = {
-                    "uri": "/judgment/uri.xml",
-                    "version_uri": None,
-                    "show_unpublished": True,
-                    "img_location": "imagepath",
-                    "xsl_filename": "as-handed-down.xsl",
-                    "query": query,
-                }
-                self.client.eval_xslt(
-                    uri,
-                    show_unpublished=True,
-                    xsl_filename="as-handed-down.xsl",
-                    query=query,
-                )
+        with patch.object(self.client, "eval") as mock_eval, patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=True,
+        ):
+            uri = "/judgment/uri"
+            query = "the query string"
+            expected_vars: XsltTransformDict = {
+                "uri": "/judgment/uri.xml",
+                "version_uri": None,
+                "show_unpublished": True,
+                "img_location": "imagepath",
+                "xsl_filename": "as-handed-down.xsl",
+                "query": query,
+            }
+            self.client.eval_xslt(
+                uri,
+                show_unpublished=True,
+                xsl_filename="as-handed-down.xsl",
+                query=query,
+            )
 
-                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "xslt_transform.xqy"))
 
-                assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -61,38 +61,39 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
         When `Client.save_locked_judgment_xml` is called with these as arguments
         Then the xquery in `update_locked_judgment.xqy` is called on the Marklogic db with those arguments
         """
-        with patch.object(caselawclient.Client, "validate_content_hash"):
-            with patch.object(self.client, "eval") as mock_eval:
-                uri = "/ewca/civ/2004/632"
-                judgment_str = "<root>My updated judgment</root>"
-                judgment_xml = judgment_str.encode("utf-8")
-                expected_vars = {
-                    "uri": "/ewca/civ/2004/632.xml",
-                    "judgment": judgment_str,
-                    "annotation": json.dumps(
-                        {
-                            "type": "enrichment",
-                            "calling_function": "save_locked_judgment_xml",
-                            "calling_agent": "marklogic-api-client-test",
-                            "automated": True,
-                            "message": "test_save_locked_judgment_xml",
-                            "payload": {"test_payload": True},
-                        },
-                    ),
-                }
-                self.client.save_locked_judgment_xml(
-                    uri,
-                    judgment_xml,
-                    VersionAnnotation(
-                        VersionType.ENRICHMENT,
-                        message="test_save_locked_judgment_xml",
-                        automated=True,
-                        payload={"test_payload": True},
-                    ),
-                )
+        with patch.object(caselawclient.Client, "validate_content_hash"), patch.object(
+            self.client, "eval"
+        ) as mock_eval:
+            uri = "/ewca/civ/2004/632"
+            judgment_str = "<root>My updated judgment</root>"
+            judgment_xml = judgment_str.encode("utf-8")
+            expected_vars = {
+                "uri": "/ewca/civ/2004/632.xml",
+                "judgment": judgment_str,
+                "annotation": json.dumps(
+                    {
+                        "type": "enrichment",
+                        "calling_function": "save_locked_judgment_xml",
+                        "calling_agent": "marklogic-api-client-test",
+                        "automated": True,
+                        "message": "test_save_locked_judgment_xml",
+                        "payload": {"test_payload": True},
+                    },
+                ),
+            }
+            self.client.save_locked_judgment_xml(
+                uri,
+                judgment_xml,
+                VersionAnnotation(
+                    VersionType.ENRICHMENT,
+                    message="test_save_locked_judgment_xml",
+                    automated=True,
+                    payload={"test_payload": True},
+                ),
+            )
 
-                assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy"))
-                assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "update_locked_judgment.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
 
     def test_save_locked_judgment_xml_checks_content_hash(self):
         """

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -17,12 +17,11 @@ class TestVerifyShowUnpublished(unittest.TestCase):
             self.client,
             "user_can_view_unpublished_judgments",
             return_value=False,
-        ):
-            with patch.object(logging, "warning") as mock_logger:
-                result = self.client.verify_show_unpublished(True)
-                assert result is False
-                # Check the logger was called
-                mock_logger.assert_called()
+        ), patch.object(logging, "warning") as mock_logger:
+            result = self.client.verify_show_unpublished(True)
+            assert result is False
+            # Check the logger was called
+            mock_logger.assert_called()
 
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -32,10 +32,7 @@ class DocumentBodyFactory:
         )
 
         for map_to, map_from in cls.PARAMS_MAP.items():
-            if map_from[0] in kwargs:
-                value = kwargs[map_from[0]]
-            else:
-                value = map_from[1]
+            value = kwargs[map_from[0]] if map_from[0] in kwargs else map_from[1]
             setattr(document_mock.return_value, map_to, value)
 
         return document_mock()
@@ -74,10 +71,7 @@ class DocumentFactory:
             judgment_mock.return_value.body = DocumentBodyFactory().build()
 
         for map_to, map_from in cls.PARAMS_MAP.items():
-            if map_from[0] in kwargs:
-                value = kwargs[map_from[0]]
-            else:
-                value = map_from[1]
+            value = kwargs[map_from[0]] if map_from[0] in kwargs else map_from[1]
             setattr(judgment_mock.return_value, map_to, value)
 
         return judgment_mock()

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -281,13 +281,12 @@ class TestCanEnrich:
             Document,
             "enriched_recently",
             new_callable=PropertyMock,
-        ) as mock_enriched_recently:
-            with patch.object(
-                Document,
-                "validates_against_schema",
-                new_callable=PropertyMock,
-            ) as mock_validates_against_schema:
-                mock_enriched_recently.return_value = enriched_recently
-                mock_validates_against_schema.return_value = validates_against_schema
+        ) as mock_enriched_recently, patch.object(
+            Document,
+            "validates_against_schema",
+            new_callable=PropertyMock,
+        ) as mock_validates_against_schema:
+            mock_enriched_recently.return_value = enriched_recently
+            mock_validates_against_schema.return_value = validates_against_schema
 
-                assert document.can_enrich is can_enrich
+            assert document.can_enrich is can_enrich


### PR DESCRIPTION
Some upcoming changes to factory methods reveal unnecessary code complexity; to combat this add the `SIM` rules to the ruff configuration and adjust code accordingly.