### PR TITLE
Stop validating xml against schema when attempting to update a locked judgment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v33.0.0 (2025-02-19)
+
+### Breaking Changes
+
+- Stop validating xml against schema when attempting to update a locked judgment
+
 ## v32.0.0 (2025-02-19)
 
 ### Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "32.0.0"
+version = "33.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/src/caselawclient/xquery/update_locked_judgment.xqy
+++ b/src/caselawclient/xquery/update_locked_judgment.xqy
@@ -8,8 +8,7 @@ declare variable $judgment as xs:string external;
 declare variable $annotation as xs:string external;
 
 let $judgment_xml := xdmp:unquote($judgment)
-(: alternative: check output of let $output := xdmp:validate($judgment_xml) :)
-let $crash_if_invalid := validate strict {$judgment_xml}
+
 return dls:document-update(
    $uri,
    $judgment_xml,


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-697

## Summary of changes

Stop validating xml against schema when attempting to update a locked judgment

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
