### PR TITLE
⚠️ [FCL-735] Inserting a new document requires an explicit document type collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- insert_document_xml() now requires a Document type class be provided
+
+### Feat
+
+- **FCL-735**: inserting a new document requires an explicit document type collection
+
+### Fix
+
+- **deps**: update dependency boto3 to v1.37.3
+
 ## v33.0.0 (2025-02-19)
 
 ### Breaking Changes

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -572,6 +572,7 @@ class MarklogicApiClient:
         self,
         document_uri: DocumentURIString,
         document_xml: Element,
+        document_type: type[Document],
         annotation: VersionAnnotation,
     ) -> requests.Response:
         """
@@ -579,6 +580,7 @@ class MarklogicApiClient:
 
         :param document_uri: The URI to insert the document at
         :param document_xml: The XML of the document to insert
+        :param document_type: The type class of the document
         :param annotation: Annotations to record alongside this version
 
         :return: The response object from MarkLogic
@@ -592,6 +594,7 @@ class MarklogicApiClient:
 
         vars: query_dicts.InsertDocumentDict = {
             "uri": uri,
+            "type_collection": document_type.type_collection_name,
             "document": xml.decode("utf-8"),
             "annotation": annotation.as_json,
         }

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -61,6 +61,8 @@ class Document:
     document_noun_plural = "documents"
     """ The noun for a plural of this document type. """
 
+    type_collection_name: str
+
     attributes_to_validate: list[tuple[str, bool, str]] = [
         (
             "is_failure",

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -23,6 +23,7 @@ class Judgment(NeutralCitationMixin, Document):
 
     document_noun = "judgment"
     document_noun_plural = "judgments"
+    type_collection_name = "judgment"
 
     def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
         super().__init__(self.document_noun, uri, *args, **kwargs)

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -24,6 +24,7 @@ class PressSummary(NeutralCitationMixin, Document):
 
     document_noun = "press summary"
     document_noun_plural = "press summaries"
+    type_collection_name = "press-summary"
 
     def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
         super().__init__(self.document_noun, uri, *args, **kwargs)

--- a/src/caselawclient/xquery/insert_document.xqy
+++ b/src/caselawclient/xquery/insert_document.xqy
@@ -4,14 +4,10 @@ import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls
 
 declare variable $uri as xs:string external;
 declare variable $document as xs:string external;
+declare variable $type_collection as xs:string external;
 declare variable $annotation as xs:string external;
 
 let $document_xml := xdmp:unquote($document)
-
-let $collections :=
-  if (fn:contains($uri, 'press-summary'))
-  then ("press-summary")
-  else ("judgment")
 
 return dls:document-insert-and-manage(
   $uri,
@@ -19,5 +15,5 @@ return dls:document-insert-and-manage(
   $document_xml,
   $annotation,
   (),
-  $collections
+  ($type_collection)
 )

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -133,6 +133,7 @@ class GetVersionCreatedDict(MarkLogicAPIDict):
 class InsertDocumentDict(MarkLogicAPIDict):
     annotation: str
     document: str
+    type_collection: str
     uri: MarkLogicDocumentURIString
 
 

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -11,6 +11,7 @@ from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.client_helpers import VersionAnnotation, VersionType
 from caselawclient.errors import InvalidContentHashError
 from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.judgments import Judgment
 
 
 class TestSaveCopyDeleteJudgment(unittest.TestCase):
@@ -130,6 +131,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
             document_xml = ElementTree.fromstring(document_str)
             expected_vars = {
                 "uri": "/ewca/civ/2004/632.xml",
+                "type_collection": "judgment",
                 "document": document_str,
                 "annotation": json.dumps(
                     {
@@ -143,9 +145,10 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
                 ),
             }
             self.client.insert_document_xml(
-                uri,
-                document_xml,
-                VersionAnnotation(
+                document_uri=uri,
+                document_xml=document_xml,
+                document_type=Judgment,
+                annotation=VersionAnnotation(
                     VersionType.SUBMISSION,
                     message="test_insert_document_xml",
                     automated=False,

--- a/tests/client_helpers/test_get_document_type_class.py
+++ b/tests/client_helpers/test_get_document_type_class.py
@@ -1,0 +1,25 @@
+from pytest import raises
+
+from caselawclient import client_helpers
+from caselawclient.models.judgments import Judgment
+from caselawclient.models.press_summaries import PressSummary
+
+
+class TestGetDocumentTypeClass:
+    def test_ingested_document_type_judgment(self):
+        """Check that documents with a root tag of `<judgment>` are detected as `Judgment`s."""
+        assert client_helpers.get_document_type_class(b"<judgment />") == Judgment
+
+    def test_ingested_document_type_press_summary(self):
+        """ "Check that documents with a root tag of `<doc name="pressSummary">` are detected as `PressSummary`s."""
+        assert client_helpers.get_document_type_class(b'<doc name="pressSummary" />') == PressSummary
+
+    def test_ingested_document_type_doc_without_press_summary_name(self):
+        """ "Check that documents with a root tag of `<doc>` but no `name="pressSummary" raise an exception."""
+        with raises(client_helpers.CannotDetermineDocumentType):
+            client_helpers.get_document_type_class(b"<doc />")
+
+    def test_ingested_document_type_unknown(self):
+        """Check that in the absence of typing information an exception is raised."""
+        with raises(client_helpers.CannotDetermineDocumentType):
+            client_helpers.get_document_type_class(b"<xml />")


### PR DESCRIPTION
## Summary of changes

This removes the reliance on a document's URI to determine its type collection in MarkLogic. This is now derived directly from the XML itself.

BREAKING CHANGE: `insert_document_xml()` now requires a Document type class be provided

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
