### PR TITLE
[FCL-568] Add new class for Press Summary identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **FCL-568**: add new class for Press Summary identifiers
+
+### Fix
+
+- **deps**: update dependency mypy-boto3-s3 to v1.35.92
+- **deps**: update dependency boto3 to v1.35.91
+- **deps**: update dependency boto3 to v1.35.88
+- **deps**: update dependency charset-normalizer to v3.4.1
+- **deps**: update dependency boto3 to v1.35.87
+- **deps**: update dependency boto3 to v1.35.85
+
 ## v29.0.1 (2024-12-20)
 
 ### Fix

--- a/src/caselawclient/models/identifiers/press_summary_ncn.py
+++ b/src/caselawclient/models/identifiers/press_summary_ncn.py
@@ -1,0 +1,20 @@
+from .neutral_citation import NeutralCitationNumber, NeutralCitationNumberSchema
+
+
+class PressSummaryRelatedNCNIdentifierSchema(NeutralCitationNumberSchema):
+    """
+    Identifier schema for relating a Press Summary to a Judgment with a given NCN
+    """
+
+    name = "Press Summary relates to NCN"
+    namespace = "uksummaryofncn"
+    human_readable = True
+    base_score_multiplier = 0.5
+
+    @classmethod
+    def compile_identifier_url_slug(cls, value: str) -> str:
+        return super().compile_identifier_url_slug(value) + "/press-summary"
+
+
+class PressSummaryRelatedNCNIdentifier(NeutralCitationNumber):
+    schema = NeutralCitationNumberSchema

--- a/tests/models/identifiers/test_identifier_press_summaries.py
+++ b/tests/models/identifiers/test_identifier_press_summaries.py
@@ -1,0 +1,72 @@
+import pytest
+
+from caselawclient.models.identifiers import press_summary_ncn
+
+
+class TestPressSummaryRelatedNCNIdentifierSchemaSchemaImplementation:
+    """
+    This class tests that we have correctly implemented a schema describing Neutral Citations.
+    """
+
+    def test_ncn_schema_configuration(self):
+        """
+        Check that the basics of the schema have been set.
+        """
+
+        schema = press_summary_ncn.PressSummaryRelatedNCNIdentifierSchema
+
+        assert schema.name == "Press Summary relates to NCN"
+        assert schema.namespace == "uksummaryofncn"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "[2022] UKSC 1",
+            "[1604] EWCA Crim 555",
+            "[2022] EWHC 1 (Comm)",
+            "[1999] EWCOP 7",
+            "[2022] UKUT 1 (IAC)",
+            "[2022] EAT 1",
+            "[2022] UKFTT 1 (TC)",
+            "[2022] UKFTT 1 (GRC)",
+            "[2022] EWHC 1 (KB)",
+        ],
+    )
+    def test_ncn_schema_validation_passes(self, value):
+        schema = press_summary_ncn.PressSummaryRelatedNCNIdentifierSchema
+        assert schema.validate_identifier(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "bananas",
+            "1604] EWCA Crim 555",
+            "[2022 EWHC 1 Comm",
+            "[1999] EWCOP",
+            "[2022] UKUT B1 IAC",
+            "[2022] EAT A",
+            "[2022] EWCA Crim Civ 123",
+        ],
+    )
+    def test_ncn_schema_validation_fails(self, value):
+        schema = press_summary_ncn.PressSummaryRelatedNCNIdentifierSchema
+        assert schema.validate_identifier(value) is False
+
+    @pytest.mark.parametrize(
+        ("value", "slug"),
+        [
+            ("[2022] UKSC 1", "uksc/2022/1/press-summary"),
+            ("[1604] EWCA Crim 555", "ewca/crim/1604/555/press-summary"),
+            ("[2022] EWHC 1 (Comm)", "ewhc/comm/2022/1/press-summary"),
+            ("[1999] EWCOP 7", "ewcop/1999/7/press-summary"),
+            ("[2022] UKUT 1 (IAC)", "ukut/iac/2022/1/press-summary"),
+            ("[2022] EAT 1", "eat/2022/1/press-summary"),
+            ("[2022] UKFTT 1 (TC)", "ukftt/tc/2022/1/press-summary"),
+            ("[2022] UKFTT 1 (GRC)", "ukftt/grc/2022/1/press-summary"),
+            ("[2022] EWHC 1 (KB)", "ewhc/kb/2022/1/press-summary"),
+        ],
+    )
+    def test_ncn_schema_compile_url_slug(self, value, slug):
+        schema = press_summary_ncn.PressSummaryRelatedNCNIdentifierSchema
+        assert schema.compile_identifier_url_slug(value) == slug


### PR DESCRIPTION
This adds a new identifier schema for relating Press Summaries to judgments.

This isn't a perfect solution - this kind of thing would ideally be handled by proper document relations and resolution code - but it does solve the problem in the short term without us needing to also add a whole new system for handling relations.