### PR TITLE
bump: version 27.2.0 → 27.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v27.3.0 (2024-10-30)
 
 ### Feat
 
 - **FCL-386**: search query can now be passed to get_document_by_uri
-- **FCL-318**: Allow setting a limit on the number of enrich/reparse targets returned
 
 ## v27.2.0 (2024-10-28)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "27.2.0"
+version = "27.3.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **FCL-386**: search query can now be passed to get_document_by_uri