### PR TITLE
Fix missing space when query contains space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unpublished
+
+### Fix
+
+- **html transform**: If query contains space, don't delete the highlighted space
+
 ## v31.0.0 (2025-02-03)
 
 ### Breaking Change

--- a/src/caselawclient/xquery/xslt_transform.xqy
+++ b/src/caselawclient/xquery/xslt_transform.xqy
@@ -28,7 +28,7 @@ let $number_marks_xslt := (
     </xsl:template>
     <xsl:template match="mark">
       <xsl:copy>
-          <xsl:copy-of select="@*" />
+          <xsl:copy-of select="*" />
           <xsl:attribute name="id">
               <xsl:text>mark_</xsl:text>
               <xsl:value-of select="count(preceding::mark)"/>


### PR DESCRIPTION
## Summary of changes

When searching for a name, e.g. `Huw Evans`, the search highlighting highlights the space, but the transform deletes the whitespace, leaving it with

`<mark id="mark_0">Huw</mark><mark id="mark_1"></mark><mark id="mark_2">Evans</mark>`

This change retains the space

`<mark id="mark_0">Huw</mark><mark id="mark_1"> </mark><mark id="mark_2">Evans</mark>`

I don't understand the difference between `*` and `@*` and `node()`, but this seems to work.

(`@*` is [attributes](https://stackoverflow.com/questions/2942989/what-is-the-at-symbol-used-for-in-xslt)... not sure how that ever worked)
https://stackoverflow.com/questions/2942989/what-is-the-at-symbol-used-for-in-xslt

<!-- Replace this with a short summary of changes in this PR -->

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136/backlog?selectedIssue=FCL-628

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
