### PR TITLE
v31.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v31.0.0 (2025-02-03)
+
+### Breaking Change
+
+- refactor(Document): remove deprecated content_as_html and number_of_mentions methods
+
+### Feat
+
+- FCL 582 Get related documents (e.g. Press Summary for Judgment)
+
+### Fix
+
+- Relax has_content to not require valid akomaNtoso
+- fix(DocumentFactory): make default body XML representative of a real document
+
 ## v30.0.0 (2025-01-31)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "30.0.0"
+version = "31.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## Summary of changes

### Breaking Change
- refactor(Document): remove deprecated content_as_html and number_of_mentions methods

### Feat

- FCL 582 Get related documents (e.g. Press Summary for Judgment)

### Fix

- Relax has_content to not require valid akomaNtoso
- fix(DocumentFactory): make default body XML representative of a real document
<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
