### PR TITLE
fix(SearchResponse): total now returns an int, not a str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- The `models.documents.body.CourtIdentifierString` type has been replaced with the more specific `courts.CourtCode` type from ds-caselaw-utils.
+
+### Fix
+
+- **SearchResponse**: total now returns an int, not a str
+- **SearchResult**: update behaviour to meet type checking
+- **deps**: update dependency ds-caselaw-utils to v1.7.0
+- **deps**: update dependency boto3 to v1.35.28
+- **deps**: update dependency ds-caselaw-utils to v1.5.7
+- **deps**: update dependency boto3 to v1.35.25
+
+### Refactor
+
+- **DocumentBody**: replace CourtIdentifierString with utils.courts.CourtCode
+
 ## v26.0.0 (2024-09-25)
 
 ### BREAKING CHANGE

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -24,13 +24,13 @@ class SearchResponse:
         self.client = client
 
     @property
-    def total(self) -> str:
+    def total(self) -> int:
         """
         The total number of search results.
 
         :return: The total number of search results
         """
-        return str(
+        return int(
             self.node.xpath("//search:response/@total", namespaces=self.NAMESPACES)[0],
         )
 

--- a/tests/responses/test_search_response.py
+++ b/tests/responses/test_search_response.py
@@ -21,7 +21,7 @@ class TestSearchResponse:
         """
         Given a SearchResponse instance
         When calling 'total' on it
-        Then it should return a string representing the total number of results
+        Then it should return an integer representing the total number of results
         """
         search_response = SearchResponse(
             etree.fromstring(
@@ -32,7 +32,7 @@ class TestSearchResponse:
             self.client,
         )
 
-        assert search_response.total == "5"
+        assert search_response.total == 5
 
     def test_results(
         self,


### PR DESCRIPTION
## Summary of changes

The total number of results is inherently an integer, and we should treat it as such.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
