### PR TITLE
Add DEBUG logging

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -62,6 +62,8 @@ except importlib.metadata.PackageNotFoundError:
     VERSION = "0"
 DEFAULT_USER_AGENT = f"ds-caselaw-marklogic-api-client/{VERSION}"
 
+DEBUG: bool = bool(os.getenv("DEBUG", default=False))
+
 
 class NoResponse(Exception):
     """A requests HTTPError has no response. We expect this will never happen."""
@@ -728,6 +730,10 @@ class MarklogicApiClient:
             "vars": vars,
         }
         path = "LATEST/eval"
+
+        if DEBUG:
+            print(f"Sending {vars} to {xquery_path}")
+
         response = self.session.request(
             "POST",
             url=self._path_to_request_url(path),


### PR DESCRIPTION
## Summary of changes

If the `DEBUG` environment variable isn't blank or empty, display the arguments passed to xquery files.

```
service-1  | Sending {"uri": "/failures/BULK-0.xml", "annotation": "Judgment locked for editing by dragon at 2024-11-06T17:08:41.872618+00:00 for 1 seconds", "timeout": 1} to /app/.venv/lib/python3.12/site-packages/caselawclient/xquery/checkout_judgment.xqy
service-1  | Sending {"user": "dragon", "role": "admin"} to /app/.venv/lib/python3.12/site-packages/caselawclient/xquery/user_has_role.xqy
service-1  | Sending {"uri": "/failures/BULK-0.xml", "version_uri": null, "show_unpublished": true, "search_query": null} to /app/.venv/lib/python3.12/site-packages/caselawclient/xquery/get_judgment.xqy
```

## Checklist

- [x] I have considered if this is a breaking change (no)
- [x] I have updated the changelog 
