### PR TITLE
Use save_identifiers on document not identifiers.save()

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -530,6 +530,11 @@ class Document:
         """
         return self.docx_exists()
 
+    def save_identifiers(self) -> None:
+        """Save the current state of this Document's identifiers to MarkLogic."""
+        self.identifiers.validate()
+        self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers.as_etree)
+
     def __getattr__(self, name: str) -> Any:
         warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
         try:

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -144,8 +144,3 @@ class Identifiers(dict[str, Identifier]):
             identifiers_root.append(identifier.as_xml_tree)
 
         return identifiers_root
-
-    def save(self, document) -> None:  # type: ignore[no-untyped-def, unused-ignore]
-        """Save the current state of this Document's identifiers to MarkLogic."""
-        self.validate()
-        document.api_client.set_property_as_node(document.uri, "identifiers", self.as_etree)

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import os
-from unittest.mock import PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import time_machine
@@ -13,8 +13,26 @@ from caselawclient.models.documents import (
     DocumentNotSafeForDeletion,
     DocumentURIString,
 )
+from caselawclient.models.identifiers import Identifiers
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.neutral_citation_mixin import NeutralCitationString
+
+
+class TestDocumentSaveIdentifiers:
+    def test_document_save_identifiers(self, mock_api_client):
+        """
+        given a particular Document with a known value of Identifiers (probably mock this out tbh)
+        when I call document.save_identifiers() it
+        calls identifiers.validate and
+        calls set_property_as_node with expected values (edited)
+        """
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.identifiers = Mock(autospec=Identifiers)
+        document.identifiers.as_etree = "fake_node"
+
+        document.save_identifiers()
+        document.identifiers.validate.assert_called_once()
+        mock_api_client.set_property_as_node.assert_called_with("test/1234", "identifiers", "fake_node")
 
 
 class TestDocumentPublish:


### PR DESCRIPTION
## Summary of changes

Move saving identifiers to the document