### PR TITLE
Relax has_content to not require valid akomaNtoso

### DIFF
--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -342,3 +342,8 @@ class TestDocumentBody:
             </akomaNtoso>""")
 
         assert not (body.has_content)
+
+    def test_minimal_xml_behaves_ok(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso/>""")
+        assert not (body.has_content)


### PR DESCRIPTION
There were many errors on PUI caused by the examples having short XML which doesn't have `header` or `judgmentBody` tags. Let's be casual about what we expect to receive.
