### PR TITLE
str(identifier) should be just the value

### DIFF
--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -83,6 +83,9 @@ class Identifier(ABC):
     def __repr__(self) -> str:
         return f"<{self.schema.name} {self.value}: {self.uuid}>"
 
+    def __str__(self) -> str:
+        return self.value
+
     def __init__(self, value: str, uuid: Optional[str] = None) -> None:
         self.value = value
         if uuid:

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -251,8 +251,6 @@ def request_parse(
         },
     }
 
-    # breakpoint()
-
     client.publish(
         TopicArn=env("REPARSE_SNS_TOPIC"),
         Message=json.dumps(message_to_send),

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -31,8 +31,8 @@ def identifiers():
     )
 
 
-TEST_NCN_1701 = NeutralCitationNumber(value="[1701] UKSC 999")
-TEST_NCN_1234 = NeutralCitationNumber(value="[1234] UKSC 999")
+TEST_NCN_1701 = NeutralCitationNumber(value="[1701] UKSC 999", uuid="id-1701")
+TEST_NCN_1234 = NeutralCitationNumber(value="[1234] UKSC 999", uuid="id-1234")
 TEST_IDENTIFIER_999 = TestIdentifier("TEST-999")
 
 
@@ -88,6 +88,12 @@ class TestIdentifierBase:
         id_a = NeutralCitationNumber("Y")
         id_b = NeutralCitationNumber("X")
         assert not id_a.same_as(id_b)
+
+    def test_str(self):
+        assert f"{TEST_NCN_1234}" == "[1234] UKSC 999"
+
+    def test_repr(self):
+        assert f"{TEST_NCN_1234!r}" == "<Neutral Citation Number [1234] UKSC 999: id-1234>"
 
 
 class TestIdentifiersCRUD:


### PR DESCRIPTION
## Summary of changes

Before:
![image](https://github.com/user-attachments/assets/3bbf4488-1afb-41ed-b147-e4c07bb3f054)

Make str(identifier) be something that's printable in the website, rather than falling back to the repr