### PR TITLE
bump: version 29.1.1 → 29.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v29.2.0 (2025-01-27)
 
 ### Feat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "29.1.1"
+version = "29.2.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **NeutralCitationMixin**: NCNs are no longer considered obligatory

### Fix

- **s3**: When publishing, only copy files in folder, not all folders that share a prefix
- **deps**: update dependency boto3 to v1.36.6
- **deps**: update boto packages to v1.36.3