### PR TITLE
⚠️ document.body.content_as_html can be None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - **identifiers**: Support identifier resolution from value and namespace
 - ⚠️ **refactor**: Move DocumentURIString and InvalidDocumentURIException to .types
+- ⚠️ **html transform**: Document.body.content_as_html can be None if there is no real content
 
 ## v29.2.0 (2025-01-27)
 

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import warnings
-from functools import cached_property
+from functools import cache, cached_property
 from typing import Optional
 from xml.etree.ElementTree import Element
 
@@ -124,7 +124,7 @@ class DocumentBody:
     def content_as_xml(self) -> str:
         return self._xml.xml_as_string
 
-    @property
+    @cached_property
     def has_content(self) -> bool:
         """If we do not have a word document, the XML will not contain
         the contents of the judgment, but will contain a preamble."""
@@ -136,6 +136,7 @@ class DocumentBody:
         content = self._xml.xml_as_tree.xpath("//akn:judgmentBody", namespaces=DEFAULT_NAMESPACES)[0]
         return not (stripped_tag_text(header) == "" and stripped_tag_text(content) == "")
 
+    @cache
     def content_as_html(self, image_base_url: Optional[str] = None) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""
         if not self.has_content:

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -125,7 +125,7 @@ class DocumentBody:
         return self._xml.xml_as_string
 
     @property
-    def has_actual_content(self) -> bool:
+    def has_content(self) -> bool:
         """If we do not have a word document, the XML will not contain
         the contents of the judgment, but will contain a preamble."""
 
@@ -138,7 +138,7 @@ class DocumentBody:
 
     def content_as_html(self, image_base_url: Optional[str] = None) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""
-        if not self.has_actual_content:
+        if not self.has_content:
             return None
 
         html_xslt_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "transforms", "html.xsl")

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -136,8 +136,10 @@ class DocumentBody:
         content = self._xml.xml_as_tree.xpath("//akn:judgmentBody", namespaces=DEFAULT_NAMESPACES)[0]
         return not (stripped_tag_text(header) == "" and stripped_tag_text(content) == "")
 
-    def content_as_html(self, image_base_url: Optional[str] = None) -> str:
+    def content_as_html(self, image_base_url: Optional[str] = None) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""
+        if not self.has_actual_content:
+            return None
 
         html_xslt_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "transforms", "html.xsl")
 

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -311,7 +311,7 @@ class TestDocumentBody:
                 </judgmentBody>
             </judgment>
             </akomaNtoso>""")
-        assert body.has_actual_content
+        assert body.has_content
 
     def test_actual_content_header(self):
         body = DocumentBodyFactory.build("""
@@ -326,7 +326,7 @@ class TestDocumentBody:
                 </judgmentBody>
             </judgment>
             </akomaNtoso>""")
-        assert body.has_actual_content
+        assert body.has_content
 
     def test_no_actual_content(self):
         body = DocumentBodyFactory.build("""
@@ -341,4 +341,4 @@ class TestDocumentBody:
             </judgment>
             </akomaNtoso>""")
 
-        assert not (body.has_actual_content)
+        assert not (body.has_content)

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from bs4 import BeautifulSoup
 
+from caselawclient.factories import DocumentBodyFactory
 from caselawclient.models.documents import (
     DocumentBody,
 )
@@ -295,3 +296,48 @@ class TestDocumentBody:
         prettified_transformed_html = BeautifulSoup(transformed_html, features="html.parser").prettify()
 
         assert prettified_transformed_html == prettified_target_html
+
+    def test_actual_content_body(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <judgment name="decision">
+                <meta/><header/>
+                <judgmentBody>
+                <decision>
+                a
+                <p/>
+                </decision>
+                </judgmentBody>
+            </judgment>
+            </akomaNtoso>""")
+        assert body.has_actual_content
+
+    def test_actual_content_header(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <judgment name="decision">
+                <meta/>
+                <header>a</header>
+                <judgmentBody>
+                <decision>
+                <p/>
+                </decision>
+                </judgmentBody>
+            </judgment>
+            </akomaNtoso>""")
+        assert body.has_actual_content
+
+    def test_no_actual_content(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <judgment name="decision">
+                <meta/><header/>
+                <judgmentBody>
+                <decision>
+                <p/>
+                </decision>
+                </judgmentBody>
+            </judgment>
+            </akomaNtoso>""")
+
+        assert not (body.has_actual_content)

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -293,6 +293,7 @@ class TestDocumentBody:
 
         body = DocumentBody(xml_document.encode())
         transformed_html = body.content_as_html(image_base_url="https://test.caselaw.nationalarchives.gov.uk/")
+        assert transformed_html
         prettified_transformed_html = BeautifulSoup(transformed_html, features="html.parser").prettify()
 
         assert prettified_transformed_html == prettified_target_html

--- a/tests/models/documents/xslt/test_standard_judgment.html
+++ b/tests/models/documents/xslt/test_standard_judgment.html
@@ -10,4 +10,8 @@
       Neutral Citation Number: <span class="ncn-nowrap">[2024] UKSC 1234</span>
     </div>
   </header>
+  <section class="judgment-body">
+   <p>
+   </p>
+  </section>
 </article>

--- a/tests/models/documents/xslt/test_standard_judgment.xml
+++ b/tests/models/documents/xslt/test_standard_judgment.xml
@@ -18,5 +18,10 @@
             <p><img src="image1.png" style="width:99.05pt;height:99.05pt"/></p>
             <p class="CoverText" style="text-align:left">Neutral Citation Number: <neutralCitation>[2024] UKSC 1234</neutralCitation></p>
         </header>
+        <judgmentBody>
+            <decision>
+            <p/>
+            </decision>
+        </judgmentBody>
     </judgment>
 </akomaNtoso>


### PR DESCRIPTION
## Summary of changes

If there is no parsed DOCX in the XML (i.e. there is no content in the header or body) `Document.body.content_as_html` now returns `None`.

This will cause typing changes downstream as it's now an `Optional[str]`

You can pre-emptively check with `Document.body.has_actual_content`

https://national-archives.atlassian.net/browse/FCL-640

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
