### PR TITLE
fix(IdentifierResolution): Be explicit about the public URLs being different than the MarkLogic URIs with new types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- **IdentifierResolution**: fix incorrect types in resolving an identifier
+
 ## v31.0.1 (2025-02-06)
 
 ### Fix

--- a/script/build_xquery_type_dicts
+++ b/script/build_xquery_type_dicts
@@ -13,7 +13,7 @@ checks. They are used to enforce appropriately typed variables being passed in t
 \"\"\"
 
 from typing import Any, NewType, Optional, TypedDict
-from caselawclient.types import DocumentURIString
+from caselawclient.types import DocumentURIString, DocumentIdentifierSlug, DocumentIdentifierValue
 from caselawclient.types import MarkLogicDocumentURIString as MarkLogicDocumentURIString
 
 MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)
@@ -54,8 +54,12 @@ def ml_type_to_python_type_declaration(variable_name: str, variable_type: str):
         variable_type = "MarkLogicDocumentVersionURIString"
     elif variable_name == "privilege_uri":
         variable_type = "MarkLogicPrivilegeURIString"
-    elif variable_name in ["identifier_uri", "parent_uri"]:
+    elif variable_name in ["parent_uri"]:
         variable_type = "DocumentURIString"
+    elif variable_name in ["identifier_slug"]:
+        variable_type = "DocumentIdentifierSlug"
+    elif variable_name in ["identifier_value"]:
+        variable_type = "DocumentIdentifierValue"
     elif variable_name == "uri" or variable_name.endswith("_uri"):
         variable_type = "MarkLogicDocumentURIString"
     else:

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -30,7 +30,7 @@ from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities import move
 from caselawclient.search_parameters import SearchParameters
-from caselawclient.types import DocumentURIString
+from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue, DocumentURIString
 from caselawclient.xquery_type_dicts import (
     MarkLogicDocumentURIString,
     MarkLogicDocumentVersionURIString,
@@ -1203,11 +1203,13 @@ class MarklogicApiClient:
 
         return results
 
-    def resolve_from_identifier_slug(self, identifier_uri: str, published_only: bool = True) -> IdentifierResolutions:
+    def resolve_from_identifier_slug(
+        self, identifier_slug: DocumentIdentifierSlug, published_only: bool = True
+    ) -> IdentifierResolutions:
         """Given a PUI/EUI url, look up the precomputed slug and return the
         MarkLogic document URIs which match that slug. Multiple returns should be anticipated"""
         vars: query_dicts.ResolveFromIdentifierSlugDict = {
-            "identifier_uri": DocumentURIString(identifier_uri),
+            "identifier_slug": identifier_slug,
             "published_only": int(published_only),
         }
         raw_results: list[str] = get_multipart_strings_from_marklogic_response(
@@ -1218,14 +1220,8 @@ class MarklogicApiClient:
         )
         return IdentifierResolutions.from_marklogic_output(raw_results)
 
-    def resolve_from_identifier(self, identifier_uri: str, published_only: bool = True) -> IdentifierResolutions:
-        warnings.warn(
-            "resolve_from_identifier deprecated, use resolve_from_identifier_slug instead", DeprecationWarning
-        )
-        return self.resolve_from_identifier_slug(identifier_uri, published_only)
-
     def resolve_from_identifier_value(
-        self, identifier_value: str, published_only: bool = True
+        self, identifier_value: DocumentIdentifierValue, published_only: bool = True
     ) -> IdentifierResolutions:
         """Given a PUI/EUI url, look up the precomputed slug and return the
         MarkLogic document URIs which match that slug. Multiple returns should be anticipated"""

--- a/src/caselawclient/identifier_resolution.py
+++ b/src/caselawclient/identifier_resolution.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.unpacker import IDENTIFIER_NAMESPACE_MAP
-from caselawclient.types import DocumentURIString
+from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
 from caselawclient.xquery_type_dicts import MarkLogicDocumentURIString
 
 
@@ -31,9 +31,9 @@ class IdentifierResolution(NamedTuple):
 
     identifier_uuid: str
     document_uri: MarkLogicDocumentURIString
-    identifier_slug: DocumentURIString
+    identifier_slug: DocumentIdentifierSlug
     document_published: bool
-    identifier_value: str
+    identifier_value: DocumentIdentifierValue
     identifier_namespace: str
     identifier_type: type[Identifier]
 
@@ -44,9 +44,9 @@ class IdentifierResolution(NamedTuple):
         return IdentifierResolution(
             identifier_uuid=row["documents.compiled_url_slugs.identifier_uuid"],
             document_uri=MarkLogicDocumentURIString(row["documents.compiled_url_slugs.document_uri"]),
-            identifier_slug=DocumentURIString(row["documents.compiled_url_slugs.identifier_slug"]),
+            identifier_slug=DocumentIdentifierSlug(row["documents.compiled_url_slugs.identifier_slug"]),
             document_published=row["documents.compiled_url_slugs.document_published"] == "true",
-            identifier_value=row["documents.compiled_url_slugs.identifier_value"],
+            identifier_value=DocumentIdentifierValue(row["documents.compiled_url_slugs.identifier_value"]),
             identifier_namespace=identifier_namespace,
             identifier_type=IDENTIFIER_NAMESPACE_MAP[identifier_namespace],
         )

--- a/src/caselawclient/types.py
+++ b/src/caselawclient/types.py
@@ -29,3 +29,11 @@ class DocumentURIString(str):
 
     def as_marklogic(self) -> MarkLogicDocumentURIString:
         return MarkLogicDocumentURIString(f"/{self}.xml")
+
+
+class DocumentIdentifierSlug(str):
+    pass
+
+
+class DocumentIdentifierValue(str):
+    pass

--- a/src/caselawclient/xquery/resolve_from_identifier_slug.xqy
+++ b/src/caselawclient/xquery/resolve_from_identifier_slug.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 declare namespace xdmp="http://marklogic.com/xdmp"; 
-declare variable $identifier_uri as xs:string external;
+declare variable $identifier_slug as xs:string external;
 declare variable $published_only as xs:int? external := 1;
 
 let $published_query := if ($published_only) then " AND document_published = 'true'" else ""
@@ -11,7 +11,6 @@ return xdmp:sql(
   $query,
   "map",
   map:new((
-    map:entry("uri", $identifier_uri)
+    map:entry("uri", $identifier_slug)
   ))
 )
-

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -7,7 +7,7 @@ checks. They are used to enforce appropriately typed variables being passed in t
 """
 
 from typing import Any, NewType, Optional, TypedDict
-from caselawclient.types import DocumentURIString
+from caselawclient.types import DocumentURIString, DocumentIdentifierSlug, DocumentIdentifierValue
 from caselawclient.types import MarkLogicDocumentURIString as MarkLogicDocumentURIString
 
 MarkLogicDocumentVersionURIString = NewType("MarkLogicDocumentVersionURIString", MarkLogicDocumentURIString)
@@ -143,13 +143,13 @@ class ListJudgmentVersionsDict(MarkLogicAPIDict):
 
 # resolve_from_identifier_slug.xqy
 class ResolveFromIdentifierSlugDict(MarkLogicAPIDict):
-    identifier_uri: DocumentURIString
+    identifier_slug: DocumentIdentifierSlug
     published_only: Optional[int]
 
 
 # resolve_from_identifier_value.xqy
 class ResolveFromIdentifierValueDict(MarkLogicAPIDict):
-    identifier_value: str
+    identifier_value: DocumentIdentifierValue
     published_only: Optional[int]
 
 


### PR DESCRIPTION
We create two new types: `DocumentIdentifierSlug` and `Value`.