### PR TITLE
v30.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v30.0.1 (2025-02-03)
+
+### Bugfix
+
+- **document**: Relax has_content to not require valid akomaNtoso to allow tests
+
 ## v30.0.0 (2025-01-31)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "30.0.0"
+version = "30.0.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## Summary of changes
Relax has_content to not require valid akomaNtoso by @dragon-dxw in https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/868

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
