### PR TITLE
Add a ParserLog Document type

### DIFF
--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -9,6 +9,7 @@ from caselawclient.xml_helpers import DEFAULT_NAMESPACES
 
 from ..models.documents import Document
 from ..models.judgments import Judgment
+from ..models.parser_logs import ParserLog
 from ..models.press_summaries import PressSummary
 
 
@@ -140,7 +141,7 @@ def get_document_type_class(xml: bytes) -> type[Document]:
 
     # If the document is a parser error with a root element of `error`, it's not of a special type.
     if node.xpath("/error", namespaces=DEFAULT_NAMESPACES):
-        return Document
+        return ParserLog
 
     # Otherwise, we don't know for sure. Fail out.
     raise CannotDetermineDocumentType(

--- a/src/caselawclient/models/parser_logs.py
+++ b/src/caselawclient/models/parser_logs.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .documents import Document
+
+
+class ParserLog(Document):
+    """
+    A fundamentally different type of Document that is not part of the akomaNtoso spec
+    """
+
+    document_noun = "parser log"
+    document_noun_plural = "parser logs"
+    type_collection_name = "parser-log"

--- a/tests/client_helpers/test_get_document_type_class.py
+++ b/tests/client_helpers/test_get_document_type_class.py
@@ -1,8 +1,8 @@
 from pytest import raises
 
 from caselawclient import client_helpers
-from caselawclient.models.documents import Document
 from caselawclient.models.judgments import Judgment
+from caselawclient.models.parser_logs import ParserLog
 from caselawclient.models.press_summaries import PressSummary
 
 
@@ -25,9 +25,9 @@ class TestGetDocumentTypeClass:
             == PressSummary
         )
 
-    def test_ingested_document_error(self):
-        """Check that parser logs with root tags of `<error>` are detected as plain `Document`s."""
-        client_helpers.get_document_type_class(b"<error/>") == Document
+    def test_ingested_document_parser_log(self):
+        """Check that parser logs with root tags of `<error>` are detected as `ParserLog`s."""
+        client_helpers.get_document_type_class(b"<error/>") == ParserLog
 
     def test_ingested_document_type_doc_without_press_summary_name(self):
         """ "Check that documents with a main tag of `<doc>` but no `name="pressSummary"` raise an exception."""

--- a/tests/models/test_parser_logs.py
+++ b/tests/models/test_parser_logs.py
@@ -1,0 +1,12 @@
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.parser_logs import ParserLog
+
+
+class TestParserLogValidation:
+    def test_parser_log_has_type_collection_name(self, mock_api_client):
+        mock_api_client.get_judgment_xml_bytestring.return_value = b"""
+        <error>something went wrong</error>
+        """
+
+        parser_log = ParserLog(DocumentURIString("test/1234"), mock_api_client)
+        parser_log.type_collection_name == "parser-log"


### PR DESCRIPTION
## Summary of changes

We get an error that `Document.collection_type_name` doesn't exist. Create a new type to handle the parser logs, so they can have a sensible value.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
