### PR TITLE
Remove query mark tags from meta section of XML

### DIFF
--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -14,12 +14,16 @@ declare variable $search_query as xs:string? external;
 let $number_marks_xslt := (
   <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                   xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                  xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
                   version="2.0">
     <xsl:output method="xml" />
     <xsl:template match="@*|node()">
       <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
+    </xsl:template>
+    <xsl:template match="//akn:meta//uk:mark">
+          <xsl:apply-templates />
     </xsl:template>
     <xsl:template match="uk:mark">
       <xsl:copy>

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -30,7 +30,7 @@ let $number_marks_xslt := (
           <xsl:copy-of select="@*" />
           <xsl:attribute name="id">
               <xsl:text>mark_</xsl:text>
-              <xsl:value-of select="count(preceding::uk:mark)"/>
+              <xsl:number count="//uk:mark" level="any" from="//*[ancestor::akn:meta]" />
           </xsl:attribute>
           <xsl:apply-templates />
       </xsl:copy>
@@ -65,6 +65,5 @@ let $transformed := if($search_query) then
       )
     else
       $raw_xml
-
 
 return $transformed


### PR DESCRIPTION
When a search query occurs for a string that occurs in the upper part of the XML, it would be corrupted, e.g.

`<uk:cite>[2024] <uk:mark id="mark_1">UKSC</uk:mark> 1</uk:cite>`

if the search query included a word from the contained string.

<s>This removes all such tags, leaving a gap if there was a match, so this will break the JS which expects a mark_1 to exist.</s> Fixed.

Pondered whether <ref> tags are affected. They work fine, but we should be wary of how we handle any tag which contains text in the body of the judgment -- e.g. <neutralCitation>, <docketNumber> in a PUI context.

This only affects PUI -- EUI does not use queries. Otherwise we could have got into a horrid situation where the editor saves back a modified XML... *shudder*

## Summary of changes

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
