### PR TITLE
bump: version 28.2.0 → 29.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v29.0.0 (2024-12-18)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "28.2.0"
+version = "29.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- Methods which were previously guaranteed to return a Neutral Citation may now return `None`.

### Feat

- **FCL-533**: getting scored or preferred identifiers can now be done by type
- **FCL-533**: modify human identifier to rely on identifiers framework
- **FCL-533**: add scoring to Identifiers

### Fix

- **IdentifierSchema**: use hasattr instead of getattr with a default when testing required attributes