### PR TITLE
Ensure publishing documents only looks in s3 'folder'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unpublished
+
+### Fix
+
+- **s3**: When publishing, only copy files in folder, not all folders that share a prefix
+
 ## v29.1.1 (2025-01-20)
 
 ### Fix

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -29,7 +29,6 @@ from caselawclient.models.utilities.aws import (
     publish_documents,
     request_parse,
     unpublish_documents,
-    uri_for_s3,
 )
 
 from .body import DocumentBody
@@ -216,11 +215,11 @@ class Document:
 
     @property
     def docx_url(self) -> str:
-        return generate_docx_url(uri_for_s3(self.uri))
+        return generate_docx_url(self.uri)
 
     @property
     def pdf_url(self) -> str:
-        return generate_pdf_url(uri_for_s3(self.uri))
+        return generate_pdf_url(self.uri)
 
     @cached_property
     def assigned_to(self) -> str:
@@ -438,7 +437,7 @@ class Document:
             self.identifiers.add(document_fclid)
             self.save_identifiers()
 
-        publish_documents(uri_for_s3(self.uri))
+        publish_documents(self.uri)
         self.api_client.set_published(self.uri, True)
         announce_document_event(
             uri=self.uri,
@@ -448,7 +447,7 @@ class Document:
 
     def unpublish(self) -> None:
         self.api_client.break_checkout(self.uri)
-        unpublish_documents(uri_for_s3(self.uri))
+        unpublish_documents(self.uri)
         self.api_client.set_published(self.uri, False)
         announce_document_event(
             uri=self.uri,


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-617

We noticed that when publishing ewca/civ/2023/1 the editor was causing every document to be copied from the unpublished assets bucket to the published assets bucket that started with this prefix; this includes files such as ewca/civ/2023/1000/image1.jpg

## Summary of changes

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
