### PR TITLE
Only install minimum requirements to build API documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           poetry-version: 1.4.2
 
-      - run: poetry install --with docs
+      - run: poetry install --only docs
 
       - run: poetry run pdoc -o docs/ src/caselawclient
 


### PR DESCRIPTION
We were previously installing absolutely every dependency to build API documentation; now we install the bare minimum of `pdoc` (and its dependencies).