### PR TITLE
bump: version 29.0.1 → 29.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v29.1.0 (2025-01-08)
 
 ### Feat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "29.0.1"
+version = "29.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **FCL-568**: add new class for Press Summary identifiers

### Fix

- **deps**: update dependency mypy-boto3-s3 to v1.35.92
- **deps**: update dependency boto3 to v1.35.91
- **deps**: update dependency boto3 to v1.35.88
- **deps**: update dependency charset-normalizer to v3.4.1
- **deps**: update dependency boto3 to v1.35.87
- **deps**: update dependency boto3 to v1.35.85