### PR TITLE
[FCL-386] Add native XSLT transformations to the API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
           - yaml
           - json
           - xml
+          - html
           - markdown
           - scss
           - javascript

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,6 @@ repos:
           - yaml
           - json
           - xml
-          - html
           - markdown
           - scss
           - javascript

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,6 +77,27 @@ botocore = ">=1.11.3"
 wrapt = "*"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.3"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "beautifulsoup4-4.12.3-py3-none-any.whl", hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed"},
+    {file = "beautifulsoup4-4.12.3.tar.gz", hash = "sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "boto3"
 version = "1.35.44"
 description = "The AWS SDK for Python"
@@ -1459,24 +1480,6 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-django"
-version = "4.9.0"
-description = "A Django plugin for pytest."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytest_django-4.9.0-py3-none-any.whl", hash = "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99"},
-    {file = "pytest_django-4.9.0.tar.gz", hash = "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314"},
-]
-
-[package.dependencies]
-pytest = ">=7.0.0"
-
-[package.extras]
-docs = ["sphinx", "sphinx-rtd-theme"]
-testing = ["Django", "django-configurations (>=2.0)"]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2053,6 +2056,17 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.6"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
+    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+]
+
+[[package]]
 name = "sympy"
 version = "1.13.3"
 description = "Computer algebra system (CAS) in Python"
@@ -2302,4 +2316,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8957e78587e961cbbd83c664d83d677c172add729d7f77233da69d7a9c4e8ce3"
+content-hash = "abdab4437fc8c0fa25f83e56d3e4cb902ab39eb883a66b1d6f788b5d1d708da5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1459,6 +1459,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-django"
+version = "4.9.0"
+description = "A Django plugin for pytest."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_django-4.9.0-py3-none-any.whl", hash = "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99"},
+    {file = "pytest_django-4.9.0.tar.gz", hash = "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1970,6 +1988,40 @@ botocore = ">=1.33.2,<2.0a.0"
 crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
+name = "saxonche"
+version = "12.5.0"
+description = "Official Saxonica python package for the SaxonC-HE 12.5.0 processor: for XSLT 3.0, XQuery 3.1, XPath 3.1 and XML Schema processing."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "saxonche-12.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3f84604bc47721b2fc1df3106083e264d6dede5eec1934000376d61b3ad73c0b"},
+    {file = "saxonche-12.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c03ce719be633ddfd70198cb469d1f27e67062e5220eb810001b16a1061f5f43"},
+    {file = "saxonche-12.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:638895fc495e22a582e1d25dcc8b15c3fb94f645788bbff0efc0765287cd1fe1"},
+    {file = "saxonche-12.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5079210932e6d6a77d638a5acc15a438a91ea47f4e322ae2ae8a8e2b1be40689"},
+    {file = "saxonche-12.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:df4ac7ef8420477184f4aa48ed5e696fef7b787d61aadfb6b62695afbb204a79"},
+    {file = "saxonche-12.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ab8ff38eba50b86c547dfe62494e8525e49737fb8c111377a530f8e4aba5398"},
+    {file = "saxonche-12.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:38a735bc7e7f7ec8fd31cf8d88d6880ea76d21f2c3da151c2d86a589f6cd6603"},
+    {file = "saxonche-12.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bfa0f72280e518bc48cb2dc648534ec9cde8da3e7f1b4a60beca8ca29c9ede31"},
+    {file = "saxonche-12.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:620849d0411e32a20193099106ddfe97d3ba07aa4b76ef0edab94920fdae0b34"},
+    {file = "saxonche-12.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:a2d30fbe608390a9e32e27d8065696df398d3c56c5a776fd5e794e940d42b14b"},
+    {file = "saxonche-12.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bc3f406ed0529ef56a796a3ddb66608047bc4d641ead57891b6924dfe0234f90"},
+    {file = "saxonche-12.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:620d586392ef7084ba8d0c6747bed2193da49cd137866ba619c479185fa24ed4"},
+    {file = "saxonche-12.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2374c58755944fa1bed6a5275eac2c988f132b461da15a33c66f79548b81f043"},
+    {file = "saxonche-12.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78f4f606165f2d9c14c871132c3b3fd2ecaaa8a2f3d6a624c63f56524cef7470"},
+    {file = "saxonche-12.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:bcdfc89a6ea6fb0e6b796cd55b6496cd21fc813110a692ed49a3457a47cafe31"},
+    {file = "saxonche-12.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f05d0679d2355721adb6d1cd98968f698e46c7cc3c85d4f604315deef1ae82ec"},
+    {file = "saxonche-12.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:98d9647d37a166be9b2402bad389aaf28e5979258a672a6db86c1f48baf9db7e"},
+    {file = "saxonche-12.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:957f28de384ad3c24125f761ad0d10a5d62e6aa5123775e845cb28303a8717c7"},
+    {file = "saxonche-12.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7648002a76fcbd7c078fe91db52a93130a1b88932e5f7cd846f2ee5c91c89ff0"},
+    {file = "saxonche-12.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:cbe5ff6b06a924e3f762ae359b5ec2fac9e5fe7febe6b0de95feca177fba7332"},
+    {file = "saxonche-12.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4128c46466561b891ab07276043b94b37762187aa0a5a38331a3870e180907b1"},
+    {file = "saxonche-12.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f926d4158a280bca25a8b1d87c98e0901c881c0d190f066dba415cb63d7361a"},
+    {file = "saxonche-12.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f4f9852684d70d708f36abc35e1da059b793b5e67d0d490c091c466fbce6d0f"},
+    {file = "saxonche-12.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc22f5ea64e118bcae1599962b8a6b3ccdcd9da6eef14328f9eebd59ee2a4c88"},
+    {file = "saxonche-12.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:26e0b1cfb7f99aed581c5c175db811a5cddfe860816b19bbeab4fdb1a7327fd6"},
+]
+
+[[package]]
 name = "setuptools"
 version = "75.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -2250,4 +2302,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a388018414ab673f608320728a0f7bbf6a797f23e445b7a5c76ed62e125b44dc"
+content-hash = "8957e78587e961cbbd83c664d83d677c172add729d7f77233da69d7a9c4e8ce3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,12 @@ mypy-boto3-s3 = "^1.26.104"
 mypy-boto3-sns = "^1.26.69"
 pytz = "^2024.1"
 python-dateutil = "^2.9.0-post.0"
+saxonche = "^12.5.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.2.3"
 pytest = "^8.0.0"
+pytest-django = "^4.9.0"
 responses = "^0.25.0"
 python-dotenv = "^1.0.0"
 time-machine = "^2.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ saxonche = "^12.5.0"
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.2.3"
 pytest = "^8.0.0"
-pytest-django = "^4.9.0"
+beautifulsoup4 = "^4.12.3"
 responses = "^0.25.0"
 python-dotenv = "^1.0.0"
 time-machine = "^2.13.0"

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -1,10 +1,12 @@
 import datetime
+import os
 import warnings
 from functools import cached_property
 from typing import Optional
 
 import pytz
 from ds_caselaw_utils.types import CourtCode
+from saxonche import PySaxonProcessor
 
 from caselawclient.models.utilities.dates import parse_string_date_as_utc
 
@@ -128,6 +130,20 @@ class DocumentBody:
     @cached_property
     def content_as_xml(self) -> str:
         return self._xml.xml_as_string
+
+    @cached_property
+    def content_as_html(self) -> str:
+        """Convert the XML representation of the Document into HTML for rendering."""
+
+        html_xslt_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "transforms", "html.xsl")
+
+        with PySaxonProcessor() as proc:
+            xsltproc = proc.new_xslt30_processor()
+            document = proc.parse_xml(
+                xml_text=self._xml.xml_as_string,
+            )
+            executable = xsltproc.compile_stylesheet(stylesheet_file=html_xslt_location)
+            return str(executable.transform_to_string(xdm_node=document))
 
     @cached_property
     def failed_to_parse(self) -> bool:

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import warnings
-from functools import cached_property
+from functools import cache, cached_property
 from typing import Optional
 
 import pytz
@@ -131,18 +131,21 @@ class DocumentBody:
     def content_as_xml(self) -> str:
         return self._xml.xml_as_string
 
-    @cached_property
-    def content_as_html(self) -> str:
+    @cache
+    def content_as_html(self, image_base_url: Optional[str] = None) -> str:
         """Convert the XML representation of the Document into HTML for rendering."""
 
         html_xslt_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "transforms", "html.xsl")
 
         with PySaxonProcessor() as proc:
-            xsltproc = proc.new_xslt30_processor()
-            document = proc.parse_xml(
-                xml_text=self._xml.xml_as_string,
-            )
-            executable = xsltproc.compile_stylesheet(stylesheet_file=html_xslt_location)
+            xslt_processor = proc.new_xslt30_processor()
+            document = proc.parse_xml(xml_text=self._xml.xml_as_string)
+
+            executable = xslt_processor.compile_stylesheet(stylesheet_file=html_xslt_location)
+
+            if image_base_url:
+                executable.set_parameter("image-base", proc.make_string_value(image_base_url))
+
             return str(executable.transform_to_string(xdm_node=document))
 
     @cached_property

--- a/src/caselawclient/models/documents/transforms/html.xsl
+++ b/src/caselawclient/models/documents/transforms/html.xsl
@@ -1,0 +1,1062 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+	xpath-default-namespace="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+	xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+	xmlns:html="http://www.w3.org/1999/xhtml"
+	xmlns:math="http://www.w3.org/1998/Math/MathML"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	exclude-result-prefixes="uk html math xs">
+
+<xsl:output method="html" encoding="utf-8" indent="no" include-content-type="no" />
+
+<xsl:strip-space elements="*" />
+<xsl:preserve-space elements="p block num heading span a courtType date docDate docTitle docketNumber judge lawyer location neutralCitation party role time" />
+
+<xsl:param name="image-base" as="xs:string" select="'https://assets.caselaw.nationalarchives.gov.uk/'" />
+
+<xsl:function name="uk:link-is-supported" as="xs:boolean">
+	<xsl:param name="href" as="attribute()?" />
+	<xsl:choose>
+		<xsl:when test="$href='#'">
+			<xsl:sequence select="false()" />
+		</xsl:when>
+		<xsl:when test="starts-with($href, '#')">
+			<xsl:sequence select="true()" />
+		</xsl:when>
+		<xsl:when test="starts-with($href, 'https://www.legislation.gov.uk/')">
+			<xsl:sequence select="true()" />
+		</xsl:when>
+		<xsl:when test="starts-with($href, 'http://www.legislation.gov.uk/')">
+			<xsl:sequence select="true()" />
+		</xsl:when>
+		<xsl:when test="starts-with($href, 'https://caselaw.nationalarchives.gov.uk/')">
+			<xsl:variable name="components" as="xs:string*" select="tokenize(substring-after($href, 'https://caselaw.nationalarchives.gov.uk/'), '/')" />
+			<xsl:choose>
+				<xsl:when test="empty($components[3])">
+					<xsl:sequence select="false()" />
+				</xsl:when>
+				<xsl:when test="$components[1] = ('uksc', 'ukpc')">
+					<xsl:sequence select="$components[2] ge '2014'" />
+				</xsl:when>
+				<xsl:when test="$components[1] = ('ewca', 'ewhc')">
+					<xsl:sequence select="$components[3] ge '2003'" />
+				</xsl:when>
+				<xsl:when test="$components[1] = 'ewcop'">
+					<xsl:sequence select="$components[2] ge '2009'" />
+				</xsl:when>
+				<xsl:when test="$components[1] = 'ewfc'">
+					<xsl:sequence select="$components[2] ge '2014'" />
+				</xsl:when>
+				<xsl:when test="$components[1] = 'ukut'">
+					<xsl:choose>
+						<xsl:when test="$components[2] = 'iac'">
+							<xsl:sequence select="$components[3] ge '2010'" />
+						</xsl:when>
+						<xsl:when test="$components[2] = 'lc'">
+							<xsl:sequence select="$components[3] ge '2015'" />
+						</xsl:when>
+						<xsl:when test="$components[2] = 'tcc'">
+							<xsl:sequence select="$components[3] ge '2017'" />
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:sequence select="false()" />
+						</xsl:otherwise>
+					</xsl:choose>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:sequence select="false()" />
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:sequence select="false()" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<xsl:variable name="doc-id" as="xs:string">
+	<xsl:variable name="work-uri" as="xs:string">
+		<xsl:sequence select="/akomaNtoso/*/meta/identification/FRBRWork/FRBRthis/@value" />
+	</xsl:variable>
+	<xsl:variable name="long-form-prefix" as="xs:string" select="'https://caselaw.nationalarchives.gov.uk/id/'" />
+	<xsl:choose>
+		<xsl:when test="starts-with($work-uri, $long-form-prefix)">
+			<xsl:sequence select="substring-after($work-uri, $long-form-prefix)" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:sequence select="$work-uri" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:variable>
+
+<xsl:template match="meta" />
+
+<xsl:template match="judgment">
+	<article class="judgment">
+		<xsl:apply-templates />
+		<xsl:apply-templates select="attachments/attachment/doc[@name=('annex','schedule')]" />
+		<xsl:call-template name="footnotes">
+			<xsl:with-param name="footnotes" as="element()*">
+				<xsl:sequence select="header//authorialNote" />
+				<xsl:sequence select="judgmentBody//authorialNote" />
+				<xsl:sequence select="attachments/attachment/doc[@name=('annex','schedule')]//authorialNote" />
+			</xsl:with-param>
+		</xsl:call-template>
+		<xsl:apply-templates select="attachments/attachment/doc[not(@name=('annex','schedule'))]" />
+	</article>
+</xsl:template>
+
+<!-- for press summaries, priority needed to trump attachment template -->
+<xsl:template match="/akomaNtoso/doc" priority="1">
+	<article class="judgment">
+		<xsl:apply-templates />
+		<xsl:call-template name="footnotes" />
+	</article>
+</xsl:template>
+
+<xsl:template match="attachments" />
+
+<xsl:template match="coverPage | header | preface">
+	<header class="judgment-header">
+		<xsl:apply-templates />
+	</header>
+</xsl:template>
+
+<xsl:template match="judgmentBody | doc[@name='pressSummary']/mainBody" priority="1">
+	<section class="judgment-body">
+		<xsl:apply-templates />
+	</section>
+</xsl:template>
+
+<xsl:template match="doc[@name=('annex','schedule')]">
+	<section>
+		<xsl:apply-templates />
+	</section>
+</xsl:template>
+
+<xsl:template match="doc[not(@name=('annex','schedule'))]">
+	<section>
+		<xsl:apply-templates />
+		<xsl:call-template name="footnotes" />
+	</section>
+</xsl:template>
+
+<xsl:template match="doc[not(@name=('annex','schedule'))]/mainBody">
+	<div>
+		<xsl:apply-templates />
+	</div>
+</xsl:template>
+
+<xsl:template match="decision">
+	<xsl:choose>
+		<xsl:when test="exists(preceding-sibling::*) or exists(following-sibling::*)">
+			<section>
+				<xsl:apply-templates />
+			</section>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:next-match />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<xsl:template match="level">
+	<section>
+		<xsl:apply-templates select="@eId" />
+		<xsl:if test="num | heading">
+			<p>
+				<xsl:apply-templates select="num | heading" />
+			</p>
+		</xsl:if>
+		<xsl:apply-templates select="* except (num, heading)" />
+	</section>
+</xsl:template>
+
+<xsl:template match="level/num">
+	<span style="display:inline-block;min-width:0.5in">
+		<xsl:call-template name="inline" />
+	</span>
+</xsl:template>
+
+<xsl:template match="paragraph">
+	<section class="judgment-body__section">
+		<xsl:apply-templates select="@eId" />
+		<span class="judgment-body__number">
+			<xsl:apply-templates select="num" />
+		</span>
+		<div>
+			<xsl:apply-templates select="* except num" />
+		</div>
+	</section>
+</xsl:template>
+
+<xsl:template match="level/@eId | paragraph/@eId">
+	<xsl:attribute name="id">
+		<xsl:sequence select="." />
+	</xsl:attribute>
+</xsl:template>
+
+<xsl:template match="subparagraph">
+	<section class="judgment-body__nested-section">
+		<span class="judgment-body__number">
+			<xsl:apply-templates select="num" />
+		</span>
+		<div>
+			<xsl:apply-templates select="* except num" />
+		</div>
+	</section>
+</xsl:template>
+
+<xsl:template match="paragraph/*/p | subparagraph/*/p">
+	<p>
+		<xsl:attribute name="class">
+			<xsl:choose>
+				<xsl:when test="position() = 1">judgment-body__text judgment-body__no-margin-top</xsl:when>
+				<xsl:otherwise>judgment-body__text</xsl:otherwise>
+			</xsl:choose>
+		</xsl:attribute>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+<!-- <xsl:template match="hcontainer[@name='tableOfContents']" /> -->
+
+<xsl:template match="blockContainer[exists(p)]">
+	<xsl:apply-templates select="* except num" />
+</xsl:template>
+
+<xsl:template match="blockContainer">
+	<xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="blockContainer/num">
+	<span style="padding-right:1em">
+		<xsl:call-template name="inline" />
+	</span>
+</xsl:template>
+
+<xsl:template match="blockContainer/p[1]">
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<p>
+		<xsl:if test="exists(ancestor::header)">
+			<xsl:variable name="alignment" as="xs:string?" select="uk:extract-alignment(., $class-context)" />
+			<xsl:if test="$alignment = ('center', 'right', 'left')">
+				<xsl:attribute name="class">
+					<xsl:sequence select="concat('judgment-header__pr-', $alignment)" />
+				</xsl:attribute>
+			</xsl:if>
+		</xsl:if>
+		<xsl:apply-templates select="../num" />
+		<xsl:text> </xsl:text>
+		<span>
+			<xsl:call-template name="inline" />
+		</span>
+	</p>
+</xsl:template>
+
+<xsl:template match="blockContainer/p[position() gt 1]">
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<p>
+		<xsl:if test="exists(ancestor::header)">
+			<xsl:variable name="alignment" as="xs:string?" select="uk:extract-alignment(., $class-context)" />
+			<xsl:if test="$alignment = ('center', 'right', 'left')">
+				<xsl:attribute name="class">
+					<xsl:sequence select="concat('judgment-header__pr-', $alignment)" />
+				</xsl:attribute>
+			</xsl:if>
+		</xsl:if>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+<!-- quoted structures -->
+
+<xsl:template match="block[@name='embeddedStructure']">
+	<xsl:apply-templates />
+</xsl:template>
+
+<xsl:template match="embeddedStructure">
+	<blockquote>
+		<xsl:apply-templates />
+	</blockquote>
+</xsl:template>
+
+
+<!-- CSS classes -->
+
+<!-- sets the ancestor document element containing the CSS style for its descendants -->
+<!-- if an attachment has its own styles, then that attachment, otherwise the main judgment -->
+<!-- priority should be the highest in the transform -->
+<xsl:template match="akomaNtoso/* | attachment/*[exists(meta/presentation)]" priority="2">
+	<xsl:next-match>
+		<xsl:with-param name="class-context" select="." tunnel="yes" />
+	</xsl:next-match>
+</xsl:template>
+
+<!-- a data structure containing all of the CSS properties, divided by selector and property name -->
+<!-- the keys that follow are designed for this structure -->
+<xsl:variable name="all-classes-parsed" as="document-node()">
+	<xsl:document>
+		<uk:classes>
+			<xsl:for-each select="(/akomaNtoso/*, /akomaNtoso/*/attachments/attachment/*)[exists(meta/presentation)]">
+				<xsl:variable name="root-key" select="generate-id(.)" />
+				<uk:classes key="{ $root-key }">
+					<xsl:for-each select="tokenize(string(meta/presentation), '\}')[contains(., '{')]">
+						<xsl:variable name="selector" select="normalize-space(substring-before(., '{'))" />
+						<xsl:variable name="properties" select="normalize-space(substring-after(., '{'))" />
+						<uk:class key="{ $selector }">
+							<xsl:for-each select="tokenize($properties, ';')[contains(., ':')]">
+								<xsl:variable name="property" select="normalize-space(substring-before(., ':'))" />
+								<xsl:variable name="value" select="normalize-space(substring-after(., ':'))" />
+								<uk:property key="{ $property }" value="{ $value }" />
+							</xsl:for-each>
+						</uk:class>
+					</xsl:for-each>
+				</uk:classes>
+			</xsl:for-each>
+		</uk:classes>
+	</xsl:document>
+</xsl:variable>
+
+<xsl:key name="classes" match="uk:class" use="concat(../@key, '|', @key)" />
+
+<xsl:key name="class-properties" match="uk:property/@value" use="concat(../../../@key, '|', ../../@key, '|', ../@key)" />
+
+<!-- class property getters -->
+
+<!-- returns the value of the property for the given selector -->
+<xsl:function name="uk:get-class-property-1" as="xs:string?">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="selector" as="xs:string" />
+	<xsl:param name="prop" as="xs:string" />
+	<xsl:variable name="key" select="concat(generate-id($context), '|', $selector, '|', $prop)" />
+	<xsl:sequence select="key('class-properties', $key, $all-classes-parsed)/string()" />
+</xsl:function>
+
+<!-- returns a sequence of key/value pairs, each divided by a colon -->
+<xsl:function name="uk:get-all-class-properties" as="xs:string*">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="selector" as="xs:string" /> <!-- constructed with 'augment-simple-class-selector' function below -->
+	<xsl:variable name="key" select="concat(generate-id($context), '|', $selector)" />
+	<xsl:for-each select="key('classes', $key, $all-classes-parsed)/uk:property">
+		<xsl:sequence select="concat(@key, ':', @value)" />
+	</xsl:for-each>
+</xsl:function>
+
+<!-- returns a sequence of key/value pairs, each divided by a colon -->
+<xsl:function name="uk:get-inline-class-properties-1" as="xs:string*">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="selector" as="xs:string" /> <!-- constructed with 'make-class-selector' function below -->
+	<xsl:variable name="key" select="concat(generate-id($context), '|', $selector)" />
+	<xsl:for-each select="key('classes', $key, $all-classes-parsed)/uk:property">
+		<xsl:if test="string(@key) = $inline-properties">
+			<xsl:sequence select="concat(@key, ':', @value)" />
+		</xsl:if>
+	</xsl:for-each>
+</xsl:function>
+
+<!-- helper functions to make selectors, depending on context -->
+
+<!-- adds a prefix to class selector, e.g., #judgment, #main, etc., depending on context -->
+<xsl:function name="uk:augment-simple-class-selector" as="xs:string">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="class" as="xs:string" /> <!-- starts with a dot -->
+	<xsl:choose>
+		<!-- the selector for main styles in a judgment is '#judgment .{ClassName}', e.g., '#judgment .ParaLevel1' -->
+		<xsl:when test="$context/self::judgment">
+			<xsl:sequence select="concat('#judgment ', $class)" />
+		</xsl:when>
+		<!-- the selector for main styles in a press summary is '#main .{ClassName}', e.g., '#main .ParaLevel1' -->
+		<xsl:when test="$context/self::doc[@name='pressSummary']">
+			<xsl:sequence select="concat('#main ', $class)" />
+		</xsl:when>
+		<!-- the selector for attachment styles is '#{type}{num} .{ClassName}', e.g., '#order1 .ParaLevel1' -->
+		<xsl:otherwise>
+			<xsl:variable name="work-uri" as="xs:string" select="$context/meta/identification/FRBRWork/FRBRthis/@value" />
+			<xsl:variable name="uri-components" as="xs:string*" select="tokenize($work-uri, '/')" />
+			<xsl:variable name="last-two" as="xs:string*" select="$uri-components[position() >= last()-1]" />
+			<xsl:variable name="last-two-combined" as="xs:string" select="string-join($last-two, '')" />
+			<xsl:sequence select="concat('#', $last-two-combined, ' ', $class)" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<xsl:function name="uk:make-class-selector" as="xs:string?">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="e" as="element()" />
+	<xsl:choose>
+		<xsl:when test="empty($e/@class)" />
+		<xsl:when test="$doc-id = 'ewhc/ch/2022/1178'">
+			<xsl:sequence select="uk:make-class-selector-for-ewhc-ch-2022-1178($context, $e)" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:sequence select="uk:augment-simple-class-selector($context, concat('.', $e/@class))" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<!-- [2022] EWHC 1178 (Ch) was generated through a manual process and has some exceptions -->
+<!-- It contains multiple sets of styles -->
+<xsl:function name="uk:make-class-selector-for-ewhc-ch-2022-1178" as="xs:string">
+	<xsl:param name="context" as="element()" />
+	<xsl:param name="e" as="element()" /> <!-- $e/@class exists -->
+	<xsl:variable name="header" as="element()?" select="$e/ancestor::header" />
+	<xsl:variable name="decision-id" as="xs:string?" select="$e/ancestor::decision/@eId" />
+	<xsl:choose>
+		<xsl:when test="$context/self::doc[@name='schedule']">
+			<xsl:sequence select="concat('#schedule .', $e/@class)" />
+		</xsl:when>
+		<xsl:when test="exists($header)">
+			<xsl:sequence select="concat('header .', $e/@class, ', #part-a .', $e/@class)" />
+		</xsl:when>
+		<xsl:when test="exists($decision-id) and $decision-id = 'part-a'"> <!-- same as header -->
+			<xsl:sequence select="concat('header .', $e/@class, ', #part-a .', $e/@class)" />
+		</xsl:when>
+		<xsl:when test="exists($decision-id)">
+			<xsl:sequence select="concat('#', $decision-id, ' .', $e/@class)" />
+		</xsl:when>
+		<xsl:otherwise> <!-- should be impossible -->
+			<xsl:sequence select="concat('.', $e/@class)" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<!-- main class property getters requiring, a source element and a context element -->
+
+<xsl:function name="uk:get-class-property" as="xs:string?">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="prop" as="xs:string" />
+	<xsl:param name="context" as="element()" />
+	<xsl:if test="exists($e/@class)">
+		<xsl:variable name="selector" as="xs:string" select="uk:make-class-selector($context, $e)" />
+		<xsl:sequence select="uk:get-class-property-1($context, $selector, $prop)" />
+	</xsl:if>
+</xsl:function>
+
+<xsl:function name="uk:get-inline-class-properties" as="xs:string*">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="context" as="element()" />
+	<xsl:if test="exists($e/@class)">
+		<xsl:variable name="selector" as="xs:string" select="uk:make-class-selector($context, $e)" />
+		<xsl:sequence select="uk:get-inline-class-properties-1($context, $selector)" />
+	</xsl:if>
+</xsl:function>
+
+<!-- style property getter -->
+
+<xsl:function name="uk:get-style-property" as="xs:string?">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="prop" as="xs:string" />
+	<xsl:if test="exists($e/@style)">
+		<xsl:analyze-string select="$e/@style" regex="{ concat($prop, ' *: *([^;]+)') }">
+			<xsl:matching-substring>
+				<xsl:sequence select="regex-group(1)"/>
+			</xsl:matching-substring>
+		</xsl:analyze-string>
+	</xsl:if>
+</xsl:function>
+
+<xsl:function name="uk:get-style-or-class-property" as="xs:string?">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="prop" as="xs:string" />
+	<xsl:param name="context" as="element()" />
+	<xsl:sequence select="uk:get-style-or-class-property($e, $prop, (), $context)" />
+</xsl:function>
+
+<xsl:function name="uk:get-style-or-class-property" as="xs:string?">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="prop" as="xs:string" />
+	<xsl:param name="default" as="xs:string?" />
+	<xsl:param name="context" as="element()" />
+	<xsl:variable name="from-style-attribute" as="xs:string?" select="uk:get-style-property($e, $prop)" />
+	<xsl:variable name="from-class-attribute" as="xs:string?" select="uk:get-class-property($e, $prop, $context)" />
+	<xsl:choose>
+		<xsl:when test="exists($from-style-attribute)">
+			<xsl:sequence select="$from-style-attribute" />
+		</xsl:when>
+		<xsl:when test="exists($from-class-attribute)">
+			<xsl:sequence select="$from-class-attribute" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:sequence select="$default" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<xsl:function name="uk:extract-alignment" as="xs:string?">
+	<xsl:param name="p" as="element()" />
+	<xsl:param name="context" as="element()" />
+	<xsl:sequence select="uk:get-style-or-class-property($p, 'text-align', $context)" />
+</xsl:function>
+
+<xsl:template match="header//p[not(parent::blockContainer)][not(ancestor::authorialNote)] | coverPage/p">
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<xsl:choose>
+		<xsl:when test="exists(child::img) and (every $block in preceding-sibling::* satisfies $block/@name = 'restriction')">
+			<div class="judgment-header__logo">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:when test="exists(child::neutralCitation)">
+			<div class="judgment-header__neutral-citation">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:when test="exists(child::docketNumber)">
+			<div class="judgment-header__case-number">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:when test="exists(child::courtType)">
+			<div class="judgment-header__court">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:when test="exists(child::docDate)">
+			<div class="judgment-header__date">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:when test="matches(normalize-space(.), '^- -( -)+$')">
+			<div class="judgment-header__line-separator" aria-hidden="true">
+				<xsl:apply-templates>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+					<xsl:with-param name="is-uppercase" select="uk:is-uppercase(., $class-context)" tunnel="yes" />
+				</xsl:apply-templates>
+			</div>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:variable name="alignment" as="xs:string?" select="uk:extract-alignment(., $class-context)" />
+			<xsl:choose>
+				<xsl:when test="$alignment = ('center', 'right', 'left')">
+					<p>
+						<xsl:attribute name="class">
+							<xsl:sequence select="concat('judgment-header__pr-', $alignment)" />
+						</xsl:attribute>
+						<xsl:call-template name="inline" />
+					</p>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:next-match />
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<!-- alignment of paragraphs in press summary headers -->
+<xsl:template match="preface/p" priority="1">
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<xsl:variable name="alignment" as="xs:string?" select="uk:extract-alignment(., $class-context)" />
+	<xsl:choose>
+		<xsl:when test="$alignment = ('center', 'right', 'left')">
+			<p>
+				<xsl:attribute name="class">
+					<xsl:sequence select="concat('judgment-header__pr-', $alignment)" />
+				</xsl:attribute>
+				<xsl:call-template name="inline" />
+			</p>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:next-match />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+
+<xsl:template match="p">
+	<p>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+<xsl:template match="block">
+	<p>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+<xsl:template match="num | heading">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+<xsl:template match="neutralCitation">
+	<span class="ncn-nowrap">
+		<xsl:call-template name="inline" />
+	</span>
+</xsl:template>
+
+<xsl:template match="docType | docTitle">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+<xsl:template match="courtType | docketNumber | docDate">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+<xsl:template match="party | role | judge | lawyer">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+<xsl:template match="span">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+<!-- all of the inline properties the parser produces -->
+<xsl:variable name="inline-properties" as="xs:string+" select="('font-family', 'font-size', 'font-weight', 'font-style', 'font-variant', 'color', 'background-color', 'text-transform', 'text-decoration-line', 'text-decoration-style', 'vertical-align')" />
+
+<xsl:function name="uk:get-combined-inline-styles" as="xs:string*">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="context" as="element()" />
+	<xsl:variable name="from-class-attr" select="uk:get-inline-class-properties($e, $context)" /><!-- inline formatting implied by the @class -->
+	<xsl:variable name="from-style-attr" as="xs:string*"><!-- inline formatting specified in @style -->
+		<xsl:for-each select="tokenize($e/@style, ';')">
+			<xsl:variable name="prop" as="xs:string" select="normalize-space(substring-before(., ':'))" />
+			<xsl:if test="$prop = $inline-properties">
+				<xsl:variable name="value" as="xs:string" select="normalize-space(substring-after(., ':'))" />
+				<xsl:sequence select="concat($prop, ':', $value)" />
+			</xsl:if>
+		</xsl:for-each>
+	</xsl:variable>
+	<xsl:variable name="combined" as="xs:string*"><!-- combined, @style trumps @class -->
+		<xsl:variable name="style-properties" as="xs:string*">
+			<xsl:for-each select="$from-style-attr">
+				<xsl:sequence select="substring-before(., ':')" />
+			</xsl:for-each>
+		</xsl:variable>
+		<xsl:for-each select="$from-class-attr">
+			<xsl:variable name="prop" as="xs:string" select="substring-before(., ':')" />
+			<xsl:if test="not($prop = $style-properties)">
+				<xsl:sequence select="." />
+			</xsl:if>
+		</xsl:for-each>
+		<xsl:sequence select="$from-style-attr" />
+	</xsl:variable>
+	<!-- remove font, font-size and text-transform -->
+	<xsl:for-each select="$combined">
+		<xsl:choose>
+			<xsl:when test="starts-with(., 'font-family:') and not(contains(., 'Symbol') or contains(., 'Wingdings'))" /> <!-- remove font, except Symbol or Wingdings -->
+			<xsl:when test="starts-with(., 'font-size:')" /> <!-- remove font-size -->
+			<xsl:when test="starts-with(., 'text-transform:')" /> <!-- remove text-transform -->
+			<xsl:when test="starts-with(., 'text-decoration')" /> <!-- remove text-decoration-..., handled by $has-underline -->
+			<xsl:otherwise>
+				<xsl:sequence select="." />
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+</xsl:function>
+
+<xsl:template name="inline">
+	<xsl:param name="has-underline" as="xs:string*" select="()" tunnel="yes" />
+	<xsl:param name="is-uppercase" as="xs:boolean" select="false()" tunnel="yes" />
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<!-- extract inline styles and recalculate has-underline and is-uppercase -->
+	<xsl:variable name="styles" as="xs:string*" select="uk:get-combined-inline-styles(., $class-context)" />
+	<xsl:variable name="has-underline" as="xs:string*" select="uk:has-underline(., $has-underline, $class-context)" />
+	<xsl:variable name="is-uppercase" as="xs:boolean" select="uk:is-uppercase(., $is-uppercase, $class-context)" />
+	<!-- call recursive template -->
+	<xsl:call-template name="inline-recursive">
+		<xsl:with-param name="styles" select="$styles" />
+		<xsl:with-param name="has-underline" select="$has-underline" tunnel="yes" />
+		<xsl:with-param name="is-uppercase" select="$is-uppercase" tunnel="yes" />
+	</xsl:call-template>
+</xsl:template>
+
+<xsl:template name="inline-recursive">
+	<xsl:param name="styles" as="xs:string*" />
+	<xsl:choose>
+		<xsl:when test="exists($styles[starts-with(., 'font-weight:') and not(starts-with(., 'font-weight:normal'))])">
+			<b>
+				<xsl:if test="exists($styles[starts-with(., 'font-weight:') and not(starts-with(., 'font-weight:bold'))])">
+					<xsl:attribute name="style">
+						<xsl:value-of select="string-join($styles[starts-with(., 'font-weight:')], ';')" />
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:call-template name="inline-recursive">
+					<xsl:with-param name="styles" select="$styles[not(starts-with(., 'font-weight:'))]" />
+				</xsl:call-template>
+			</b>
+		</xsl:when>
+		<xsl:when test="exists($styles[starts-with(., 'font-style:') and not(starts-with(., 'font-style:normal'))])">
+			<i>
+				<xsl:if test="exists($styles[starts-with(., 'font-style:') and not(starts-with(., 'font-style:italic'))])">
+					<xsl:attribute name="style">
+						<xsl:value-of select="string-join($styles[starts-with(., 'font-style:')], ';')" />
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:call-template name="inline-recursive">
+					<xsl:with-param name="styles" select="$styles[not(starts-with(., 'font-style:'))]" />
+				</xsl:call-template>
+			</i>
+		</xsl:when>
+		<xsl:when test="exists($styles[. = 'vertical-align:super'])">
+			<sup>
+				<xsl:call-template name="inline-recursive">
+					<xsl:with-param name="styles" select="$styles[not(starts-with(., 'vertical-align:'))]" />
+				</xsl:call-template>
+			</sup>
+		</xsl:when>
+		<xsl:when test="exists($styles[. = 'vertical-align:sub'])">
+			<sub>
+				<xsl:call-template name="inline-recursive">
+					<xsl:with-param name="styles" select="$styles[not(starts-with(., 'vertical-align:'))]" />
+				</xsl:call-template>
+			</sub>
+		</xsl:when>
+		<xsl:when test="exists($styles)">
+			<span>
+				<xsl:attribute name="style">
+					<xsl:value-of select="string-join($styles, ';')" />
+				</xsl:attribute>
+				<xsl:apply-templates />
+			</span>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:apply-templates />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<xsl:template match="img">
+	<img>
+		<xsl:apply-templates select="@*" />
+		<xsl:apply-templates />
+	</img>
+</xsl:template>
+<xsl:template match="img/@src">
+	<xsl:attribute name="src">
+		<xsl:sequence select="concat($image-base, $doc-id, '/', .)" />
+	</xsl:attribute>
+</xsl:template>
+
+<xsl:template match="img/@style">
+	<xsl:next-match>
+		<xsl:with-param name="properties" select="('width', 'height')" />
+	</xsl:next-match>
+</xsl:template>
+
+<xsl:template match="br">
+	<br />
+</xsl:template>
+
+<xsl:template match="date">
+	<xsl:call-template name="inline" />
+</xsl:template>
+
+
+<!-- tables -->
+
+<xsl:template match="table">
+	<div class="judgment-body__table">
+	<table>
+		<xsl:variable name="header-rows" as="element()*" select="*[child::th]" />
+		<xsl:if test="exists($header-rows)">
+			<thead>
+				<xsl:apply-templates select="$header-rows">
+					<xsl:with-param name="table-class" as="xs:string?" select="@class" tunnel="yes" />
+				</xsl:apply-templates>
+			</thead>
+		</xsl:if>
+		<tbody>
+			<xsl:apply-templates select="* except $header-rows">
+				<xsl:with-param name="table-class" as="xs:string?" select="@class" tunnel="yes" />
+			</xsl:apply-templates>
+		</tbody>
+	</table>
+	</div>
+</xsl:template>
+
+<xsl:template match="tr | th | td">
+	<xsl:param name="class-context" as="element()" tunnel="yes" />
+	<xsl:param name="table-class" as="xs:string?" tunnel="yes" />
+	<xsl:element name="{ local-name() }">
+		<xsl:copy-of select="@*" />
+		<xsl:if test="$table-class">
+			<xsl:variable name="selector" as="xs:string" select="concat('.', $table-class, ' ', local-name(.))" /> <!-- e.g., '.TableClass1 td' -->
+			<xsl:variable name="selector" as="xs:string" select="uk:augment-simple-class-selector($class-context, $selector)" /> <!-- e.g., '#judgment .TableClass1 td' -->
+			<xsl:variable name="table-class-properties" select="uk:get-all-class-properties($class-context, $selector)" />
+			<xsl:if test="exists($table-class-properties)">
+				<xsl:attribute name="style">
+					<xsl:value-of select="string-join($table-class-properties, ';')" />
+					<xsl:if test="exists(@style)">
+						<xsl:value-of select="';'" />
+						<xsl:value-of select="concat(';', @style)" />
+					</xsl:if>
+				</xsl:attribute>
+			</xsl:if>
+		</xsl:if>
+		<xsl:apply-templates />
+	</xsl:element>
+</xsl:template>
+
+<!-- header tables -->
+
+<xsl:template match="header//table">
+	<xsl:choose>
+		<xsl:when test="every $row in * satisfies uk:can-remove-first-column($row)">
+			<xsl:apply-templates select="." mode="remove-first-column" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:next-match />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<xsl:function name="uk:can-remove-first-column" as="xs:boolean">
+	<xsl:param name="row" as="element()" />
+	<xsl:sequence select="count($row/*) = 3 and uk:cell-is-empty($row/*[1])" />
+</xsl:function>
+
+<xsl:function name="uk:cell-is-empty" as="xs:boolean">
+	<xsl:param name="cell" as="element()" />
+	<xsl:sequence select="uk:cell-span-is-effectively-one($cell/@colspan) and uk:cell-span-is-effectively-one($cell/@rowspan) and not(normalize-space(string($cell)))" />
+</xsl:function>
+
+<xsl:function name="uk:cell-span-is-effectively-one" as="xs:boolean">
+	<xsl:param name="attr" as="attribute()?" />
+	<xsl:sequence select="empty($attr) or string($attr) = '' or string($attr) = '1'" />
+</xsl:function>
+
+<xsl:template match="table" mode="remove-first-column">
+	<table class="pr-two-column">
+		<tbody>
+			<xsl:apply-templates mode="remove-first-column" />
+		</tbody>
+	</table>
+</xsl:template>
+
+<xsl:template match="tr" mode="remove-first-column">
+	<tr>
+		<xsl:apply-templates select="*[position() gt 1]" mode="remove-first-column" />
+	</tr>
+</xsl:template>
+
+<xsl:template match="th | td" mode="remove-first-column">
+	<xsl:element name="{ local-name() }">
+		<xsl:apply-templates />
+	</xsl:element>
+</xsl:template>
+
+
+<!-- links -->
+
+<xsl:template match="a | ref">
+	<xsl:choose>
+		<xsl:when test="uk:link-is-supported(@href)">
+			<a>
+				<xsl:apply-templates select="@href" />
+				<xsl:call-template name="inline" />
+			</a>
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:call-template name="inline" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+
+<!-- tables of contents -->
+
+<xsl:template match="toc">
+	<div>
+		<xsl:apply-templates />
+	</div>
+</xsl:template>
+
+<xsl:template match="tocItem">
+	<p>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+
+<!-- markers and attributes -->
+
+<xsl:template match="marker[@name='tab']">
+	<span>
+		<xsl:text> </xsl:text>
+	</span>
+</xsl:template>
+
+<xsl:template match="@style">
+	<xsl:param name="properties" as="xs:string*" select="('font-weight', 'font-style', 'text-transform', 'font-variant', 'text-decoration-line', 'text-decoration-style')" />
+	<xsl:variable name="values" as="xs:string*">
+		<xsl:for-each select="tokenize(., ';')">
+			<xsl:if test="tokenize(., ':')[1] = $properties">
+				<xsl:sequence select="." />
+			</xsl:if>
+		</xsl:for-each>
+	</xsl:variable>
+	<xsl:if test="exists($values)">
+		<xsl:attribute name="style">
+			<xsl:sequence select="string-join($values, ';')" />
+		</xsl:attribute>
+	</xsl:if>
+</xsl:template>
+
+<xsl:template match="@src | @href | @title">
+	<xsl:copy />
+</xsl:template>
+
+<xsl:template match="@class | @refersTo | @date | @as" />
+
+<xsl:template match="@*" />
+
+
+<!-- footnotes -->
+
+<xsl:template match="authorialNote">
+	<xsl:variable name="marker" as="xs:string" select="@marker" />
+	<a id="{ concat('fnref', $marker) }" href="{ concat('#fn', $marker) }" class="judgment-body__footnote-reference">
+		<span class="judgment__hidden"> (Footnote: </span>
+		<sup>
+			<xsl:value-of select="$marker" />
+		</sup>
+		<span class="judgment__hidden">)</span>
+	</a>
+</xsl:template>
+
+<xsl:template name="footnotes">
+	<xsl:param name="footnotes" as="element()*" select="descendant::authorialNote" />
+	<xsl:if test="exists($footnotes)">
+		<footer class="judgment-footer">
+			<hr />
+			<xsl:apply-templates select="$footnotes" mode="footnote" />
+		</footer>
+	</xsl:if>
+</xsl:template>
+
+<xsl:template match="authorialNote" mode="footnote">
+	<div>
+		<xsl:apply-templates />
+	</div>
+</xsl:template>
+
+<xsl:template match="authorialNote/p[1]">
+	<xsl:variable name="marker" as="xs:string" select="../@marker" />
+	<p id="{ concat('fn', $marker) }" class="judgment-footer__footnote">
+		<a href="{ concat('#fnref', $marker) }" class="judgment-footer__footnote-backlink">
+			<span class="judgment__hidden"> (Footnote reference from: </span>
+			<sup>
+				<xsl:value-of select="$marker" />
+			</sup>
+			<span class="judgment__hidden">)</span>
+		</a>
+		<xsl:text> </xsl:text>
+		<xsl:call-template name="inline" />
+	</p>
+</xsl:template>
+
+
+<!-- math -->
+
+<xsl:template match="math:*">
+	<xsl:element name="{ local-name(.) }">
+		<xsl:copy-of select="@*"/>
+		<xsl:apply-templates />
+	</xsl:element>
+</xsl:template>
+
+
+<!-- text -->
+
+<xsl:function name="uk:is-uppercase" as="xs:boolean">
+	<xsl:param name="p" as="element()" />
+	<xsl:param name="context" as="element()" />
+	<xsl:sequence select="uk:is-uppercase($p, false(), $context)" />
+</xsl:function>
+
+<xsl:function name="uk:is-uppercase" as="xs:boolean">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="default" as="xs:boolean" />
+	<xsl:param name="context" as="element()" />
+	<xsl:variable name="text-transform" as="xs:string?" select="uk:get-style-or-class-property($e, 'text-transform', $context)" />
+	<xsl:choose>
+		<xsl:when test="exists($text-transform)">
+			<xsl:sequence select="$text-transform = 'uppercase'" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:sequence select="$default" />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:function>
+
+<!-- the following two functions return a sequence of 0, 1 or 2 values:
+	the first is for the text-decoration-line property,
+	the second is for the text-decoration-style property -->
+
+<xsl:function name="uk:has-underline" as="xs:string*">
+	<xsl:param name="p" as="element()" />
+	<xsl:param name="context" as="element()" />
+	<xsl:sequence select="uk:has-underline($p, (), $context)" />
+</xsl:function>
+
+<xsl:function name="uk:has-underline" as="xs:string*">
+	<xsl:param name="e" as="element()" />
+	<xsl:param name="default" as="xs:string*" />
+	<xsl:param name="context" as="element()" />
+	<xsl:variable name="decor-line" as="xs:string?" select="uk:get-style-or-class-property($e, 'text-decoration-line', $default[1], $context)" />
+	<xsl:variable name="decor-style" as="xs:string?" select="uk:get-style-or-class-property($e, 'text-decoration-style', $default[2], $context)" />
+	<xsl:sequence select="$decor-line" />
+	<xsl:if test="exists($decor-line)">
+		<xsl:sequence select="$decor-style" />
+	</xsl:if>
+</xsl:function>
+
+<xsl:template match="text()">
+	<xsl:param name="has-underline" as="xs:string*" select="()" tunnel="yes" />
+	<xsl:param name="is-uppercase" as="xs:boolean" select="false()" tunnel="yes" />
+	<xsl:choose>
+		<xsl:when test="exists($has-underline) and $has-underline[1] = 'none'">
+			<xsl:next-match>
+				<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+			</xsl:next-match>
+		</xsl:when>
+		<xsl:when test="exists($has-underline)">
+			<xsl:variable name="decor-line" as="xs:string" select="$has-underline[1]" />
+			<xsl:variable name="decor-style" as="xs:string?" select="$has-underline[2]" />
+			<xsl:variable name="styles" as="xs:string*">
+				<xsl:if test="$decor-line != 'underline'">
+					<xsl:sequence select="concat('text-decoration-line:', $decor-line)" />
+				</xsl:if>
+				<xsl:if test="exists($decor-style) and $decor-style != 'solid'">
+					<xsl:sequence select="concat('text-decoration-style:', $decor-style)" />
+				</xsl:if>
+			</xsl:variable>
+			<u>
+				<xsl:if test="exists($styles)">
+					<xsl:attribute name="style">
+						<xsl:sequence select="string-join($styles, ';')" />
+					</xsl:attribute>
+				</xsl:if>
+				<xsl:next-match>
+					<xsl:with-param name="has-underline" select="()" tunnel="yes" />
+				</xsl:next-match>
+			</u>
+		</xsl:when>
+		<xsl:when test="$is-uppercase">
+			<xsl:value-of select="upper-case(.)" />
+		</xsl:when>
+		<xsl:otherwise>
+			<xsl:copy />
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+</xsl:transform>

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -1,4 +1,6 @@
 import datetime
+import os
+import re
 
 import pytest
 
@@ -272,3 +274,24 @@ class TestDocumentBody:
         assert body.transformation_datetime is None
         assert body.get_latest_manifestation_datetime() is None
         assert body.get_manifestation_datetimes("any") == []
+
+    def test_content_as_html_for_standard_judgment(self):
+        """Run our HTML XSLT on a judgment to make sure it's formatting as we expect."""
+
+        with open(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "xslt", "test_standard_judgment.xml"), "r"
+        ) as file:
+            xml_document = file.read()
+
+        with open(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), "xslt", "test_standard_judgment.html"), "r"
+        ) as file:
+            html_document = file.read()
+
+            # The HTML which comes out of the XSLT doesn't have extra whitespace, but our test document does to aid readability.
+            # This reassembles our pretty HTML into a straight string for comparison purposes.
+            html_without_whitespace = "".join(re.split(r"\s*\n\s*", html_document.strip()))
+
+        body = DocumentBody(xml_document.encode())
+
+        assert body.content_as_html == html_without_whitespace

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -1,8 +1,8 @@
 import datetime
 import os
-import re
 
 import pytest
+from bs4 import BeautifulSoup
 
 from caselawclient.models.documents import (
     DocumentBody,
@@ -286,12 +286,11 @@ class TestDocumentBody:
         with open(
             os.path.join(os.path.dirname(os.path.realpath(__file__)), "xslt", "test_standard_judgment.html"), "r"
         ) as file:
-            html_document = file.read()
-
-            # The HTML which comes out of the XSLT doesn't have extra whitespace, but our test document does to aid readability.
-            # This reassembles our pretty HTML into a straight string for comparison purposes.
-            html_without_whitespace = "".join(re.split(r"\s*\n\s*", html_document.strip()))
+            target_html = file.read()
+            prettified_target_html = BeautifulSoup(target_html, features="html.parser").prettify()
 
         body = DocumentBody(xml_document.encode())
+        transformed_html = body.content_as_html(image_base_url="https://test.caselaw.nationalarchives.gov.uk/")
+        prettified_transformed_html = BeautifulSoup(transformed_html, features="html.parser").prettify()
 
-        assert body.content_as_html == html_without_whitespace
+        assert prettified_transformed_html == prettified_target_html

--- a/tests/models/documents/xslt/test_standard_judgment.html
+++ b/tests/models/documents/xslt/test_standard_judgment.html
@@ -1,0 +1,7 @@
+<article class="judgment">
+  <header class="judgment-header">
+    <div class="judgment-header__neutral-citation">
+      Neutral Citation Number: <span class="ncn-nowrap">[2024] UKSC 1234</span>
+    </div>
+  </header>
+</article>

--- a/tests/models/documents/xslt/test_standard_judgment.html
+++ b/tests/models/documents/xslt/test_standard_judgment.html
@@ -1,5 +1,11 @@
 <article class="judgment">
   <header class="judgment-header">
+    <div class="judgment-header__logo">
+      <img
+        src="https://test.caselaw.nationalarchives.gov.uk/uksc/2024/1234/image1.png"
+        style="width:99.05pt;height:99.05pt"
+      />
+    </div>
     <div class="judgment-header__neutral-citation">
       Neutral Citation Number: <span class="ncn-nowrap">[2024] UKSC 1234</span>
     </div>

--- a/tests/models/documents/xslt/test_standard_judgment.xml
+++ b/tests/models/documents/xslt/test_standard_judgment.xml
@@ -15,6 +15,7 @@
             </identification>
         </meta>
         <header>
+            <p><img src="image1.png" style="width:99.05pt;height:99.05pt"/></p>
             <p class="CoverText" style="text-align:left">Neutral Citation Number: <neutralCitation>[2024] UKSC 1234</neutralCitation></p>
         </header>
     </judgment>

--- a/tests/models/documents/xslt/test_standard_judgment.xml
+++ b/tests/models/documents/xslt/test_standard_judgment.xml
@@ -1,0 +1,21 @@
+<akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+    xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+    <judgment>
+        <meta>
+            <identification>
+                <FRBRWork>
+                    <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/uksc/2024/1234"/>
+                    <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/uksc/2024/1234"/>
+                    <FRBRdate date="2024-01-01" name="judgment"/>
+                    <FRBRauthor href="#uksc"/>
+                    <FRBRcountry value="GB-UKM"/>
+                    <FRBRnumber value="1234"/>
+                    <FRBRname value="Test Claimant v TestDefendant"/>
+                </FRBRWork>
+            </identification>
+        </meta>
+        <header>
+            <p class="CoverText" style="text-align:left">Neutral Citation Number: <neutralCitation>[2024] UKSC 1234</neutralCitation></p>
+        </header>
+    </judgment>
+</akomaNtoso>


### PR DESCRIPTION
This will allow us to run XSLT operations in the application itself, rather than handing it off to MarkLogic. This makes the process more easily testable and observable.

## Jira

FCL-386