### PR TITLE
Breaking: Remove unused overwrite methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
+- Remove `Document.overwrite` and `MarkLogicApiClient.overwrite`
 - The `models.documents.body.CourtIdentifierString` type has been replaced with the more specific `courts.CourtCode` type from ds-caselaw-utils.
 
 ### Fix
@@ -17,10 +18,10 @@ The format is based on [Keep a Changelog 1.0.0].
 - **deps**: update dependency ds-caselaw-utils to v1.7.0
 - **deps**: update dependency boto3 to v1.35.28
 - **deps**: update dependency ds-caselaw-utils to v1.5.7
-- **deps**: update dependency boto3 to v1.35.25
 
 ### Refactor
 
+- **Document**: remove unused overwrite method
 - **DocumentBody**: replace CourtIdentifierString with utils.courts.CourtCode
 
 ## v26.0.0 (2024-09-25)

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1035,12 +1035,7 @@ class MarklogicApiClient:
         search_parameters.collections = [DOCUMENT_COLLECTION_URI_JUDGMENT]
         return self.search_and_decode_response(search_parameters)
 
-    def overwrite_document(self, old_uri: str, new_citation: str) -> str:
-        """Move the judgment at old_uri on top of the new citation, which must already exist
-        Compare to update_document_uri"""
-        return move.overwrite_document(old_uri, new_citation, api_client=self)
-
-    def update_document_uri(self, old_uri: str, new_citation: str) -> str:
+    def update_document_uri(self, old_uri: DocumentURIString, new_citation: str) -> DocumentURIString:
         """
         Move the document at old_uri to the correct location based on the neutral citation
         The new neutral citation *must* not already exist (that is handled elsewhere)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -441,9 +441,6 @@ class Document:
         else:
             raise DocumentNotSafeForDeletion
 
-    def overwrite(self, new_citation: str) -> None:
-        self.api_client.overwrite_document(self.uri, new_citation)
-
     def move(self, new_citation: str) -> None:
         self.api_client.update_document_uri(self.uri, new_citation)
 


### PR DESCRIPTION
## Summary of changes

Remove `Document.overwrite` and `MarklogicApiClient.overwrite` methods, and associated move utility methods. These are never used downstream, and contained a call to an undefined method which would have raised a runtime error.

BREAKING CHANGE: Remove `Document.overwrite` and `MarkLogicApiClient.overwrite`

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
