### PR TITLE
bump: version 31.0.1 → 31.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v31.1.0 (2025-02-10)
+
+### Feat
+
+- **types**: MarkLogicDocumentURIString now validates and can be converted back to a DocumentURIString
 
 ### Fix
 
+- **deps**: update boto packages to v1.36.15
 - **IdentifierResolution**: fix incorrect types in resolving an identifier
 
 ## v31.0.1 (2025-02-06)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "31.0.1"
+version = "31.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **types**: MarkLogicDocumentURIString now validates and can be converted back to a DocumentURIString

### Fix

- **deps**: update boto packages to v1.36.15
- **IdentifierResolution**: fix incorrect types in resolving an identifier