### PR TITLE
⚠️ Refactor DocumentURIString to .types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **identifiers**: Support identifier resolution from value and namespace
+- ⚠️ **refactor**: Move DocumentURIString and InvalidDocumentURIException to .types
 
 ## v29.2.0 (2025-01-27)
 

--- a/script/build_xquery_type_dicts
+++ b/script/build_xquery_type_dicts
@@ -13,7 +13,7 @@ checks. They are used to enforce appropriately typed variables being passed in t
 \"\"\"
 
 from typing import Any, NewType, Optional, TypedDict
-from caselawclient.models.documents import DocumentURIString
+from caselawclient.types import DocumentURIString
 
 MarkLogicDocumentURIString = NewType("MarkLogicDocumentURIString", str)
 MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -25,12 +25,12 @@ from caselawclient.models.documents import (
     DOCUMENT_COLLECTION_URI_JUDGMENT,
     DOCUMENT_COLLECTION_URI_PRESS_SUMMARY,
     Document,
-    DocumentURIString,
 )
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities import move
 from caselawclient.search_parameters import SearchParameters
+from caselawclient.types import DocumentURIString
 from caselawclient.xquery_type_dicts import (
     MarkLogicDocumentURIString,
     MarkLogicDocumentVersionURIString,

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -5,11 +5,12 @@ from unittest.mock import Mock
 from typing_extensions import TypeAlias
 
 from caselawclient.Client import MarklogicApiClient
-from caselawclient.models.documents import Document, DocumentURIString
+from caselawclient.models.documents import Document
 from caselawclient.models.documents.body import DocumentBody
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.responses.search_result import SearchResult, SearchResultMetadata
+from caselawclient.types import DocumentURIString
 
 DEFAULT_DOCUMENT_BODY_XML = "<akomantoso>This is some XML of a judgment.</akomantoso>"
 

--- a/src/caselawclient/identifier_resolution.py
+++ b/src/caselawclient/identifier_resolution.py
@@ -1,9 +1,9 @@
 import json
 from typing import NamedTuple
 
-from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.unpacker import IDENTIFIER_NAMESPACE_MAP
+from caselawclient.types import DocumentURIString
 from caselawclient.xquery_type_dicts import MarkLogicDocumentURIString
 
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -30,9 +30,10 @@ from caselawclient.models.utilities.aws import (
     request_parse,
     unpublish_documents,
 )
+from caselawclient.types import DocumentURIString
 
 from .body import DocumentBody
-from .exceptions import CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion, InvalidDocumentURIException
+from .exceptions import CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
 
 MINIMUM_ENRICHMENT_TIME = datetime.timedelta(minutes=20)
@@ -47,28 +48,6 @@ DOCUMENT_COLLECTION_URI_PRESS_SUMMARY = "press-summary"
 
 if TYPE_CHECKING:
     from caselawclient.Client import MarklogicApiClient
-
-
-class DocumentURIString(str):
-    """
-    This class checks that the string is actually a valid Document URI on creation. It does _not_ manipulate the string.
-    """
-
-    def __new__(cls, content: str) -> "DocumentURIString":
-        # Check that the URI doesn't begin or end with a slash
-        if content[0] == "/" or content[-1] == "/":
-            raise InvalidDocumentURIException(
-                f'"{content}" is not a valid document URI; URIs cannot begin or end with slashes.'
-            )
-
-        # Check that the URI doesn't contain a full stop
-        if "." in content:
-            raise InvalidDocumentURIException(
-                f'"{content}" is not a valid document URI; URIs cannot contain full stops.'
-            )
-
-        # If everything is good, return as usual
-        return str.__new__(cls, content)
 
 
 class Document:

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -4,7 +4,3 @@ class CannotPublishUnpublishableDocument(Exception):
 
 class DocumentNotSafeForDeletion(Exception):
     """A document which is not safe for deletion cannot be deleted."""
-
-
-class InvalidDocumentURIException(Exception):
-    """The document URI is not valid."""

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -10,7 +10,9 @@ from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 if TYPE_CHECKING:
     from caselawclient.models.press_summaries import PressSummary
 
-from .documents import Document, DocumentURIString
+from caselawclient.types import DocumentURIString
+
+from .documents import Document
 
 
 class Judgment(NeutralCitationMixin, Document):

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -8,8 +8,9 @@ from ds_caselaw_utils.types import NeutralCitationString
 
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
+from caselawclient.types import DocumentURIString
 
-from .documents import Document, DocumentURIString
+from .documents import Document
 
 if TYPE_CHECKING:
     from caselawclient.models.judgments import Judgment

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, overload
+from typing import Any, Literal, Optional, TypedDict, overload
 
 import boto3
 import botocore.client
@@ -13,10 +13,7 @@ from mypy_boto3_sns.client import SNSClient
 from mypy_boto3_sns.type_defs import MessageAttributeValueTypeDef
 from typing_extensions import NotRequired
 
-if TYPE_CHECKING:
-    from caselawclient.models.documents import DocumentURIString
-else:
-    DocumentURIString = None
+from caselawclient.types import DocumentURIString
 
 env = environ.Env()
 

--- a/src/caselawclient/models/utilities/move.py
+++ b/src/caselawclient/models/utilities/move.py
@@ -4,8 +4,8 @@ import ds_caselaw_utils as caselawutils
 from ds_caselaw_utils.types import NeutralCitationString
 
 from caselawclient.errors import MarklogicAPIError
-from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.utilities.aws import copy_assets
+from caselawclient.types import DocumentURIString
 
 if TYPE_CHECKING:
     from caselawclient.Client import MarklogicApiClient

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -12,7 +12,7 @@ from ds_caselaw_utils.types import CourtCode, JurisdictionCode
 from lxml import etree
 
 from caselawclient.Client import MarklogicApiClient
-from caselawclient.models.documents import DocumentURIString
+from caselawclient.types import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
 
 

--- a/src/caselawclient/types.py
+++ b/src/caselawclient/types.py
@@ -1,0 +1,24 @@
+class InvalidDocumentURIException(Exception):
+    """The document URI is not valid."""
+
+
+class DocumentURIString(str):
+    """
+    This class checks that the string is actually a valid Document URI on creation. It does _not_ manipulate the string.
+    """
+
+    def __new__(cls, content: str) -> "DocumentURIString":
+        # Check that the URI doesn't begin or end with a slash
+        if content[0] == "/" or content[-1] == "/":
+            raise InvalidDocumentURIException(
+                f'"{content}" is not a valid document URI; URIs cannot begin or end with slashes.'
+            )
+
+        # Check that the URI doesn't contain a full stop
+        if "." in content:
+            raise InvalidDocumentURIException(
+                f'"{content}" is not a valid document URI; URIs cannot contain full stops.'
+            )
+
+        # If everything is good, return as usual
+        return str.__new__(cls, content)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -7,7 +7,7 @@ checks. They are used to enforce appropriately typed variables being passed in t
 """
 
 from typing import Any, NewType, Optional, TypedDict
-from caselawclient.models.documents import DocumentURIString
+from caselawclient.types import DocumentURIString
 
 MarkLogicDocumentURIString = NewType("MarkLogicDocumentURIString", str)
 MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -18,8 +18,8 @@ from caselawclient.models.documents import (
     Document,
     DocumentURIString,
 )
-from caselawclient.models.documents.exceptions import InvalidDocumentURIException
 from caselawclient.models.judgments import Judgment
+from caselawclient.types import InvalidDocumentURIException
 from tests.test_helpers import MockMultipartResponse
 
 


### PR DESCRIPTION
## Summary of changes

To fix a circular import, we move DocumentURIString and associated exceptions into a new types file at the root of the structure. **This is a breaking change.**

## Checklist

- [x] This is a breaking change
- [x] I have updated the changelog (if necessary)
