### PR TITLE
Erroneous doc.body attribute calls on body work with a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v27.0.2 (unreleased)
+
+- Allow things on doc.body to be called from doc with a warning
+
 ## v27.0.1 (2024-10-17)
 
 - Fix `.content_as_html` on Document Factory

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -495,3 +495,10 @@ class Document:
         Is it sensible to reparse this document?
         """
         return self.docx_exists()
+
+    def __getattr__(self, name: str) -> Any:
+        warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
+        try:
+            return getattr(self.body, name)
+        except Exception:
+            raise AttributeError(f"Neither 'Document' nor 'DocumentBody' objects have an attribute '{name}'")


### PR DESCRIPTION

## Checklist

- [x] I have updated the changelog (if necessary)
