### PR TITLE
[FCL-396] Change search query highlighting behaviour

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -403,6 +403,7 @@ class MarklogicApiClient:
         judgment_uri: DocumentURIString,
         version_uri: Optional[DocumentURIString] = None,
         show_unpublished: bool = False,
+        query: Optional[str] = None,
     ) -> bytes:
         marklogic_document_uri = self._format_uri_for_marklogic(judgment_uri)
         marklogic_document_version_uri = (
@@ -418,6 +419,7 @@ class MarklogicApiClient:
             "uri": marklogic_document_uri,
             "version_uri": marklogic_document_version_uri,
             "show_unpublished": show_unpublished,
+            "query": query,
         }
 
         response = self._eval_as_bytes(vars, "get_judgment.xqy")
@@ -433,6 +435,7 @@ class MarklogicApiClient:
         judgment_uri: DocumentURIString,
         version_uri: Optional[DocumentURIString] = None,
         show_unpublished: bool = False,
+        query: Optional[str] = None,
     ) -> str:
         return self.get_judgment_xml_bytestring(
             judgment_uri,

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -403,7 +403,7 @@ class MarklogicApiClient:
         judgment_uri: DocumentURIString,
         version_uri: Optional[DocumentURIString] = None,
         show_unpublished: bool = False,
-        query: Optional[str] = None,
+        search_query: Optional[str] = None,
     ) -> bytes:
         marklogic_document_uri = self._format_uri_for_marklogic(judgment_uri)
         marklogic_document_version_uri = (
@@ -419,7 +419,7 @@ class MarklogicApiClient:
             "uri": marklogic_document_uri,
             "version_uri": marklogic_document_version_uri,
             "show_unpublished": show_unpublished,
-            "query": query,
+            "search_query": search_query,
         }
 
         response = self._eval_as_bytes(vars, "get_judgment.xqy")
@@ -435,12 +435,13 @@ class MarklogicApiClient:
         judgment_uri: DocumentURIString,
         version_uri: Optional[DocumentURIString] = None,
         show_unpublished: bool = False,
-        query: Optional[str] = None,
+        search_query: Optional[str] = None,
     ) -> str:
         return self.get_judgment_xml_bytestring(
             judgment_uri,
             version_uri,
             show_unpublished,
+            search_query=search_query,
         ).decode(encoding="utf-8")
 
     def set_document_name(

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -135,6 +135,11 @@ class Document:
         """There is a docx in S3 private bucket for this Document"""
         return check_docx_exists(self.uri)
 
+    def body_with_query(self, query: Optional[str] = None) -> DocumentBody:
+        if not query:
+            return self.body
+        return DocumentBody(self.api_client.get_judgment_xml_bytestring(self.uri, show_unpublished=True, query=query))
+
     @property
     def best_human_identifier(self) -> Optional[str]:
         """

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -105,7 +105,7 @@ class Document:
     Individual document classes should extend this list where necessary to validate document type-specific attributes.
     """
 
-    def __init__(self, uri: str, api_client: "MarklogicApiClient"):
+    def __init__(self, uri: str, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
         """
         :param uri: For historical reasons this accepts a pseudo-URI which may include leading or trailing slashes.
 
@@ -117,7 +117,11 @@ class Document:
             raise DocumentNotFoundError(f"Document {self.uri} does not exist")
 
         self.body: DocumentBody = DocumentBody(
-            xml_bytestring=self.api_client.get_judgment_xml_bytestring(self.uri, show_unpublished=True),
+            xml_bytestring=self.api_client.get_judgment_xml_bytestring(
+                self.uri,
+                show_unpublished=True,
+                search_query=search_query,
+            ),
         )
         """ `Document.body` represents the XML of the document itself, without any information such as version tracking or properties. """
 
@@ -134,11 +138,6 @@ class Document:
     def docx_exists(self) -> bool:
         """There is a docx in S3 private bucket for this Document"""
         return check_docx_exists(self.uri)
-
-    def body_with_query(self, query: Optional[str] = None) -> DocumentBody:
-        if not query:
-            return self.body
-        return DocumentBody(self.api_client.get_judgment_xml_bytestring(self.uri, show_unpublished=True, query=query))
 
     @property
     def best_human_identifier(self) -> Optional[str]:

--- a/src/caselawclient/models/documents/transforms/html.xsl
+++ b/src/caselawclient/models/documents/transforms/html.xsl
@@ -973,6 +973,14 @@
 	</xsl:element>
 </xsl:template>
 
+<!-- search query numbering -->
+
+<xsl:template match="*:mark">
+	<xsl:element name="{ local-name(.) }">
+		<xsl:copy-of select="@*"/>
+		<xsl:apply-templates />
+	</xsl:element>
+</xsl:template>
 
 <!-- text -->
 

--- a/src/caselawclient/models/documents/transforms/html.xsl
+++ b/src/caselawclient/models/documents/transforms/html.xsl
@@ -975,7 +975,7 @@
 
 <!-- search query numbering -->
 
-<xsl:template match="*:mark">
+<xsl:template match="uk:mark">
 	<xsl:element name="{ local-name(.) }">
 		<xsl:copy-of select="@*"/>
 		<xsl:apply-templates />

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -2,6 +2,7 @@ xquery version "1.0-ml";
 
 declare namespace xdmp = "http://marklogic.com/xdmp";
 declare namespace cts = "http://marklogic.com/cts";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
 
 declare variable $show_unpublished as xs:boolean? external;
@@ -12,6 +13,7 @@ declare variable $query as xs:string? external;
 (: Note that `xsl:output method` is changed from `html` to `xml` and we've namespaced the tag :)
 let $number_marks_xslt := (
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                  xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
                   version="2.0">
     <xsl:output method="xml" />
     <xsl:template match="@*|node()">
@@ -19,12 +21,12 @@ let $number_marks_xslt := (
         <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
     </xsl:template>
-    <xsl:template match="mark">
+    <xsl:template match="uk:mark">
       <xsl:copy>
           <xsl:copy-of select="@*" />
           <xsl:attribute name="id">
               <xsl:text>mark_</xsl:text>
-              <xsl:value-of select="count(preceding::mark)"/>
+              <xsl:value-of select="count(preceding::uk:mark)"/>
           </xsl:attribute>
           <xsl:apply-templates />
       </xsl:copy>
@@ -53,7 +55,7 @@ let $transformed := if($query) then
         cts:highlight(
           $raw_xml,
           helper:make-q-query($query),
-          <mark>{$cts:text}</mark>
+          <uk:mark>{$cts:text}</uk:mark>
         )
       )
     else

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -1,8 +1,36 @@
 xquery version "1.0-ml";
 
+declare namespace xdmp = "http://marklogic.com/xdmp";
+declare namespace cts = "http://marklogic.com/cts";
+import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper" at "/judgments/search/helper.xqy";
+
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
 declare variable $version_uri as xs:string? external;
+declare variable $query as xs:string? external;
+
+(: Note that `xsl:output method` is changed from `html` to `xml` and we've namespaced the tag :)
+let $number_marks_xslt := (
+  <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                  version="2.0">
+    <xsl:output method="xml" />
+    <xsl:template match="@*|node()">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </xsl:template>
+    <xsl:template match="mark">
+      <xsl:copy>
+          <xsl:copy-of select="@*" />
+          <xsl:attribute name="id">
+              <xsl:text>mark_</xsl:text>
+              <xsl:value-of select="count(preceding::mark)"/>
+          </xsl:attribute>
+          <xsl:apply-templates />
+      </xsl:copy>
+    </xsl:template>
+  </xsl:stylesheet>
+)
 
 let $judgment := fn:document($uri)
 let $version := if ($version_uri) then fn:document($version_uri) else ()
@@ -11,11 +39,25 @@ let $is_published := $judgment_published_property/text()
 
 let $document_to_return := if ($version_uri) then $version else $judgment
 
-let $return_value := if ($show_unpublished) then
+
+let $raw_xml := if ($show_unpublished) then
         $document_to_return
     else if (xs:boolean($is_published)) then
         $document_to_return
     else
         ()
 
-return $return_value
+let $transformed := if($query) then
+      xdmp:xslt-eval(
+        $number_marks_xslt,
+        cts:highlight(
+          $raw_xml,
+          helper:make-q-query($query),
+          <mark>{$cts:text}</mark>
+        )
+      )
+    else
+      $raw_xml
+
+
+return $transformed

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -8,7 +8,7 @@ import module namespace helper = "https://caselaw.nationalarchives.gov.uk/helper
 declare variable $show_unpublished as xs:boolean? external;
 declare variable $uri as xs:string external;
 declare variable $version_uri as xs:string? external;
-declare variable $query as xs:string? external;
+declare variable $search_query as xs:string? external;
 
 (: Note that `xsl:output method` is changed from `html` to `xml` and we've namespaced the tag :)
 let $number_marks_xslt := (
@@ -49,12 +49,13 @@ let $raw_xml := if ($show_unpublished) then
     else
         ()
 
-let $transformed := if($query) then
+(: If a search query string is present, highlight instances :)
+let $transformed := if($search_query) then
       xdmp:xslt-eval(
         $number_marks_xslt,
         cts:highlight(
           $raw_xml,
-          helper:make-q-query($query),
+          helper:make-q-query($search_query),
           <uk:mark>{$cts:text}</uk:mark>
         )
       )

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -64,7 +64,7 @@ class GetComponentsForDocumentDict(MarkLogicAPIDict):
 
 # get_judgment.xqy
 class GetJudgmentDict(MarkLogicAPIDict):
-    query: Optional[str]
+    search_query: Optional[str]
     show_unpublished: Optional[bool]
     uri: MarkLogicDocumentURIString
     version_uri: Optional[MarkLogicDocumentVersionURIString]

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -64,6 +64,7 @@ class GetComponentsForDocumentDict(MarkLogicAPIDict):
 
 # get_judgment.xqy
 class GetJudgmentDict(MarkLogicAPIDict):
+    query: Optional[str]
     show_unpublished: Optional[bool]
     uri: MarkLogicDocumentURIString
     version_uri: Optional[MarkLogicDocumentVersionURIString]

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -220,6 +220,13 @@ class TestDocument:
 
         mock_api_client.validate_document.assert_called_with(document.uri)
 
+    def test_document_initialises_with_search_query_string(self, mock_api_client):
+        document = Document("test/1234", mock_api_client, search_query="test search query")
+
+        mock_api_client.get_judgment_xml_bytestring.assert_called_with(
+            document.uri, show_unpublished=True, search_query="test search query"
+        )
+
 
 class TestDocumentEnrichedRecently:
     def test_enriched_recently_returns_false_when_never_enriched(self, mock_api_client):

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -45,6 +45,7 @@ class TestJudgmentValidation:
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
             "test/1234",
             show_unpublished=True,
+            search_query=None,
         )
 
     @pytest.mark.parametrize(

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -51,6 +51,7 @@ class TestPressSummaryValidation:
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
             "test/1234",
             show_unpublished=True,
+            search_query=None,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary of changes

Change the behaviour of search query highlighting so that it happens when the document is retrieved, not when it's transformed into HTML.

## Jira

FCL-396

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
