### PR TITLE
Lock judgment with fixed timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## v27.0.2 (unreleased)
 
 - Allow things on doc.body to be called from doc with a warning
+- client.checkout_judgment now accepts a `timeout_seconds` parameter
 
 ## v27.0.1 (2024-10-17)
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -634,12 +634,14 @@ class MarklogicApiClient:
         judgment_uri: DocumentURIString,
         annotation: str = "",
         expires_at_midnight: bool = False,
+        timeout_seconds: int = -1,
     ) -> requests.Response:
+        """If timeout_seconds is -1, the lock never times out"""
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.CheckoutJudgmentDict = {
             "uri": uri,
             "annotation": annotation,
-            "timeout": -1,
+            "timeout": timeout_seconds,
         }
 
         if expires_at_midnight:

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -28,7 +28,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 accept_header="application/xml",
             )
 
-    def test_checkout_judgment_with_timeout(self):
+    def test_checkout_judgment_with_midnight_timeout(self):
         with patch.object(self.client, "eval") as mock_eval, patch.object(
             self.client,
             "calculate_seconds_until_midnight",
@@ -43,6 +43,21 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 "timeout": 3600,
             }
             self.client.checkout_judgment(uri, annotation, expires_at_midnight)
+
+            assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"))
+            assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)
+
+    def test_checkout_judgment_with_timeout_seconds(self):
+        with patch.object(self.client, "eval") as mock_eval:
+            uri = "/ewca/civ/2004/632"
+            annotation = "locked by A KITTEN"
+            timeout_seconds = 1234
+            expected_vars = {
+                "uri": "/ewca/civ/2004/632.xml",
+                "annotation": "locked by A KITTEN",
+                "timeout": 1234,
+            }
+            self.client.checkout_judgment(uri, annotation, timeout_seconds=timeout_seconds)
 
             assert mock_eval.call_args.args[0] == (os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"))
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(expected_vars)


### PR DESCRIPTION
## Summary of changes

In order to support automatic unlocking of enriched judgments before the editors start work in the morning, allow a fixed amount of time before automatically unlocking the judgment.

Once used in the privileged API, this should prevent enrichment leaving editors with locked judgments when enrichment fails.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
