### PR TITLE
feat(Identifier): update the types of outputs from value and slug

### DIFF
--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -4,6 +4,8 @@ from uuid import uuid4
 
 from lxml import etree
 
+from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
+
 IDENTIFIER_PACKABLE_ATTRIBUTES: list[str] = [
     "uuid",
     "value",
@@ -60,7 +62,7 @@ class IdentifierSchema(ABC):
 
     @classmethod
     @abstractmethod
-    def compile_identifier_url_slug(cls, value: str) -> str:
+    def compile_identifier_url_slug(cls, value: str) -> DocumentIdentifierSlug:
         """Convert an identifier into a precompiled URL slug."""
         pass
 
@@ -71,7 +73,7 @@ class Identifier(ABC):
     schema: type[IdentifierSchema]
 
     uuid: str
-    value: str
+    value: DocumentIdentifierValue
 
     def __init_subclass__(cls: type["Identifier"], **kwargs: Any) -> None:
         """Ensure that subclasses have the required attributes set."""
@@ -87,7 +89,7 @@ class Identifier(ABC):
         return self.value
 
     def __init__(self, value: str, uuid: Optional[str] = None) -> None:
-        self.value = value
+        self.value = DocumentIdentifierValue(value)
         if uuid:
             self.uuid = uuid
         else:

--- a/src/caselawclient/models/identifiers/fclid.py
+++ b/src/caselawclient/models/identifiers/fclid.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from sqids import Sqids
 
+from caselawclient.types import DocumentIdentifierSlug
+
 from . import Identifier, IdentifierSchema
 
 if TYPE_CHECKING:
@@ -35,8 +37,8 @@ class FindCaseLawIdentifierSchema(IdentifierSchema):
         return bool(VALID_FCLID_PATTERN.match(value))
 
     @classmethod
-    def compile_identifier_url_slug(cls, value: str) -> str:
-        return "tna." + value
+    def compile_identifier_url_slug(cls, value: str) -> DocumentIdentifierSlug:
+        return DocumentIdentifierSlug("tna." + value)
 
     @classmethod
     def mint(cls, api_client: "MarklogicApiClient") -> "FindCaseLawIdentifier":

--- a/src/caselawclient/models/identifiers/neutral_citation.py
+++ b/src/caselawclient/models/identifiers/neutral_citation.py
@@ -3,6 +3,8 @@ import re
 from ds_caselaw_utils import neutral_url
 from ds_caselaw_utils.types import NeutralCitationString
 
+from caselawclient.types import DocumentIdentifierSlug
+
 from . import Identifier, IdentifierSchema
 
 VALID_NCN_PATTERN = re.compile(r"(^\[([0-9]{4})\] ([a-zA-Z]+)(?: ([a-zA-Z]+))? ([0-9]+)(?: \(([a-zA-Z]+)\))?$)")
@@ -38,13 +40,13 @@ class NeutralCitationNumberSchema(IdentifierSchema):
         return bool(VALID_NCN_PATTERN.match(value))
 
     @classmethod
-    def compile_identifier_url_slug(cls, value: str) -> str:
+    def compile_identifier_url_slug(cls, value: str) -> DocumentIdentifierSlug:
         ncn_based_uri_string = neutral_url(
             NeutralCitationString(value)
         )  # TODO: At some point this should move out of utils and into this class.
         if not ncn_based_uri_string:
             raise Exception(f"Unable to convert NCN {value} into NCN-based URL slug")
-        return ncn_based_uri_string
+        return DocumentIdentifierSlug(ncn_based_uri_string)
 
 
 class NeutralCitationNumber(Identifier):

--- a/src/caselawclient/models/identifiers/press_summary_ncn.py
+++ b/src/caselawclient/models/identifiers/press_summary_ncn.py
@@ -1,3 +1,5 @@
+from caselawclient.types import DocumentIdentifierSlug
+
 from .neutral_citation import NeutralCitationNumber, NeutralCitationNumberSchema
 
 
@@ -12,8 +14,8 @@ class PressSummaryRelatedNCNIdentifierSchema(NeutralCitationNumberSchema):
     base_score_multiplier = 0.5
 
     @classmethod
-    def compile_identifier_url_slug(cls, value: str) -> str:
-        return super().compile_identifier_url_slug(value) + "/press-summary"
+    def compile_identifier_url_slug(cls, value: str) -> DocumentIdentifierSlug:
+        return DocumentIdentifierSlug(super().compile_identifier_url_slug(value) + "/press-summary")
 
 
 class PressSummaryRelatedNCNIdentifier(NeutralCitationNumber):

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -3,6 +3,7 @@ from lxml import etree
 
 from caselawclient.models.identifiers import Identifier, Identifiers, IdentifierSchema
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
+from caselawclient.types import DocumentIdentifierSlug
 
 
 class TestIdentifierSchema(IdentifierSchema):
@@ -14,8 +15,8 @@ class TestIdentifierSchema(IdentifierSchema):
     base_score_multiplier = 2.5
 
     @classmethod
-    def compile_identifier_url_slug(cls, value: str) -> str:
-        return value.lower()
+    def compile_identifier_url_slug(cls, value: str) -> DocumentIdentifierSlug:
+        return DocumentIdentifierSlug(value.lower())
 
 
 class TestIdentifier(Identifier):


### PR DESCRIPTION
We now specify stricter types on `Identifier.value` and `IdentifierSchema.slug` so they match up with other functions relying on strict inputs.