### PR TITLE
[FCL-499, FCL-532] Add IdentifierSchema for creating SQID-based Find Case Law Identifiers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -692,8 +692,6 @@ optional = false
 python-versions = "*"
 files = [
     {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
 ]
 
 [package.dependencies]
@@ -2080,6 +2078,17 @@ files = [
 ]
 
 [[package]]
+name = "sqids"
+version = "0.5.0"
+description = "Generate YouTube-like ids from numbers."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "sqids-0.5.0-py3-none-any.whl", hash = "sha256:4c2d1eabf4721e6e18001b1ff2bc0b30d059447ef96f1e1d1fb7f56841814154"},
+    {file = "sqids-0.5.0.tar.gz", hash = "sha256:647798e7d5bfeb236e7ac4709cfd4cd808630a6c50f80205df17b4c93e560140"},
+]
+
+[[package]]
 name = "sympy"
 version = "1.13.3"
 description = "Computer algebra system (CAS) in Python"
@@ -2354,4 +2363,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "475e15790354088d83c43ee782d985b62159ac7a095d292471e23a2c21612e86"
+content-hash = "a50c329d99433bcf05b86641f3333dff7e33f508549bc24fb857e8eb5f85cbcc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ mypy-boto3-sns = "^1.26.69"
 pytz = "^2024.1"
 python-dateutil = "^2.9.0-post.0"
 saxonche = "^12.5.0"
+sqids = "^0.5.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.2.3"

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1217,3 +1217,7 @@ class MarklogicApiClient:
             ),
         )
         return IdentifierResolutions.from_marklogic_output(raw_results)
+
+    def get_next_document_sequence_number(self) -> int:
+        """Increment the MarkLogic sequence number by one and return the value."""
+        return int(self._eval_and_decode({}, "get_next_document_sequence_number.xqy"))

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -15,6 +15,7 @@ from caselawclient.errors import (
     NotSupportedOnVersion,
     OnlySupportedOnVersion,
 )
+from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier, FindCaseLawIdentifierSchema
 from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
 from caselawclient.models.utilities import VersionsDict, extract_version, render_versions
 from caselawclient.models.utilities.aws import (
@@ -431,6 +432,12 @@ class Document:
         """
         if not self.is_publishable:
             raise CannotPublishUnpublishableDocument
+
+        ## If it doesn't already have one, get a new FCLID for this document and assign
+        if len(self.identifiers.of_type(FindCaseLawIdentifier)) < 1:
+            document_fclid = FindCaseLawIdentifierSchema.mint(self.api_client)
+            self.identifiers.add(document_fclid)
+            self.save_identifiers()
 
         publish_documents(uri_for_s3(self.uri))
         self.api_client.set_published(self.uri, True)

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -127,6 +127,11 @@ class Identifiers(dict[str, Identifier]):
         else:
             super().__delitem__(key)
 
+    def of_type(self, identifier_type: type[Identifier]) -> list[Identifier]:
+        """Return a list of all identifiers of a given type."""
+        uuids = self.keys()
+        return [self[uuid] for uuid in list(uuids) if isinstance(self[uuid], identifier_type)]
+
     def delete_type(self, deleted_identifier_type: type[Identifier]) -> None:
         "For when we want an identifier to be the only valid identifier of that type, delete the others first"
         uuids = self.keys()

--- a/src/caselawclient/models/identifiers/fclid.py
+++ b/src/caselawclient/models/identifiers/fclid.py
@@ -1,0 +1,48 @@
+import re
+from typing import TYPE_CHECKING
+
+from sqids import Sqids
+
+from . import Identifier, IdentifierSchema
+
+if TYPE_CHECKING:
+    from caselawclient.Client import MarklogicApiClient
+
+
+VALID_FCLID_PATTERN = re.compile(r"^[bcdfghjkmnpqrstvwxyz23456789]{4,}$")
+
+FCLID_MINIMUM_LENGTH = 8
+FCLID_ALPHABET = "bcdfghjkmnpqrstvwxyz23456789"
+
+sqids = Sqids(
+    min_length=FCLID_MINIMUM_LENGTH,
+    alphabet=FCLID_ALPHABET,
+)
+
+
+class FindCaseLawIdentifierSchema(IdentifierSchema):
+    """
+    Identifier schema describing a Find Case Law Identifier.
+    """
+
+    name = "Find Case Law Identifier"
+    namespace = "fclid"
+
+    @classmethod
+    def validate_identifier(cls, value: str) -> bool:
+        return bool(VALID_FCLID_PATTERN.match(value))
+
+    @classmethod
+    def compile_identifier_url_slug(cls, value: str) -> str:
+        return "tna." + value
+
+    @classmethod
+    def mint(cls, api_client: "MarklogicApiClient") -> "FindCaseLawIdentifier":
+        """Generate a totally new Find Case Law identifier."""
+        next_sequence_number = api_client.get_next_document_sequence_number()
+        new_identifier = sqids.encode([next_sequence_number])
+        return FindCaseLawIdentifier(value=new_identifier)
+
+
+class FindCaseLawIdentifier(Identifier):
+    schema = FindCaseLawIdentifierSchema

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -3,9 +3,11 @@ from typing import Optional
 from lxml import etree
 
 from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier, Identifiers, InvalidIdentifierXMLRepresentationException
+from .fclid import FindCaseLawIdentifier
 from .neutral_citation import NeutralCitationNumber
 
 IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
+    "fclid": FindCaseLawIdentifier,
     "ukncn": NeutralCitationNumber,
 }
 

--- a/src/caselawclient/xquery/get_next_document_sequence_number.xqy
+++ b/src/caselawclient/xquery/get_next_document_sequence_number.xqy
@@ -1,0 +1,14 @@
+xquery version "1.0-ml";
+declare option xdmp:transaction-mode "update";
+
+let $_ := xdmp:set-transaction-mode("update")
+let $state_doc := fn:doc("state.xml")
+let $counter_node := $state_doc/state/document_counter
+
+let $current_counter := $counter_node/text()
+let $new_counter := fn:sum(($current_counter, 1))
+
+let $_ := xdmp:node-replace($counter_node, <document_counter>{$new_counter}</document_counter>)
+let $_ := xdmp:commit()
+
+return $new_counter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,5 +130,6 @@ def mock_api_client():
     mock_client = Mock(spec=MarklogicApiClient)
     mock_client.get_judgment_xml_bytestring.return_value = b"<xml>content</xml>"
     mock_client.get_property_as_node.return_value = None
+    mock_client.get_next_document_sequence_number.return_value = 1
 
     return mock_client

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -105,6 +105,12 @@ class TestIdentifiersCRUD:
         assert not identifiers.contains(TestIdentifier(value="TEST-333"))
         assert not identifiers.contains(NeutralCitationNumber(value="TEST-111"))
 
+    def test_of_type(self, mixed_identifiers):
+        only_ncns = mixed_identifiers.of_type(NeutralCitationNumber)
+        assert "TEST-999" not in str(only_ncns)
+        assert "[1701] UKSC 999" in str(only_ncns)
+        assert "[1234] UKSC 999" in str(only_ncns)
+
     def test_delete_type(self, mixed_identifiers):
         mixed_identifiers.delete_type(NeutralCitationNumber)
         assert "TEST-999" in str(mixed_identifiers)


### PR DESCRIPTION
- Adds a new FCLID identifier class
- Adds new `Client` method for getting the next sequence number from MarkLogic
- Calling `Document.publish()` will now assign the document a FCLID if one doesn't already exist.
