### PR TITLE
bump: version 33.0.0 → 34.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v34.0.0 (2025-03-05)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "33.0.0"
+version = "34.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- Python versions below 3.10 are no longer supported.
- `insert_document_xml()` now requires a Document type class be provided

### Feat

- **FCL-735**: inserting a new document requires an explicit document type collection
- `SearchResults` now includes an `identifiers` property

### Fix

- **deps**: update dependency boto3 to v1.37.3