### PR TITLE
[FCL-309] Add the ability for documents to store abstract identifiers in MarkLogic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### Feat
+
+- **FCL-309**: add functionality for packing and unpacking XML representations of identifiers
+- **FCL-309**: add stub for defining identifier schemas, and a Neutral Citation schema
+
 ### Fix
 
 - **deps**: update boto packages to v1.35.61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- **FCL-309**: identifiers can compile URL slugs
+- **FCL-309**: identifiers can now be saved to and retrieved from MarkLogic
 - **FCL-309**: add functionality for packing and unpacking XML representations of identifiers
 - **FCL-309**: add stub for defining identifier schemas, and a Neutral Citation schema
 
 ### Fix
 
+- **deps**: update dependency ds-caselaw-utils to v2.0.1
+- **deps**: update dependency mypy-boto3-sns to v1.35.68
+- **deps**: update boto packages to v1.35.67
+- **deps**: update dependency boto3 to v1.35.64
 - **deps**: update boto packages to v1.35.61
 
 ## v28.0.0 (2024-11-14)

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -62,6 +62,7 @@ class DocumentFactory:
         if not api_client:
             api_client = Mock(spec=MarklogicApiClient)
             api_client.get_judgment_xml_bytestring.return_value = DEFAULT_DOCUMENT_BODY_XML.encode(encoding="utf-8")
+            api_client.get_property_as_node.return_value = None
 
         document = cls.target_class(uri, api_client=api_client)
         document.content_as_html = Mock(return_value=html)  # type: ignore[method-assign]

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -127,7 +127,7 @@ class Document:
     Individual document classes should extend this list where necessary to validate document type-specific attributes.
     """
 
-    identifiers: dict[str, Identifier] = {}
+    _identifiers: dict[str, Identifier]
 
     def __init__(self, uri: DocumentURIString, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
         """
@@ -151,7 +151,7 @@ class Document:
         )
         """ `Document.body` represents the body of the document itself, without any information such as version tracking or properties. """
 
-        self.identifiers = {}
+        self._initialise_identifiers()
 
     def __repr__(self) -> str:
         name = self.body.name or "un-named"
@@ -167,29 +167,41 @@ class Document:
         """There is a docx in S3 private bucket for this Document"""
         return check_docx_exists(self.uri)
 
-    def _load_identifiers(self) -> None:
-        """Load this document's identifiers from MarkLogic"""
-        identifiers_element_as_string = self.api_client.get_property(self.uri, "identifiers")
-        identifiers_element_as_etree = etree.fromstring(identifiers_element_as_string)
+    def _initialise_identifiers(self) -> None:
+        """Load this document's identifiers from MarkLogic."""
 
-        for identifier_etree in identifiers_element_as_etree.findall("identifier"):
-            identifier = unpack_identifier_from_etree(identifier_etree)
-            self.add_identifier(identifier)
+        self._identifiers = {}
+
+        identifiers_element_as_etree = self.api_client.get_property_as_node(self.uri, "identifiers")
+
+        if identifiers_element_as_etree is not None:
+            for identifier_etree in identifiers_element_as_etree.findall("identifier"):
+                identifier = unpack_identifier_from_etree(identifier_etree)
+                self.add_identifier(identifier)
+
+    @property
+    def identifiers(self) -> list[Identifier]:
+        """Return a list of Identifier objects for easy display and interaction."""
+        return list(self._identifiers.values())
 
     def add_identifier(self, identifier: Identifier) -> None:
         """Add an identifier to this Document's identifiers array."""
-        self.identifiers[identifier.uuid] = identifier
 
+        self._identifiers[identifier.uuid] = identifier
+
+    @property
     def identifiers_as_etree(self) -> etree._Element:
         identifiers_root = etree.Element("identifiers")
 
-        for identifier in self.identifiers.values():
+        for identifier in self.identifiers:
             identifiers_root.append(identifier.as_xml_tree)
 
         return identifiers_root
 
     def save_identifiers(self) -> None:
         """Save the current state of this Document's identifiers to MarkLogic."""
+
+        self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers_as_etree)
 
     @property
     def best_human_identifier(self) -> Optional[str]:

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -16,6 +16,7 @@ from caselawclient.errors import (
     NotSupportedOnVersion,
     OnlySupportedOnVersion,
 )
+from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.unpacker import unpack_identifier_from_etree
 from caselawclient.models.utilities import VersionsDict, extract_version, render_versions
 from caselawclient.models.utilities.aws import (
@@ -31,7 +32,6 @@ from caselawclient.models.utilities.aws import (
     uri_for_s3,
 )
 
-from ..identifiers import Identifier
 from .body import DocumentBody
 from .exceptions import CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion, InvalidDocumentURIException
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -185,12 +185,13 @@ class Document:
         return list(self._identifiers.values())
 
     def add_identifier(self, identifier: Identifier) -> None:
-        """Add an identifier to this Document's identifiers array."""
+        """Add an Identifier object to this Document's list of identifiers."""
 
         self._identifiers[identifier.uuid] = identifier
 
     @property
     def identifiers_as_etree(self) -> etree._Element:
+        """Return an etree representation of all the Document's identifiers."""
         identifiers_root = etree.Element("identifiers")
 
         for identifier in self.identifiers:

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -29,6 +29,7 @@ from caselawclient.models.utilities.aws import (
     uri_for_s3,
 )
 
+from ..identifiers import Identifier
 from .body import DocumentBody
 from .exceptions import CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion, InvalidDocumentURIException
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
@@ -159,6 +160,10 @@ class Document:
     def docx_exists(self) -> bool:
         """There is a docx in S3 private bucket for this Document"""
         return check_docx_exists(self.uri)
+
+    @property
+    def identifiers(self) -> list[Identifier]:
+        return []
 
     @property
     def best_human_identifier(self) -> Optional[str]:

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -1,0 +1,48 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class IdentifierSchema(ABC):
+    """
+    A base class which describes what an identifier schema should look like.
+    """
+
+    name: str
+
+    def __init_subclass__(cls: type["IdentifierSchema"], **kwargs: Any) -> None:
+        for required in (
+            "name",
+            "namespace",
+        ):
+            if not getattr(cls, required, False):
+                raise NotImplementedError(f"Can't instantiate IdentifierSchema without {required} attribute.")
+        super().__init_subclass__(**kwargs)
+
+    def __repr__(self) -> str:
+        return self.name
+
+    @classmethod
+    @abstractmethod
+    def validate_identifier(cls, value: str) -> bool:
+        pass
+
+
+class Identifier(ABC):
+    """
+    A base class for subclasses representing a concrete identifier.
+    """
+
+    schema: type[IdentifierSchema]
+    value: str
+
+    def __init_subclass__(cls: type["Identifier"], **kwargs: Any) -> None:
+        for required in ("schema",):
+            if not getattr(cls, required, False):
+                raise NotImplementedError(f"Can't instantiate Identifier without {required} attribute.")
+        super().__init_subclass__(**kwargs)
+
+    def __repr__(self) -> str:
+        return "self.schema.name: self.value"
+
+    def __init__(self, value: str) -> None:
+        self.value = value

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -7,6 +7,12 @@ from lxml import etree
 IDENTIFIER_PACKABLE_ATTRIBUTES: list[str] = [
     "uuid",
     "value",
+    "url_slug",
+]
+
+IDENTIFIER_UNPACKABLE_ATTRIBUTES: list[str] = [
+    "uuid",
+    "value",
 ]
 
 
@@ -39,6 +45,12 @@ class IdentifierSchema(ABC):
     @abstractmethod
     def validate_identifier(cls, value: str) -> bool:
         """Check that any given identifier value is valid for this schema."""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def compile_identifier_url_slug(cls, value: str) -> str:
+        """Convert an identifier into a precompiled URL slug."""
         pass
 
 
@@ -80,3 +92,7 @@ class Identifier(ABC):
             packed_attribute.text = getattr(self, attribute)
 
         return identifier_root
+
+    @property
+    def url_slug(self) -> str:
+        return self.schema.compile_identifier_url_slug(self.value)

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -77,7 +77,7 @@ class Identifier(ABC):
         if uuid:
             self.uuid = uuid
         else:
-            self.uuid = str(uuid4())
+            self.uuid = "id-" + str(uuid4())
 
     @property
     def as_xml_tree(self) -> etree._Element:

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -4,6 +4,11 @@ from uuid import uuid4
 
 from lxml import etree
 
+IDENTIFIER_PACKABLE_ATTRIBUTES: list[str] = [
+    "uuid",
+    "value",
+]
+
 
 class InvalidIdentifierXMLRepresentationException(Exception):
     pass
@@ -64,15 +69,14 @@ class Identifier(ABC):
 
     @property
     def as_xml_tree(self) -> etree._Element:
+        """Convert this Identifier into a packed XML representation for storage."""
         identifier_root = etree.Element("identifier")
 
-        identifier_namespace = etree.SubElement(identifier_root, "namespace")
-        identifier_namespace.text = self.schema.namespace
+        namespace_attribute = etree.SubElement(identifier_root, "namespace")
+        namespace_attribute.text = self.schema.namespace
 
-        identifier_uuid = etree.SubElement(identifier_root, "uuid")
-        identifier_uuid.text = self.uuid
-
-        identifier_value = etree.SubElement(identifier_root, "value")
-        identifier_value.text = self.value
+        for attribute in IDENTIFIER_PACKABLE_ATTRIBUTES:
+            packed_attribute = etree.SubElement(identifier_root, attribute)
+            packed_attribute.text = getattr(self, attribute)
 
         return identifier_root

--- a/src/caselawclient/models/identifiers/neutral_citation.py
+++ b/src/caselawclient/models/identifiers/neutral_citation.py
@@ -1,0 +1,35 @@
+import re
+
+from . import Identifier, IdentifierSchema
+
+VALID_NCN_PATTERN = re.compile(r"(^\[([0-9]{4})\] ([a-zA-Z]+)(?: ([a-zA-Z]+))? ([0-9]+)(?: \(([a-zA-Z]+)\))?$)")
+"""
+This is a catch-all pattern for anything which looks like a Neutral Citation, even if the court itself isn't valid. Checking that an NCN is plausibly correct is handled elsewhere.
+
+This pattern also defines five capture groups to standardise how we interface with the elements:
+
+- `0`: The year of the decision
+- `1`: The court
+- `2`: (Optionally) the jurisdiction or division, depending on the court
+- `3`: The sequence number of the decision
+- `4`: (Optionally) the jurisdiction or division, depending on the court
+"""
+
+
+class NeutralCitationNumberSchema(IdentifierSchema):
+    """
+    Identifier schema describing a Neutral Citation Number.
+
+    https://www.iclr.co.uk/knowledge/case-law/neutral-citations/
+    """
+
+    name = "Neutral Citation Number"
+    namespace = "ukncn"
+
+    @classmethod
+    def validate_identifier(cls, value: str) -> bool:
+        return bool(VALID_NCN_PATTERN.match(value))
+
+
+class NeutralCitationNumber(Identifier):
+    schema = NeutralCitationNumberSchema

--- a/src/caselawclient/models/identifiers/neutral_citation.py
+++ b/src/caselawclient/models/identifiers/neutral_citation.py
@@ -1,5 +1,8 @@
 import re
 
+from ds_caselaw_utils import neutral_url
+from ds_caselaw_utils.types import NeutralCitationString
+
 from . import Identifier, IdentifierSchema
 
 VALID_NCN_PATTERN = re.compile(r"(^\[([0-9]{4})\] ([a-zA-Z]+)(?: ([a-zA-Z]+))? ([0-9]+)(?: \(([a-zA-Z]+)\))?$)")
@@ -29,6 +32,13 @@ class NeutralCitationNumberSchema(IdentifierSchema):
     @classmethod
     def validate_identifier(cls, value: str) -> bool:
         return bool(VALID_NCN_PATTERN.match(value))
+
+    @classmethod
+    def compile_identifier_url_slug(cls, value: str) -> str:
+        ncn_based_uri_string = neutral_url(NeutralCitationString(value))
+        if not ncn_based_uri_string:
+            raise Exception(f"Unable to convert NCN {value} into NCN-based URL slug")
+        return ncn_based_uri_string
 
 
 class NeutralCitationNumber(Identifier):

--- a/src/caselawclient/models/identifiers/neutral_citation.py
+++ b/src/caselawclient/models/identifiers/neutral_citation.py
@@ -16,6 +16,8 @@ This pattern also defines five capture groups to standardise how we interface wi
 - `2`: (Optionally) the jurisdiction or division, depending on the court
 - `3`: The sequence number of the decision
 - `4`: (Optionally) the jurisdiction or division, depending on the court
+
+TODO: When these capture groups are being used in anger (eg to build URL slugs) you should go through and name the groups.
 """
 
 
@@ -35,7 +37,9 @@ class NeutralCitationNumberSchema(IdentifierSchema):
 
     @classmethod
     def compile_identifier_url_slug(cls, value: str) -> str:
-        ncn_based_uri_string = neutral_url(NeutralCitationString(value))
+        ncn_based_uri_string = neutral_url(
+            NeutralCitationString(value)
+        )  # TODO: At some point this should move out of utils and into this class.
         if not ncn_based_uri_string:
             raise Exception(f"Unable to convert NCN {value} into NCN-based URL slug")
         return ncn_based_uri_string

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from . import Identifier, InvalidIdentifierXMLRepresentationException
+from . import IDENTIFIER_PACKABLE_ATTRIBUTES, Identifier, InvalidIdentifierXMLRepresentationException
 from .neutral_citation import NeutralCitationNumber
 
 IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
@@ -12,22 +12,20 @@ def unpack_identifier_from_etree(identifier_xml: etree._Element) -> Identifier:
     """Given an etree representation of an identifier, unpack it into an appropriate instance of an Identifier."""
 
     namespace_element = identifier_xml.find("namespace")
-    uuid_element = identifier_xml.find("uuid")
-    value_element = identifier_xml.find("value")
 
     if namespace_element is None or not namespace_element.text:
         raise InvalidIdentifierXMLRepresentationException(
             "Identifer XML representation is not valid: namespace not present or empty"
         )
 
-    if uuid_element is None or not uuid_element.text:
-        raise InvalidIdentifierXMLRepresentationException(
-            "Identifer XML representation is not valid: UUID not present or empty"
-        )
+    kwargs: dict[str, str] = {}
 
-    if value_element is None or not value_element.text:
-        raise InvalidIdentifierXMLRepresentationException(
-            "Identifer XML representation is not valid: value not present or empty"
-        )
+    for attribute in IDENTIFIER_PACKABLE_ATTRIBUTES:
+        element = identifier_xml.find(attribute)
+        if element is None or not element.text:
+            raise InvalidIdentifierXMLRepresentationException(
+                f"Identifer XML representation is not valid: {element} not present or empty"
+            )
+        kwargs[attribute] = element.text
 
-    return IDENTIFIER_NAMESPACE_MAP[namespace_element.text](uuid=uuid_element.text, value=value_element.text)
+    return IDENTIFIER_NAMESPACE_MAP[namespace_element.text](**kwargs)

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -1,6 +1,6 @@
 from lxml import etree
 
-from . import IDENTIFIER_PACKABLE_ATTRIBUTES, Identifier, InvalidIdentifierXMLRepresentationException
+from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier, InvalidIdentifierXMLRepresentationException
 from .neutral_citation import NeutralCitationNumber
 
 IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
@@ -20,7 +20,7 @@ def unpack_identifier_from_etree(identifier_xml: etree._Element) -> Identifier:
 
     kwargs: dict[str, str] = {}
 
-    for attribute in IDENTIFIER_PACKABLE_ATTRIBUTES:
+    for attribute in IDENTIFIER_UNPACKABLE_ATTRIBUTES:
         element = identifier_xml.find(attribute)
         if element is None or not element.text:
             raise InvalidIdentifierXMLRepresentationException(

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -1,0 +1,33 @@
+from lxml import etree
+
+from . import Identifier, InvalidIdentifierXMLRepresentationException
+from .neutral_citation import NeutralCitationNumber
+
+IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
+    "ukncn": NeutralCitationNumber,
+}
+
+
+def unpack_identifier_from_etree(identifier_xml: etree._Element) -> Identifier:
+    """Given an etree representation of an identifier, unpack it into an appropriate instance of an Identifier."""
+
+    namespace_element = identifier_xml.find("namespace")
+    uuid_element = identifier_xml.find("uuid")
+    value_element = identifier_xml.find("value")
+
+    if namespace_element is None or not namespace_element.text:
+        raise InvalidIdentifierXMLRepresentationException(
+            "Identifer XML representation is not valid: namespace not present or empty"
+        )
+
+    if uuid_element is None or not uuid_element.text:
+        raise InvalidIdentifierXMLRepresentationException(
+            "Identifer XML representation is not valid: UUID not present or empty"
+        )
+
+    if value_element is None or not value_element.text:
+        raise InvalidIdentifierXMLRepresentationException(
+            "Identifer XML representation is not valid: value not present or empty"
+        )
+
+    return IDENTIFIER_NAMESPACE_MAP[namespace_element.text](uuid=uuid_element.text, value=value_element.text)

--- a/src/caselawclient/xquery/get_property_as_node.xqy
+++ b/src/caselawclient/xquery/get_property_as_node.xqy
@@ -1,0 +1,9 @@
+xquery version "1.0-ml";
+
+declare variable $uri as xs:string external;
+
+declare variable $name as xs:string external;
+
+let $prop := fn:QName("", $name)
+
+return xdmp:document-get-properties($uri, $prop)

--- a/src/caselawclient/xquery/set_property_as_node.xqy
+++ b/src/caselawclient/xquery/set_property_as_node.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $value as xs:string external;
+declare variable $name as xs:string external;
+
+let $props := ( element {$name} {xdmp:unquote($value)/*/*} )
+
+return dls:document-set-property($uri, $props)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -113,6 +113,12 @@ class GetPropertyDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString
 
 
+# get_property_as_node.xqy
+class GetPropertyAsNodeDict(MarkLogicAPIDict):
+    name: str
+    uri: MarkLogicDocumentURIString
+
+
 # get_version_annotation.xqy
 class GetVersionAnnotationDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString
@@ -182,6 +188,13 @@ class SetMetadataWorkExpressionDateDict(MarkLogicAPIDict):
 
 # set_property.xqy
 class SetPropertyDict(MarkLogicAPIDict):
+    name: str
+    uri: MarkLogicDocumentURIString
+    value: str
+
+
+# set_property_as_node.xqy
+class SetPropertyAsNodeDict(MarkLogicAPIDict):
     name: str
     uri: MarkLogicDocumentURIString
     value: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,5 +129,6 @@ def generate_mock_response_fixture() -> Callable:
 def mock_api_client():
     mock_client = Mock(spec=MarklogicApiClient)
     mock_client.get_judgment_xml_bytestring.return_value = b"<xml>content</xml>"
+    mock_client.get_property_as_node.return_value = None
 
     return mock_client

--- a/tests/models/documents/test_document_identifiers.py
+++ b/tests/models/documents/test_document_identifiers.py
@@ -1,0 +1,46 @@
+from lxml import etree
+
+from caselawclient.factories import DocumentFactory
+from tests.models.identifiers.test_identifiers import TestIdentifier
+
+
+class TestDocumentIdentifiers:
+    def test_add_identifiers(self):
+        document = DocumentFactory.build()
+
+        identifier_1 = TestIdentifier(uuid="e28e3ef1-85ed-4997-87ee-e7428a6cc02e", value="TEST-123")
+        identifier_2 = TestIdentifier(uuid="14ce4b3b-03c8-44f9-a29e-e02ce35fe136", value="TEST-456")
+        document.add_identifier(identifier_1)
+        document.add_identifier(identifier_2)
+
+        assert document.identifiers == {
+            "e28e3ef1-85ed-4997-87ee-e7428a6cc02e": identifier_1,
+            "14ce4b3b-03c8-44f9-a29e-e02ce35fe136": identifier_2,
+        }
+
+    def test_identifiers_as_etree(self):
+        document = DocumentFactory.build()
+
+        identifier_1 = TestIdentifier(uuid="e28e3ef1-85ed-4997-87ee-e7428a6cc02e", value="TEST-123")
+        identifier_2 = TestIdentifier(uuid="14ce4b3b-03c8-44f9-a29e-e02ce35fe136", value="TEST-456")
+        document.add_identifier(identifier_1)
+        document.add_identifier(identifier_2)
+
+        expected_xml = """
+            <identifiers>
+                <identifier>
+                    <namespace>test</namespace>
+                    <uuid>e28e3ef1-85ed-4997-87ee-e7428a6cc02e</uuid>
+                    <value>TEST-123</value>
+                </identifier>
+                <identifier>
+                    <namespace>test</namespace>
+                    <uuid>14ce4b3b-03c8-44f9-a29e-e02ce35fe136</uuid>
+                    <value>TEST-456</value>
+                </identifier>
+            </identifiers>
+        """
+
+        assert etree.canonicalize(document.identifiers_as_etree(), strip_text=True) == etree.canonicalize(
+            etree.fromstring(expected_xml), strip_text=True
+        )

--- a/tests/models/documents/test_document_identifiers.py
+++ b/tests/models/documents/test_document_identifiers.py
@@ -13,10 +13,10 @@ class TestDocumentIdentifiers:
         document.add_identifier(identifier_1)
         document.add_identifier(identifier_2)
 
-        assert document.identifiers == {
-            "e28e3ef1-85ed-4997-87ee-e7428a6cc02e": identifier_1,
-            "14ce4b3b-03c8-44f9-a29e-e02ce35fe136": identifier_2,
-        }
+        assert document.identifiers == [
+            identifier_1,
+            identifier_2,
+        ]
 
     def test_identifiers_as_etree(self):
         document = DocumentFactory.build()
@@ -41,6 +41,6 @@ class TestDocumentIdentifiers:
             </identifiers>
         """
 
-        assert etree.canonicalize(document.identifiers_as_etree(), strip_text=True) == etree.canonicalize(
+        assert etree.canonicalize(document.identifiers_as_etree, strip_text=True) == etree.canonicalize(
             etree.fromstring(expected_xml), strip_text=True
         )

--- a/tests/models/documents/test_document_identifiers.py
+++ b/tests/models/documents/test_document_identifiers.py
@@ -32,11 +32,13 @@ class TestDocumentIdentifiers:
                     <namespace>test</namespace>
                     <uuid>e28e3ef1-85ed-4997-87ee-e7428a6cc02e</uuid>
                     <value>TEST-123</value>
+                    <url_slug>test-123</url_slug>
                 </identifier>
                 <identifier>
                     <namespace>test</namespace>
                     <uuid>14ce4b3b-03c8-44f9-a29e-e02ce35fe136</uuid>
                     <value>TEST-456</value>
+                    <url_slug>test-456</url_slug>
                 </identifier>
             </identifiers>
         """

--- a/tests/models/identifiers/test_identifer_unpacking.py
+++ b/tests/models/identifiers/test_identifer_unpacking.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from lxml import etree
+from test_identifiers import TestIdentifier
+
+from caselawclient.models.identifiers.unpacker import unpack_identifier_from_etree
+
+
+class TestIdentifierUnpacking:
+    @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
+    def test_unpack_identifier(self):
+        xml_tree = etree.fromstring("""
+            <identifier>
+                <namespace>test</namespace>
+                <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
+                <value>TEST-123</value>
+            </identifier>
+        """)
+
+        unpacked_identifier = unpack_identifier_from_etree(xml_tree)
+
+        assert type(unpacked_identifier) is TestIdentifier
+        assert unpacked_identifier.uuid == "2d80bf1d-e3ea-452f-965c-041f4399f2dd"
+        assert unpacked_identifier.value == "TEST-123"
+
+
+class TestIdentifierPackUnpackRoundTrip:
+    @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
+    def test_unpack_identifier(self):
+        """Check that if we convert an Identifier to XML and back again we get the same thing out at the far end."""
+
+        original_identifier = TestIdentifier(value="TEST-123")
+
+        xml_tree = original_identifier.as_xml_tree
+
+        unpacked_identifier = unpack_identifier_from_etree(xml_tree)
+
+        assert type(unpacked_identifier) is TestIdentifier
+        assert unpacked_identifier.uuid == original_identifier.uuid
+        assert unpacked_identifier.value == "TEST-123"

--- a/tests/models/identifiers/test_identifier_ncns.py
+++ b/tests/models/identifiers/test_identifier_ncns.py
@@ -52,3 +52,21 @@ class TestNeutralCitationSchemaImplementation:
     def test_ncn_schema_validation_fails(self, value):
         schema = neutral_citation.NeutralCitationNumberSchema
         assert schema.validate_identifier(value) is False
+
+    @pytest.mark.parametrize(
+        ("value", "slug"),
+        [
+            ("[2022] UKSC 1", "uksc/2022/1"),
+            ("[1604] EWCA Crim 555", "ewca/crim/1604/555"),
+            ("[2022] EWHC 1 (Comm)", "ewhc/comm/2022/1"),
+            ("[1999] EWCOP 7", "ewcop/1999/7"),
+            ("[2022] UKUT 1 (IAC)", "ukut/iac/2022/1"),
+            ("[2022] EAT 1", "eat/2022/1"),
+            ("[2022] UKFTT 1 (TC)", "ukftt/tc/2022/1"),
+            ("[2022] UKFTT 1 (GRC)", "ukftt/grc/2022/1"),
+            ("[2022] EWHC 1 (KB)", "ewhc/kb/2022/1"),
+        ],
+    )
+    def test_ncn_schema_compile_url_slug(self, value, slug):
+        schema = neutral_citation.NeutralCitationNumberSchema
+        assert schema.compile_identifier_url_slug(value) == slug

--- a/tests/models/identifiers/test_identifier_ncns.py
+++ b/tests/models/identifiers/test_identifier_ncns.py
@@ -1,0 +1,53 @@
+import pytest
+
+from caselawclient.models.identifiers import neutral_citation
+
+
+class TestNeutralCitationSchemaImplementation:
+    """
+    This class tests that we have correctly implemented a schema describing Neutral Citations.
+    """
+
+    def test_ncn_schema_configuration(self):
+        """
+        Check that the basics of the schema have been set.
+        """
+
+        schema = neutral_citation.NeutralCitationNumberSchema
+
+        assert schema.name == "Neutral Citation Number"
+        assert schema.namespace == "ukncn"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "[2022] UKSC 1",
+            "[1604] EWCA Crim 555",
+            "[2022] EWHC 1 (Comm)",
+            "[1999] EWCOP 7",
+            "[2022] UKUT 1 (IAC)",
+            "[2022] EAT 1",
+            "[2022] UKFTT 1 (TC)",
+            "[2022] UKFTT 1 (GRC)",
+            "[2022] EWHC 1 (KB)",
+        ],
+    )
+    def test_ncn_schema_validation_passes(self, value):
+        schema = neutral_citation.NeutralCitationNumberSchema
+        assert schema.validate_identifier(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "bananas" "1604] EWCA Crim 555",
+            "[2022 EWHC 1 Comm",
+            "[1999] EWCOP",
+            "[2022] UKUT B1 IAC",
+            "[2022] EAT A",
+            "[2022] EWCA Crim Civ 123",
+        ],
+    )
+    def test_ncn_schema_validation_fails(self, value):
+        schema = neutral_citation.NeutralCitationNumberSchema
+        assert schema.validate_identifier(value) is False

--- a/tests/models/identifiers/test_identifier_ncns.py
+++ b/tests/models/identifiers/test_identifier_ncns.py
@@ -40,7 +40,8 @@ class TestNeutralCitationSchemaImplementation:
         "value",
         [
             "",
-            "bananas" "1604] EWCA Crim 555",
+            "bananas",
+            "1604] EWCA Crim 555",
             "[2022 EWHC 1 Comm",
             "[1999] EWCOP",
             "[2022] UKUT B1 IAC",

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -1,0 +1,38 @@
+from lxml import etree
+
+from caselawclient.models.identifiers import Identifier, IdentifierSchema
+
+
+class TestIdentifierSchema(IdentifierSchema):
+    __test__ = False
+
+    name = "Test Schema"
+    namespace = "test"
+
+
+class TestIdentifier(Identifier):
+    __test__ = False
+
+    schema = TestIdentifierSchema
+
+
+class TestIdentifierBase:
+    def test_uuid_setting(self):
+        """Ensure that if a UUID is provided when initialising an Identifier that it is properly stored."""
+        identifier = Identifier(uuid="2d80bf1d-e3ea-452f-965c-041f4399f2dd", value="TEST-123")
+        assert identifier.uuid == "2d80bf1d-e3ea-452f-965c-041f4399f2dd"
+
+    def test_xml_representation(self):
+        """Ensure that an identifer generates the expected representation of itself as XML."""
+        identifier = TestIdentifier(uuid="2d80bf1d-e3ea-452f-965c-041f4399f2dd", value="TEST-123")
+
+        expected_xml = """
+            <identifier>
+                <namespace>test</namespace>
+                <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
+                <value>TEST-123</value>
+            </identifier>
+        """
+        assert etree.canonicalize(identifier.as_xml_tree, strip_text=True) == etree.canonicalize(
+            etree.fromstring(expected_xml), strip_text=True
+        )

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -9,6 +9,10 @@ class TestIdentifierSchema(IdentifierSchema):
     name = "Test Schema"
     namespace = "test"
 
+    @classmethod
+    def compile_identifier_url_slug(cls, value: str) -> str:
+        return value.lower()
+
 
 class TestIdentifier(Identifier):
     __test__ = False
@@ -31,6 +35,7 @@ class TestIdentifierBase:
                 <namespace>test</namespace>
                 <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
                 <value>TEST-123</value>
+                <url_slug>test-123</url_slug>
             </identifier>
         """
         assert etree.canonicalize(identifier.as_xml_tree, strip_text=True) == etree.canonicalize(


### PR DESCRIPTION
## Summary of changes

- [x] New `IdentifierSchema` and `Identifier` abstract classes which define interfaces for how we think about what any given type of identifier looks like (`IdentifierSchema`), and how we might be able to interact with specific instances of that identifier (`Identifier`)
- [x] New `NeutralCitationSchema` and `NeutralCitation` concretions of the above abstract classes, defining NCN-specific implementations of methods where necessary.
- [x] `Identifier`s can compile themselves down to a URL slug, used for simplifying retrieval at any given URL.
- [ ] New methods for a `Document` which allow CRUD operations on its identifiers, using the above classes to turn identifier concepts into serialisations which can be stashed in the MarkLogic properties for a document.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)

## Jira

FCL-309
