### PR TITLE
[FCL-394] Allow test failures for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,17 @@ jobs:
       MARKLOGIC_USER: ""
       MARKLOGIC_PASSWORD: ""
 
+    continue-on-error: ${{ matrix.experimental }}
+
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        experimental: [false]
+        include:
+          - version: "3.13"
+            experimental: true
+          - version: "3.14"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Improve our testing strategy by now including Python 3.14 in the test matrix, and also allowing tests on Python 3.13 and 3.14 (which are not yet targeted for support) to fail without cancelling the entire test job.

- [x] This will need an update to GitHub's required tests configuration.

## Jira

FCL-394