### PR TITLE
[FCL-461] Initialising a Document now requires a DocumentURIString, not a str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- Document can now no longer be initialised with a string as the `uri`, it must be a `DocumentURIString`.
+
 ## v27.4.0 (2024-11-07)
 
 ### Change of behaviour

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -209,12 +209,14 @@ class MarklogicApiClient:
         Returns a list of PressSummary objects associated with a given Document URI
         """
         vars: query_dicts.GetComponentsForDocumentDict = {
-            "parent_uri": DocumentURIString(uri if uri.startswith("/") else "/" + uri),
+            "parent_uri": uri,
             "component": "pressSummary",
         }
         response = self._send_to_eval(vars, "get_components_for_document.xqy")
         uris = get_multipart_strings_from_marklogic_response(response)
-        return [PressSummary(uri.strip(".xml"), self) for uri in uris]
+        return [
+            PressSummary(DocumentURIString(uri.strip("/").strip(".xml")), self) for uri in uris
+        ]  # TODO: Migrate this strip behaviour into proper manipulation of a MarkLogicURIString
 
     def get_document_by_uri(
         self,

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from typing_extensions import TypeAlias
 
 from caselawclient.Client import MarklogicApiClient
-from caselawclient.models.documents import Document
+from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.models.documents.body import DocumentBody
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
@@ -54,7 +54,7 @@ class DocumentFactory:
     @classmethod
     def build(
         cls,
-        uri: str = "test/2023/123",
+        uri: DocumentURIString = DocumentURIString("test/2023/123"),
         html: str = "<p>This is a judgment.</p>",
         api_client: Optional[MarklogicApiClient] = None,
         **kwargs: Any,

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -105,13 +105,15 @@ class Document:
     Individual document classes should extend this list where necessary to validate document type-specific attributes.
     """
 
-    def __init__(self, uri: str, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
+    def __init__(self, uri: DocumentURIString, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
         """
-        :param uri: For historical reasons this accepts a pseudo-URI which may include leading or trailing slashes.
+        :param uri: The URI of the document to retrieve from MarkLogic.
+        :param api_client: An instance of the API client object to handle communication with the MarkLogic server.
+        :param search_query: Optionally, a search string which should be highlighted if it appears in the document body.
 
         :raises DocumentNotFoundError: The document does not exist within MarkLogic
         """
-        self.uri: DocumentURIString = DocumentURIString(uri.strip("/"))
+        self.uri: DocumentURIString = uri
         self.api_client: MarklogicApiClient = api_client
         if not self.document_exists():
             raise DocumentNotFoundError(f"Document {self.uri} does not exist")
@@ -123,7 +125,7 @@ class Document:
                 search_query=search_query,
             ),
         )
-        """ `Document.body` represents the XML of the document itself, without any information such as version tracking or properties. """
+        """ `Document.body` represents the body of the document itself, without any information such as version tracking or properties. """
 
     def __repr__(self) -> str:
         name = self.body.name or "un-named"

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -4,3 +4,7 @@ class CannotPublishUnpublishableDocument(Exception):
 
 class DocumentNotSafeForDeletion(Exception):
     """A document which is not safe for deletion cannot be deleted."""
+
+
+class InvalidDocumentURIException(Exception):
+    """The document URI is not valid."""

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -10,7 +10,7 @@ from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 if TYPE_CHECKING:
     from caselawclient.models.press_summaries import PressSummary
 
-from .documents import Document
+from .documents import Document, DocumentURIString
 
 
 class Judgment(NeutralCitationMixin, Document):
@@ -21,8 +21,8 @@ class Judgment(NeutralCitationMixin, Document):
     document_noun = "judgment"
     document_noun_plural = "judgments"
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(self.document_noun, *args, **kwargs)
+    def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
+        super().__init__(self.document_noun, uri, *args, **kwargs)
 
     @cached_property
     def neutral_citation(self) -> NeutralCitationString:
@@ -46,7 +46,7 @@ class Judgment(NeutralCitationMixin, Document):
         Attempt to fetch a linked press summary, and return it, if it exists
         """
         try:
-            uri = self.uri + "/press-summary/1"
+            uri = DocumentURIString(self.uri + "/press-summary/1")
             if not TYPE_CHECKING:  # This isn't nice, but will be cleaned up when we refactor how related documents work
                 PressSummary = importlib.import_module("caselawclient.models.press_summaries").PressSummary
             return PressSummary(uri, self.api_client)

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -9,7 +9,7 @@ from ds_caselaw_utils.types import NeutralCitationString
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 
-from .documents import Document
+from .documents import Document, DocumentURIString
 
 if TYPE_CHECKING:
     from caselawclient.models.judgments import Judgment
@@ -23,8 +23,8 @@ class PressSummary(NeutralCitationMixin, Document):
     document_noun = "press summary"
     document_noun_plural = "press summaries"
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(self.document_noun, *args, **kwargs)
+    def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
+        super().__init__(self.document_noun, uri, *args, **kwargs)
 
     @cached_property
     def neutral_citation(self) -> NeutralCitationString:
@@ -47,7 +47,7 @@ class PressSummary(NeutralCitationMixin, Document):
         Attempt to fetch a linked judgement, and return it, if it exists
         """
         try:
-            uri = self.uri.removesuffix("/press-summary/1")
+            uri = DocumentURIString(self.uri.removesuffix("/press-summary/1"))
             if not TYPE_CHECKING:  # This isn't nice, but will be cleaned up when we refactor how related documents work
                 Judgment = importlib.import_module("caselawclient.models.judgments").Judgment
             return Judgment(uri, self.api_client)

--- a/src/caselawclient/models/utilities/__init__.py
+++ b/src/caselawclient/models/utilities/__init__.py
@@ -12,14 +12,14 @@ uk_namespace = {"uk": "https://caselaw.nationalarchives.gov.uk/akn"}
 
 
 class VersionsDict(TypedDict):
-    uri: str
+    uri: str  ## TODO: This should be either a MarkLogicDocumentURIString (raw from ML) or a DocumentURIString (and we parse it out). Just a str is too vague.
     version: int
 
 
 def render_versions(decoded_versions: list[BodyPart]) -> list[VersionsDict]:
     versions: list[VersionsDict] = [
         {
-            "uri": part.text.rstrip(".xml"),
+            "uri": part.text.strip("/").rstrip(".xml"),
             "version": extract_version(part.text),
         }
         for part in decoded_versions

--- a/src/caselawclient/xquery/get_components_for_document.xqy
+++ b/src/caselawclient/xquery/get_components_for_document.xqy
@@ -14,7 +14,7 @@ let $docTypeQuery := cts:element-attribute-value-query(
     )
 let $refQuery := cts:element-query(
       xs:QName("uk:summaryOf"),
-      concat("https://caselaw.nationalarchives.gov.uk/id", $parent_uri)
+      concat("https://caselaw.nationalarchives.gov.uk/id/", $parent_uri)
     )
 
 return xdmp:node-uri(cts:search(//akn:akomaNtoso, cts:and-query(($refQuery, $collectionQuery, $docTypeQuery))))

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -14,7 +14,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
 
     def test_checkout_judgment(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             annotation = "locked by A KITTEN"
             expected_vars = {
                 "uri": "/ewca/civ/2004/632.xml",
@@ -35,7 +35,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
             "calculate_seconds_until_midnight",
             return_value=3600,
         ):
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             annotation = "locked by A KITTEN"
             expires_at_midnight = True
             expected_vars = {
@@ -50,7 +50,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
 
     def test_checkout_judgment_with_timeout_seconds(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             annotation = "locked by A KITTEN"
             timeout_seconds = 1234
             expected_vars = {
@@ -65,7 +65,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
 
     def test_checkin_judgment(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             expected_vars = {"uri": "/ewca/civ/2004/632.xml"}
             self.client.checkin_judgment(uri)
 
@@ -101,7 +101,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 b"</dls:checkout>\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_judgment_checkout_status_message(DocumentURIString("/ewca/2002/2"))
+            result = self.client.get_judgment_checkout_status_message(DocumentURIString("ewca/2002/2"))
             assert result == "locked by a kitten"
 
     def test_get_checkout_status_message_empty(self):
@@ -118,7 +118,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 b"\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_judgment_checkout_status_message(DocumentURIString("/ewca/2002/2"))
+            result = self.client.get_judgment_checkout_status_message(DocumentURIString("ewca/2002/2"))
             assert result is None
 
     def test_calculate_seconds_until_midnight(self):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -106,7 +106,7 @@ class ApiClientTest(unittest.TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
     def test_document_exists(self, mock_decode):
         mock_decode.return_value = "true"
-        assert self.client.document_exists(DocumentURIString("/2029/eat/1")) is True
+        assert self.client.document_exists(DocumentURIString("2029/eat/1")) is True
         mock_decode.assert_called_with(
             {"uri": "/2029/eat/1.xml"},
             "document_exists.xqy",
@@ -115,7 +115,7 @@ class ApiClientTest(unittest.TestCase):
     @patch("caselawclient.Client.MarklogicApiClient._eval_and_decode")
     def test_document_not_exists(self, mock_decode):
         mock_decode.return_value = "false"
-        assert self.client.document_exists(DocumentURIString("/2029/eat/1")) is False
+        assert self.client.document_exists(DocumentURIString("2029/eat/1")) is False
         mock_decode.assert_called_with(
             {"uri": "/2029/eat/1.xml"},
             "document_exists.xqy",
@@ -158,19 +158,7 @@ class ApiClientTest(unittest.TestCase):
             )
 
     def test_format_uri(self):
-        uri = DocumentURIString("/ewca/2022/123")
-        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
-
-    def test_format_uri_no_leading_slash(self):
         uri = DocumentURIString("ewca/2022/123")
-        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
-
-    def test_format_uri_trailing_slash(self):
-        uri = DocumentURIString("ewca/2022/123/")
-        assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
-
-    def test_format_uri_all_the_slashes(self):
-        uri = DocumentURIString("/ewca/2022/123/")
         assert self.client._format_uri_for_marklogic(uri) == "/ewca/2022/123.xml"
 
     def test_user_agent(self):

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -20,7 +20,7 @@ class TestEvalXslt(unittest.TestCase):
             "user_can_view_unpublished_judgments",
             return_value=True,
         ):
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars: XsltTransformDict = {
                 "uri": MarkLogicDocumentURIString("/judgment/uri.xml"),
                 "version_uri": None,
@@ -43,7 +43,7 @@ class TestEvalXslt(unittest.TestCase):
             "user_can_view_unpublished_judgments",
             return_value=False,
         ), patch.object(logging, "warning") as mock_logging:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars: XsltTransformDict = {
                 "uri": MarkLogicDocumentURIString("/judgment/uri.xml"),
                 "version_uri": None,
@@ -67,7 +67,7 @@ class TestEvalXslt(unittest.TestCase):
             "user_can_view_unpublished_judgments",
             return_value=True,
         ):
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars: XsltTransformDict = {
                 "uri": MarkLogicDocumentURIString("/judgment/uri.xml"),
                 "version_uri": None,
@@ -92,7 +92,7 @@ class TestEvalXslt(unittest.TestCase):
             "user_can_view_unpublished_judgments",
             return_value=True,
         ):
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             query = "the query string"
             expected_vars: XsltTransformDict = {
                 "uri": MarkLogicDocumentURIString("/judgment/uri.xml"),

--- a/tests/client/test_get_judgment_and_versions.py
+++ b/tests/client/test_get_judgment_and_versions.py
@@ -29,7 +29,7 @@ class TestGetJudgment(unittest.TestCase):
                 b"</akomaNtoso>"
             )
 
-            result = self.client.get_judgment_xml(DocumentURIString("/judgment/uri"))
+            result = self.client.get_judgment_xml(DocumentURIString("judgment/uri"))
 
             expected = (
                 '<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -42,7 +42,7 @@ class TestGetJudgment(unittest.TestCase):
 
     def test_get_judgment_version(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             version = 3
             expected_vars = {"uri": "/ewca/civ/2004/632.xml", "version": "3"}
             self.client.get_judgment_version(uri, version)
@@ -52,7 +52,7 @@ class TestGetJudgment(unittest.TestCase):
 
     def test_list_judgment_versions(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             expected_vars = {"uri": "/ewca/civ/2004/632.xml"}
             self.client.list_judgment_versions(uri)
 

--- a/tests/client/test_get_press_summaries_for_document_uri.py
+++ b/tests/client/test_get_press_summaries_for_document_uri.py
@@ -19,25 +19,23 @@ class TestGetPressSummariesForDocumentUri(TestCase):
         mock_press_summary,
     ):
         mock_eval.return_value = "EVAL"
-        mock_get_marklogic_response.return_value = ["/foo/bar/baz/1", "/foo/bar/baz/2"]
+        mock_get_marklogic_response.return_value = ["foo/bar/baz/1", "foo/bar/baz/2"]
 
-        for uri in ["foo/bar", "/foo/bar"]:
-            with self.subTest(uri=uri):
-                self.client.get_press_summaries_for_document_uri(DocumentURIString(uri))
+        self.client.get_press_summaries_for_document_uri(DocumentURIString("foo/bar"))
 
-                mock_get_marklogic_response.assert_called_with("EVAL")
-                mock_eval.assert_called_with(
-                    {
-                        "parent_uri": "/foo/bar",
-                        "component": "pressSummary",
-                    },
-                    "get_components_for_document.xqy",
-                )
+        mock_get_marklogic_response.assert_called_with("EVAL")
+        mock_eval.assert_called_with(
+            {
+                "parent_uri": "foo/bar",
+                "component": "pressSummary",
+            },
+            "get_components_for_document.xqy",
+        )
 
-                mock_press_summary.assert_has_calls(
-                    [
-                        call("/foo/bar/baz/1", self.client),
-                        call("/foo/bar/baz/2", self.client),
-                    ],
-                    any_order=True,
-                )
+        mock_press_summary.assert_has_calls(
+            [
+                call("foo/bar/baz/1", self.client),
+                call("foo/bar/baz/2", self.client),
+            ],
+            any_order=True,
+        )

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -153,7 +153,7 @@ class TestGetSetMetadata(unittest.TestCase):
 
     def test_set_internal_uri_leading_slash(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars = {
                 "uri": "/judgment/uri.xml",
                 "content_with_id": "https://caselaw.nationalarchives.gov.uk/id/judgment/uri",

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -13,7 +13,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
 
     def test_set_boolean_property_true(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars = {
                 "uri": "/judgment/uri.xml",
                 "value": "true",
@@ -29,7 +29,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
 
     def test_set_boolean_property_false(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars = {
                 "uri": "/judgment/uri.xml",
                 "value": "false",
@@ -46,7 +46,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
     def test_get_unset_boolean_property(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.content = ""
-            result = self.client.get_boolean_property(DocumentURIString("/judgment/uri"), "my-property")
+            result = self.client.get_boolean_property(DocumentURIString("judgment/uri"), "my-property")
 
             assert result is False
 
@@ -65,7 +65,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 b"\r\ntrue\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_boolean_property(DocumentURIString("/judgment/uri"), "my-property")
+            result = self.client.get_boolean_property(DocumentURIString("judgment/uri"), "my-property")
 
             assert result is True
 
@@ -84,20 +84,20 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 b"\r\nmy-content\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_property(DocumentURIString("/judgment/uri"), "my-property")
+            result = self.client.get_property(DocumentURIString("judgment/uri"), "my-property")
 
             assert result == "my-content"
 
     def test_get_unset_property(self):
         with patch.object(self.client, "eval") as mock_eval:
             mock_eval.return_value.content = ""
-            result = self.client.get_property(DocumentURIString("/judgment/uri"), "my-property")
+            result = self.client.get_property(DocumentURIString("judgment/uri"), "my-property")
 
             assert result == ""
 
     def test_set_property(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars = {
                 "uri": "/judgment/uri.xml",
                 "value": "my-value",

--- a/tests/client/test_get_version_annotation.py
+++ b/tests/client/test_get_version_annotation.py
@@ -23,6 +23,6 @@ class TestGetVersionAnnotation(unittest.TestCase):
                 b"\r\nthis is an annotation\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_version_annotation(DocumentURIString("/judgment/uri"))
+            result = self.client.get_version_annotation(DocumentURIString("judgment/uri"))
 
             assert result == "this is an annotation"

--- a/tests/client/test_get_version_created_datetime.py
+++ b/tests/client/test_get_version_created_datetime.py
@@ -24,7 +24,7 @@ class TestGetVersionCreatedDatetime(unittest.TestCase):
                 b"\r\n2022-04-11T16:12:33.548954+01:00\r\n"
                 b"--595658fa1db1aa98--\r\n"
             )
-            result = self.client.get_version_created_datetime(DocumentURIString("/judgment/uri"))
+            result = self.client.get_version_created_datetime(DocumentURIString("judgment/uri"))
 
             assert result == datetime.datetime(
                 2022,

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -25,7 +25,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
 
     def test_update_document_xml(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             judgment_str = "<root>My updated judgment</root>"
             judgment_xml = ElementTree.fromstring(judgment_str)
             expected_vars = {
@@ -65,7 +65,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
         with patch.object(caselawclient.Client, "validate_content_hash"), patch.object(
             self.client, "eval"
         ) as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             judgment_str = "<root>My updated judgment</root>"
             judgment_xml = judgment_str.encode("utf-8")
             expected_vars = {
@@ -106,7 +106,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             caselawclient.Client,
             "validate_content_hash",
         ) as mock_validate_hash:
-            uri = DocumentURIString("/ewca/civ/2004/632")
+            uri = DocumentURIString("ewca/civ/2004/632")
             judgment_str = "<root>My updated judgment</root>"
             judgment_xml = judgment_str.encode("utf-8")
             mock_validate_hash.side_effect = InvalidContentHashError()
@@ -124,7 +124,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
 
     def test_insert_document_xml(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/ewca/civ/2004/632/")
+            uri = DocumentURIString("ewca/civ/2004/632")
             document_str = "<root>My judgment</root>"
             document_xml = ElementTree.fromstring(document_str)
             expected_vars = {
@@ -157,7 +157,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
 
     def test_delete_document(self):
         with patch.object(self.client, "eval") as mock_eval:
-            uri = DocumentURIString("/judgment/uri")
+            uri = DocumentURIString("judgment/uri")
             expected_vars = {
                 "uri": "/judgment/uri.xml",
             }
@@ -168,8 +168,8 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
 
     def test_copy_document(self):
         with patch.object(self.client, "eval") as mock_eval:
-            old_uri = DocumentURIString("/judgment/old_uri")
-            new_uri = DocumentURIString("/judgment/new_uri")
+            old_uri = DocumentURIString("judgment/old_uri")
+            new_uri = DocumentURIString("judgment/new_uri")
             expected_vars = {
                 "old_uri": "/judgment/old_uri.xml",
                 "new_uri": "/judgment/new_uri.xml",

--- a/tests/client/test_validate_document.py
+++ b/tests/client/test_validate_document.py
@@ -24,7 +24,7 @@ class TestValidateDocument(unittest.TestCase):
                 b"--c878f7cb55370005--\r\n"
             )
 
-            assert self.client.validate_document(DocumentURIString("/foo/bar/123")) is True
+            assert self.client.validate_document(DocumentURIString("foo/bar/123")) is True
 
     def test_validation_failure(self):
         with patch.object(self.client, "eval") as mock_eval:
@@ -44,4 +44,4 @@ class TestValidateDocument(unittest.TestCase):
                 b"--c878f7cb55370005--\r\n"
             )
 
-            assert self.client.validate_document(DocumentURIString("/foo/bar/123")) is False
+            assert self.client.validate_document(DocumentURIString("foo/bar/123")) is False

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -172,7 +172,7 @@ class TestReparse:
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
     def test_force_reparse_empty(self, sns, mock_api_client):
-        document = Judgment("test/2023/123", mock_api_client)
+        document = Judgment(DocumentURIString("test/2023/123"), mock_api_client)
 
         document.consignment_reference = "TDR-12345"
 
@@ -224,7 +224,7 @@ class TestReparse:
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
     def test_force_reparse_full(self, sns, mock_api_client):
-        document = Judgment("test/2023/123", mock_api_client)
+        document = Judgment(DocumentURIString("test/2023/123"), mock_api_client)
 
         document.neutral_citation = NeutralCitationString("[2023] Test 123")
         document.consignment_reference = "TDR-12345"

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -4,23 +4,24 @@ import pytest
 
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.factories import PressSummaryFactory
+from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.neutral_citation_mixin import NeutralCitationString
 
 
 class TestJudgment:
     def test_best_identifier(self, mock_api_client):
-        judgment = Judgment("test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
         judgment.neutral_citation = NeutralCitationString("[2023] TEST 1234")
         assert judgment.best_human_identifier == judgment.neutral_citation
 
 
 class TestJudgmentValidation:
     def test_has_ncn(self, mock_api_client):
-        document_with_ncn = Judgment("test/1234", mock_api_client)
+        document_with_ncn = Judgment(DocumentURIString("test/1234"), mock_api_client)
         document_with_ncn.neutral_citation = NeutralCitationString("[2023] TEST 1234")
 
-        document_without_ncn = Judgment("test/1234", mock_api_client)
+        document_without_ncn = Judgment(DocumentURIString("test/1234"), mock_api_client)
         document_without_ncn.neutral_citation = NeutralCitationString("")
 
         assert document_with_ncn.has_ncn is True
@@ -40,7 +41,7 @@ class TestJudgmentValidation:
             </akomaNtoso>
         """
 
-        judgment = Judgment("test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
 
         assert judgment.neutral_citation == "[2023] TEST 1234"
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
@@ -71,13 +72,13 @@ class TestJudgmentValidation:
         ],
     )
     def test_has_valid_ncn(self, mock_api_client, ncn_to_test, valid):
-        judgment = Judgment("test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
         judgment.neutral_citation = ncn_to_test
 
         assert judgment.has_valid_ncn is valid
 
     def test_judgment_validation_failure_messages_if_failing(self, mock_api_client):
-        judgment = Judgment("test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
         judgment.is_failure = True
         judgment.is_parked = True
         judgment.is_held = True
@@ -105,7 +106,7 @@ class TestLinkedDocuments:
         press_summary = PressSummaryFactory.build()
         document_mock.return_value = press_summary
 
-        judgment = Judgment("/test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
 
         assert judgment.linked_document == press_summary
         document_mock.assert_called_once_with(
@@ -121,5 +122,5 @@ class TestLinkedDocuments:
     ):
         document_mock.side_effect = DocumentNotFoundError()
 
-        judgment = Judgment("/test/1234", mock_api_client)
+        judgment = Judgment(DocumentURIString("test/1234"), mock_api_client)
         assert judgment.linked_document is None

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -11,7 +11,7 @@ from caselawclient.models.press_summaries import PressSummary
 
 class TestPressSummary:
     def test_best_identifier(self, mock_api_client):
-        summary = PressSummary("test/1234", mock_api_client)
+        summary = PressSummary(DocumentURIString("test/1234"), mock_api_client)
         summary.neutral_citation = NeutralCitationString("[2023] TEST 1234")
         assert summary.best_human_identifier == summary.neutral_citation
 
@@ -47,7 +47,7 @@ class TestPressSummaryValidation:
         </akomaNtoso>
         """
 
-        press_summary = PressSummary("test/1234", mock_api_client)
+        press_summary = PressSummary(DocumentURIString("test/1234"), mock_api_client)
 
         assert press_summary.neutral_citation == "[2016] TEST 49"
         mock_api_client.get_judgment_xml_bytestring.assert_called_once_with(
@@ -78,7 +78,7 @@ class TestPressSummaryValidation:
         ],
     )
     def test_has_valid_ncn(self, mock_api_client, ncn_to_test, valid):
-        press_summary = PressSummary("test/1234", mock_api_client)
+        press_summary = PressSummary(DocumentURIString("test/1234"), mock_api_client)
         press_summary.neutral_citation = ncn_to_test
 
         assert press_summary.has_valid_ncn is valid
@@ -87,7 +87,7 @@ class TestPressSummaryValidation:
         self,
         mock_api_client,
     ):
-        press_summary = PressSummary("test/1234", mock_api_client)
+        press_summary = PressSummary(DocumentURIString("test/1234"), mock_api_client)
         press_summary.is_failure = True
         press_summary.is_parked = True
         press_summary.is_held = True
@@ -115,7 +115,7 @@ class TestLinkedDocuments:
         judgment = JudgmentFactory.build()
         document_mock.return_value = judgment
 
-        press_summary = PressSummary("/test/1234/press-summary/1", mock_api_client)
+        press_summary = PressSummary(DocumentURIString("test/1234/press-summary/1"), mock_api_client)
 
         assert press_summary.linked_document == judgment
         document_mock.assert_called_once_with("test/1234", mock_api_client)
@@ -128,5 +128,5 @@ class TestLinkedDocuments:
     ):
         document_mock.side_effect = DocumentNotFoundError()
 
-        press_summary = PressSummary("/test/1234/press-summary/1", mock_api_client)
+        press_summary = PressSummary(DocumentURIString("test/1234/press-summary/1"), mock_api_client)
         assert press_summary.linked_document is None

--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -39,9 +39,9 @@ class TestVersionUtils:
         requests_toolbelt.multipart.decoder.BodyPart.return_value = version_parts
 
         expected_result = [
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/3-1178", "version": 3},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/2-1178", "version": 2},
-            {"uri": "/ewhc/ch/2022/1178_xml_versions/1-1178", "version": 1},
+            {"uri": "ewhc/ch/2022/1178_xml_versions/3-1178", "version": 3},
+            {"uri": "ewhc/ch/2022/1178_xml_versions/2-1178", "version": 2},
+            {"uri": "ewhc/ch/2022/1178_xml_versions/1-1178", "version": 1},
         ]
 
         assert render_versions(version_parts) == expected_result


### PR DESCRIPTION
This previously accepted a str and would attempt to strip it and remove slashes. It now only accepts a `DocumentURIString` object.

To enforce this, `DocumentURIString` is now a subclass of `str` which will validate incoming strings on creation time and raise an exception if they don't match the expected format.

BREAKING CHANGE: Document can now no longer be initialised with a string as the `uri`, it must be a `DocumentURIString`.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
