### PR TITLE
[FCL-386] Search query can now be passed to get_document_by_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **FCL-386**: search query can now be passed to get_document_by_uri
+
 ## v27.2.0 (2024-10-28)
 
 ## Feat

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -217,10 +217,10 @@ class MarklogicApiClient:
     def get_document_by_uri(
         self,
         uri: DocumentURIString,
-        query: Optional[str] = None,
+        search_query: Optional[str] = None,
     ) -> Document:
         document_type_class = self.get_document_type_from_uri(uri)
-        return document_type_class(uri, self)
+        return document_type_class(uri, self, search_query=search_query)
 
     def get_document_type_from_uri(self, uri: DocumentURIString) -> Type[Document]:
         vars: query_dicts.DocumentCollectionsDict = {

--- a/tests/client/test_get_document_by_uri.py
+++ b/tests/client/test_get_document_by_uri.py
@@ -25,7 +25,19 @@ class TestGetDocumentByUri(TestCase):
         document = self.client.get_document_by_uri(uri="test/1234")
 
         mock_get_document_type.assert_called_with("test/1234")
-        mock_judgment.assert_called_with("test/1234", self.client)
+        mock_judgment.assert_called_with("test/1234", self.client, search_query=None)
+
+        self.assertIsInstance(document, Judgment)
+
+    @patch("caselawclient.Client.Judgment", autospec=True)
+    @patch("caselawclient.Client.MarklogicApiClient.get_document_type_from_uri")
+    def test_get_document_by_uri_with_search_query(self, mock_get_document_type, mock_judgment):
+        mock_get_document_type.return_value = mock_judgment
+
+        document = self.client.get_document_by_uri(uri="test/1234", search_query="Test search")
+
+        mock_get_document_type.assert_called_with("test/1234")
+        mock_judgment.assert_called_with("test/1234", self.client, search_query="Test search")
 
         self.assertIsInstance(document, Judgment)
 


### PR DESCRIPTION
## Summary of changes

This is necessary to support constructing documents with query highlighting.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
