### PR TITLE
bump: version 28.0.0 → 28.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v28.1.0 (2024-12-12)
 
 ### Feat
 
+- **FCL-309**: identifier UUIDs are now prefixed with 'id-'
 - **FCL-309**: identifiers can compile URL slugs
 - **FCL-309**: identifiers can now be saved to and retrieved from MarkLogic
 - **FCL-309**: add functionality for packing and unpacking XML representations of identifiers
@@ -16,11 +17,16 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- **deps**: update boto packages to v1.35.69
 - **deps**: update dependency ds-caselaw-utils to v2.0.1
 - **deps**: update dependency mypy-boto3-sns to v1.35.68
 - **deps**: update boto packages to v1.35.67
 - **deps**: update dependency boto3 to v1.35.64
 - **deps**: update boto packages to v1.35.61
+- **deps**: update dependency boto3 to v1.35.77
+- **deps**: update dependency mypy-boto3-s3 to v1.35.76
+- **deps**: update dependency boto3 to v1.35.75
+- **deps**: update boto packages to v1.35.72
 
 ## v28.0.0 (2024-11-14)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "28.0.0"
+version = "28.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## Summary of changes

### Feat

- **FCL-309**: identifier UUIDs are now prefixed with 'id-'
- **FCL-309**: identifiers can compile URL slugs
- **FCL-309**: identifiers can now be saved to and retrieved from MarkLogic
- **FCL-309**: add functionality for packing and unpacking XML representations of identifiers
- **FCL-309**: add stub for defining identifier schemas, and a Neutral Citation schema

### Fix

- **deps**: update boto packages to v1.35.69
- **deps**: update dependency ds-caselaw-utils to v2.0.1
- **deps**: update dependency mypy-boto3-sns to v1.35.68
- **deps**: update boto packages to v1.35.67
- **deps**: update dependency boto3 to v1.35.64
- **deps**: update boto packages to v1.35.61
- **deps**: update dependency boto3 to v1.35.77
- **deps**: update dependency mypy-boto3-s3 to v1.35.76
- **deps**: update dependency boto3 to v1.35.75
- **deps**: update boto packages to v1.35.72
