### PR TITLE
Enforce type-safe behaviour using lxml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
           - boto3-stubs[s3,sns]
           - types-python-dateutil
           - types-pytz
+          - types-lxml
           - ds-caselaw-utils~=2.0.0
         args:
           - --strict
@@ -48,6 +49,7 @@ repos:
           - boto3-stubs[s3,sns]
           - types-python-dateutil
           - types-pytz
+          - types-lxml
           - ds-caselaw-utils~=2.0.0
         exclude: ^smoketest/
         id: mypy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- **deps**: update boto packages to v1.35.61
+
 ## v28.0.0 (2024-11-14)
 
 ### BREAKING CHANGE

--- a/src/caselawclient/models/documents/xml.py
+++ b/src/caselawclient/models/documents/xml.py
@@ -17,7 +17,7 @@ class XML:
         :raises NonXMLDocumentError: This document is not valid XML
         """
         try:
-            self.xml_as_tree: etree.Element = etree.fromstring(xml_bytestring)
+            self.xml_as_tree: etree._Element = etree.fromstring(xml_bytestring)
         except etree.XMLSyntaxError:
             raise NonXMLDocumentError
 

--- a/src/caselawclient/xml_helpers.py
+++ b/src/caselawclient/xml_helpers.py
@@ -9,8 +9,7 @@ def get_xpath_match_string(
     namespaces: Optional[Dict[str, str]] = None,
     fallback: str = "",
 ) -> str:
-    kwargs = {"namespaces": namespaces} if namespaces else {}
-    return str((node.xpath(path, **kwargs) or [fallback])[0])
+    return str((node.xpath(path, namespaces=namespaces) or [fallback])[0])
 
 
 def get_xpath_match_strings(
@@ -18,5 +17,4 @@ def get_xpath_match_strings(
     path: str,
     namespaces: Optional[Dict[str, str]] = None,
 ) -> list[str]:
-    kwargs = {"namespaces": namespaces} if namespaces else {}
-    return [str(x) for x in node.xpath(path, **kwargs)]
+    return [str(x) for x in node.xpath(path, namespaces=namespaces)]


### PR DESCRIPTION
## Summary of changes

- Add the `types-lxml` library to mypy so that it can perform type checking on interactions with lxml.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
