### PR TITLE
Provide bytestrings when we're producing search XML.

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1068,14 +1068,14 @@ class MarklogicApiClient:
         response = self._send_to_eval(vars, "get_properties_for_search_results.xqy")
         return get_single_string_from_marklogic_response(response)
 
-    def search_and_decode_response(self, search_parameters: SearchParameters) -> str:
+    def search_and_decode_response(self, search_parameters: SearchParameters) -> bytes:
         response = self.advanced_search(search_parameters)
-        return get_single_string_from_marklogic_response(response)
+        return get_single_bytestring_from_marklogic_response(response)
 
     def search_judgments_and_decode_response(
         self,
         search_parameters: SearchParameters,
-    ) -> str:
+    ) -> bytes:
         search_parameters.collections = [DOCUMENT_COLLECTION_URI_JUDGMENT]
         return self.search_and_decode_response(search_parameters)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,22 +55,22 @@ def generate_search_response_xml_fixture() -> Callable:
         Callable: Function that generates search response XML.
     """
 
-    def _generate_search_response_xml(response_content: str, facets="") -> str:
+    def _generate_search_response_xml(response_content: str, facets="") -> bytes:
         """
-        Generate a search response XML string.
+        Generate a search response XML bytestring.
 
         Args:
             response_content (str): Content of the search response.
 
         Returns:
-            str: Generated search response XML string.
+            bytes: Generated search response XML bytestring.
         """
         return (
             '<search:response xmlns:search="http://marklogic.com/appservices/search" total="2">'
             f"{response_content}"
             f"{facets}"
             "</search:response>"
-        )
+        ).encode("utf-8")
 
     return _generate_search_response_xml
 
@@ -102,12 +102,12 @@ def generate_mock_response_fixture() -> Callable:
         Callable: Function that generates a mock search response.
     """
 
-    def _generate_mock_response(search_response_xml: str) -> Mock:
+    def _generate_mock_response(search_response_xml: bytes) -> Mock:
         """
         Generate a mock search response.
 
         Args:
-            search_response_xml (str): Search response XML.
+            search_response_xml (bytes): Search response XML.
 
         Returns:
             Mock: Generated mock search response.
@@ -118,7 +118,7 @@ def generate_mock_response_fixture() -> Callable:
         mock_response.content = (
             b"\r\n--foo\r\n"
             b"Content-Type: application/xml\r\n"
-            b"X-Primitive: element()\r\nX-Path: /*:response\r\n\r\n" + search_response_xml.encode() + b"\r\n--foo--\r\n"
+            b"X-Primitive: element()\r\nX-Path: /*:response\r\n\r\n" + search_response_xml + b"\r\n--foo--\r\n"
         )
         return mock_response
 


### PR DESCRIPTION
[Changes to the search](https://github.com/nationalarchives/ds-caselaw-marklogic/pull/158) may mean that search will return XML with an encoding declaration, but the way we absorb that XML in the API client is incorrect -- we get it as a `str` which means that it's already abstract unicode rather than undecoded bytes, and lxml correctly (and annoyingly) tells us it doesn't want to parse abstract unicode as if it's undecoded UTF-8.

The solution is to return bytestrings, which so long as consumers aren't looking too carefully into the types it gets from the API client and just passing them to lxml or similar should be absolutely fine.

This should be safe to run with or without the marklogic changes which depend on them.

This code runs with no errors to demonstrate the problem:

```python
import lxml.etree
import pytest

raw_bytes = b"<x/>"
raw_string = "<x/>"
declared_bytes = b'<?xml version="1.0" encoding="utf-8"?><x/>'
declared_string = '<?xml version="1.0" encoding="utf-8"?><x/>'

lxml.etree.fromstring(raw_bytes)
lxml.etree.fromstring(raw_string)
lxml.etree.fromstring(declared_bytes)
with pytest.raises(Exception):
    lxml.etree.fromstring(declared_string)
```
