### PR TITLE
[FCL-667] Retrieve a DocumentURIString from a MarkLogic one

### DIFF
--- a/src/caselawclient/types.py
+++ b/src/caselawclient/types.py
@@ -2,8 +2,29 @@ class InvalidDocumentURIException(Exception):
     """The document URI is not valid."""
 
 
+class InvalidMarkLogicDocumentURIException(Exception):
+    """The MarkLogic document URI is not valid."""
+
+
 class MarkLogicDocumentURIString(str):
-    pass
+    def __new__(cls, content: str) -> "MarkLogicDocumentURIString":
+        # Check that the URI begins with a slash
+        if content[0] != "/":
+            raise InvalidMarkLogicDocumentURIException(
+                f'"{content}" is not a valid MarkLogic document URI; URIs must begin with a slash.'
+            )
+
+        # Check that the URI ends with ".xml"
+        if not content.endswith(".xml"):
+            raise InvalidMarkLogicDocumentURIException(
+                f'"{content}" is not a valid MarkLogic document URI; URIs must end with ".xml". '
+            )
+
+        # If everything is good, return as usual
+        return str.__new__(cls, content)
+
+    def as_document_uri(self) -> "DocumentURIString":
+        return DocumentURIString(self.lstrip("/").rstrip(".xml"))
 
 
 class DocumentURIString(str):

--- a/tests/client/test_identifier_resolution.py
+++ b/tests/client/test_identifier_resolution.py
@@ -3,7 +3,7 @@ from caselawclient.models.identifiers.neutral_citation import NeutralCitationNum
 
 raw_marklogic_resolutions = [
     """
-                                 {"documents.compiled_url_slugs.identifier_uuid":"24b9a384-8bcf-4f20-996a-5c318f8dc657",
+                                 {"documents.compiled_url_slugs.identifier_uuid":"id-24b9a384-8bcf-4f20-996a-5c318f8dc657",
                                   "documents.compiled_url_slugs.document_uri":"/ewca/civ/2003/547.xml",
                                   "documents.compiled_url_slugs.identifier_slug":"ewca/civ/2003/54721",
                                   "documents.compiled_url_slugs.document_published":"false",
@@ -12,12 +12,12 @@ raw_marklogic_resolutions = [
                                   }
                                  """,
     """
-                                 {"documents.compiled_url_slugs.identifier_uuid":"x",
-                                  "documents.compiled_url_slugs.document_uri":"x",
-                                  "documents.compiled_url_slugs.identifier_slug":"x",
+                                 {"documents.compiled_url_slugs.identifier_uuid":"id-04026b8d-3b34-4603-86cd-da145ce6ec26",
+                                  "documents.compiled_url_slugs.document_uri":"/uksc/2025/123.xml",
+                                  "documents.compiled_url_slugs.identifier_slug":"uksc/2025/123",
                                   "documents.compiled_url_slugs.document_published":"true",
                                   "documents.compiled_url_slugs.identifier_namespace":"ukncn",
-                                  "documents.compiled_url_slugs.identifier_value":"X"
+                                  "documents.compiled_url_slugs.identifier_value":"[2025] UKSC 123"
                                   }
                                  """,
 ]
@@ -26,7 +26,7 @@ raw_marklogic_resolutions = [
 def test_decoded_identifier():
     decoded_resolutions = IdentifierResolutions.from_marklogic_output(raw_marklogic_resolutions)
     res = decoded_resolutions[0]
-    assert res.identifier_uuid == "24b9a384-8bcf-4f20-996a-5c318f8dc657"
+    assert res.identifier_uuid == "id-24b9a384-8bcf-4f20-996a-5c318f8dc657"
     assert res.document_uri == "/ewca/civ/2003/547.xml"
     assert res.identifier_slug == "ewca/civ/2003/54721"
     assert res.identifier_namespace == "ukncn"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,63 @@
+from pytest import raises
+
+from caselawclient.types import (
+    DocumentURIString,
+    InvalidDocumentURIException,
+    InvalidMarkLogicDocumentURIException,
+    MarkLogicDocumentURIString,
+)
+
+
+class TestMarkLogicDocumentURIString:
+    def test_must_begin_with_slash(self):
+        with raises(
+            InvalidMarkLogicDocumentURIException,
+            match='"test/2025/123.xml" is not a valid MarkLogic document URI; URIs must begin with a slash.',
+        ):
+            MarkLogicDocumentURIString("test/2025/123.xml")
+
+    def test_must_end_with_dotxml(self):
+        with raises(
+            InvalidMarkLogicDocumentURIException,
+            match='"/test/2025/123" is not a valid MarkLogic document URI; URIs must end with ".xml".',
+        ):
+            MarkLogicDocumentURIString("/test/2025/123")
+
+    def test_as_documenturi(self):
+        marklogic_uri = MarkLogicDocumentURIString("/test/2025/123.xml")
+
+        document_uri = marklogic_uri.as_document_uri()
+
+        assert document_uri == "test/2025/123"
+        assert type(document_uri) is DocumentURIString
+
+
+class TestDocumentURIString:
+    def test_must_not_begin_with_slash(self):
+        with raises(
+            InvalidDocumentURIException,
+            match='"/test/2025/123" is not a valid document URI; URIs cannot begin or end with slashes.',
+        ):
+            DocumentURIString("/test/2025/123")
+
+    def test_must_not_end_with_slash(self):
+        with raises(
+            InvalidDocumentURIException,
+            match='"test/2025/123/" is not a valid document URI; URIs cannot begin or end with slashes.',
+        ):
+            DocumentURIString("test/2025/123/")
+
+    def test_must_not_contain_dot(self):
+        with raises(
+            InvalidDocumentURIException,
+            match='"test/2025/123.456" is not a valid document URI; URIs cannot contain full stops.',
+        ):
+            DocumentURIString("test/2025/123.456")
+
+    def test_as_marklogic(self):
+        document_uri = DocumentURIString("test/2025/123")
+
+        marklogic_uri = document_uri.as_marklogic()
+
+        assert marklogic_uri == "/test/2025/123.xml"
+        assert type(marklogic_uri) is MarkLogicDocumentURIString


### PR DESCRIPTION
## Summary of changes

We need to be able to switch both directions between a DocumentURIString (`uksc/2024/1`) and a MarklogicDocumentURIString (`/uksc/2024/1.xml`)