### PR TITLE
bump: version 31.0.0 → 31.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unpublished
+## v31.0.1 (2025-02-06)
 
-### Fix
+### Fix
 
 - **html transform**: If query contains space, don't delete the highlighted space
+- **deps**: update dependency pytz to v2025
+- **deps**: update dependency boto3 to v1.36.12
 
 ## v31.0.0 (2025-02-03)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "31.0.0"
+version = "31.0.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Fix

- **html transform**: If query contains space, don't delete the highlighted space
- **deps**: update dependency pytz to v2025
- **deps**: update dependency boto3 to v1.36.12