### PR TITLE
bump: version 26.0.0 → 27.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v27.0.0 (2024-10-08)
 
 ### BREAKING CHANGE
 
 - Remove `Document.overwrite` and `MarkLogicApiClient.overwrite`
 - The `models.documents.body.CourtIdentifierString` type has been replaced with the more specific `courts.CourtCode` type from ds-caselaw-utils.
 
+### Feat
+
+- **NeutralCitationMixin**: use ABC to flag abstract methods properly
+
 ### Fix
 
+- **deps**: update dependency boto3 to v1.35.33
+- **deps**: update dependency mypy-boto3-s3 to v1.35.32
+- **deps**: update dependency boto3 to v1.35.30
 - **SearchResponse**: total now returns an int, not a str
 - **SearchResult**: update behaviour to meet type checking
 - **deps**: update dependency ds-caselaw-utils to v1.7.0
@@ -21,6 +28,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Refactor
 
+- **FCL-331**: move api_client, xml and html params to build method signature instead of kwargs
+- **types**: typing improvements around NeutralCitationString
 - **Document**: remove unused overwrite method
 - **DocumentBody**: replace CourtIdentifierString with utils.courts.CourtCode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "26.0.0"
+version = "27.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- Remove `Document.overwrite` and `MarkLogicApiClient.overwrite`
- The `models.documents.body.CourtIdentifierString` type has been replaced with the more specific `courts.CourtCode` type from ds-caselaw-utils.

### Feat

- **NeutralCitationMixin**: use ABC to flag abstract methods properly

### Fix

- **deps**: update dependency boto3 to v1.35.33
- **deps**: update dependency mypy-boto3-s3 to v1.35.32
- **deps**: update dependency boto3 to v1.35.30
- **SearchResponse**: total now returns an int, not a str
- **SearchResult**: update behaviour to meet type checking
- **deps**: update dependency ds-caselaw-utils to v1.7.0
- **deps**: update dependency boto3 to v1.35.28
- **deps**: update dependency ds-caselaw-utils to v1.5.7

### Refactor

- **FCL-331**: move api_client, xml and html params to build method signature instead of kwargs
- **types**: typing improvements around NeutralCitationString
- **Document**: remove unused overwrite method
- **DocumentBody**: replace CourtIdentifierString with utils.courts.CourtCode