### PR TITLE
Return identifiers in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **FCL-735**: inserting a new document requires an explicit document type collection
+- `SearchResults` now includes an `identifiers` property
 
 ### Fix
 

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -179,6 +179,13 @@ class SearchResult:
         identifiers_etree = None if not identifiers_etrees else identifiers_etrees[0]
         return unpack_all_identifiers_from_etree(identifiers_etree)
 
+    @cached_property
+    def slug(self) -> str:
+        preferred = self.identifiers.preferred()
+        if not preferred:
+            raise RuntimeError("No preferred identifier for search result")
+        return str(preferred.url_slug)
+
     @property
     def neutral_citation(self) -> str:
         """

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime
 from enum import Enum
 from functools import cached_property
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from dateutil import parser as dateparser
 from dateutil.parser import ParserError
@@ -12,6 +12,8 @@ from ds_caselaw_utils.types import CourtCode, JurisdictionCode
 from lxml import etree
 
 from caselawclient.Client import MarklogicApiClient
+from caselawclient.models.identifiers import Identifiers
+from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
 from caselawclient.types import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
 
@@ -170,6 +172,14 @@ class SearchResult:
         )
 
     @property
+    def identifiers(self) -> Identifiers:
+        identifiers_etrees = self._get_xpath("//identifiers")
+        if count := len(identifiers_etrees) != 1:
+            logging.warning(f"{count} //identifiers nodes found in search result, expected 1.")
+        identifiers_etree = None if not identifiers_etrees else identifiers_etrees[0]
+        return unpack_all_identifiers_from_etree(identifiers_etree)
+
+    @property
     def neutral_citation(self) -> str:
         """
         :return: The neutral citation of the search result, or the judgment it is a press summary of.
@@ -278,3 +288,6 @@ class SearchResult:
 
     def _get_xpath_match_string(self, path: str) -> str:
         return get_xpath_match_string(self.node, path, namespaces=self.NAMESPACES)
+
+    def _get_xpath(self, path: str) -> Any:
+        return self.node.xpath(path, namespaces=self.NAMESPACES)

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -183,6 +183,7 @@ class TestSearchResult:
         assert isinstance(identifiers, Identifiers)
         (identifier_1,) = identifiers.values()
         assert identifier_1.value == "[1901] UKSC 1"
+        assert search_result.slug == "uksc/1901/1"
 
     def test_identifiers_absent(self):
         """
@@ -202,6 +203,8 @@ class TestSearchResult:
         identifiers = search_result.identifiers
         assert isinstance(identifiers, Identifiers)
         assert not identifiers
+        with pytest.raises(RuntimeError):
+            search_result.slug
 
 
 class TestSearchResultMeta:


### PR DESCRIPTION
`SearchResults.identifiers` returns a list of identifiers.

Could do with e2e tests at some point in the future once everything leading up to this point is pushed up; confirming all the different components are working together.

Contains a commit from a previous PR because it depends on that work.