### PR TITLE
refactor(Document): remove deprecated content_as_html and number_of_mentions methods

### DIFF
--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -56,7 +56,6 @@ class DocumentFactory:
     def build(
         cls,
         uri: DocumentURIString = DocumentURIString("test/2023/123"),
-        html: str = "<p>This is a judgment.</p>",
         api_client: Optional[MarklogicApiClient] = None,
         **kwargs: Any,
     ) -> target_class:
@@ -66,7 +65,6 @@ class DocumentFactory:
             api_client.get_property_as_node.return_value = None
 
         document = cls.target_class(uri, api_client=api_client)
-        document.content_as_html = Mock(return_value=html)  # type: ignore[method-assign]
         document.body = kwargs.pop("body") if "body" in kwargs else DocumentBodyFactory.build()
 
         for param_name, default_value in cls.PARAMS_MAP.items():

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -20,7 +20,6 @@ from caselawclient.models.documents import (
 )
 from caselawclient.models.judgments import Judgment
 from caselawclient.types import InvalidDocumentURIException
-from tests.test_helpers import MockMultipartResponse
 
 
 class TestDocument:
@@ -179,34 +178,6 @@ class TestDocument:
         version_document = Document(DocumentURIString("test/1234_xml_versions/9-1234"), mock_api_client)
         assert version_document.version_number == 9
         assert version_document.is_version
-
-    def test_number_of_mentions_when_no_mentions(self, mock_api_client):
-        mock_api_client.eval_xslt.return_value = MockMultipartResponse(
-            b"""
-            <article>
-                <p>An article with no mark elements.</p>
-            </article>
-        """,
-        )
-
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-
-        assert document.number_of_mentions("some") == 0
-
-    def test_number_of_mentions_when_mentions(self, mock_api_client):
-        mock_api_client.eval_xslt.return_value = MockMultipartResponse(
-            b"""
-            <article>
-                <p>
-                    An article with <mark id="mark_0">some</mark> mark elements, and <mark id="mark_1">some</mark> more.
-                </p>
-            </article>
-        """,
-        )
-
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-
-        assert document.number_of_mentions("some") == 2
 
     def test_validates_against_schema(self, mock_api_client):
         mock_api_client.validate_document.return_value = True

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -3,11 +3,6 @@ import pytest
 from caselawclient.factories import DocumentFactory, JudgmentFactory, PressSummaryFactory, SearchResultFactory
 
 
-def test_content_as_html():
-    doc = DocumentFactory.build()
-    assert doc.content_as_html() == "<p>This is a judgment.</p>"
-
-
 class TestSearchStatusBehaviour:
     def test_status(self):
         search = SearchResultFactory.build()


### PR DESCRIPTION
BREAKING CHANGE: Remove `content_as_html` and `number_of_mentions` methods from `Document`. Use those on `Document.body` instead.
