### PR TITLE
Return Document if an XML document has no relevant collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unpublished
+
+## Fix
+
+- Allow XML documents to be read as Documents even if they don't have a collection
+
 ## v34.1.0 (2025-03-13)
 
 ### Feat

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -77,12 +77,6 @@ class MultipartResponseLongerThanExpected(Exception):
     """
 
 
-class DocumentHasNoTypeCollection(Exception):
-    """
-    A MarkLogic document is not part of a collection which identifies its document type.
-    """
-
-
 def get_multipart_strings_from_marklogic_response(
     response: requests.Response,
 ) -> list[str]:
@@ -239,9 +233,7 @@ class MarklogicApiClient:
             return Judgment
         if DOCUMENT_COLLECTION_URI_PRESS_SUMMARY in collections:
             return PressSummary
-        raise DocumentHasNoTypeCollection(
-            f"The document at URI {uri} is not part of a valid document type collection.",
-        )
+        return Document
 
     def _get_error_code_class(self, error_code: str) -> Type[MarklogicAPIError]:
         """

--- a/tests/client/test_get_document_by_uri.py
+++ b/tests/client/test_get_document_by_uri.py
@@ -1,15 +1,12 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-import pytest
-
 from caselawclient.Client import (
     DOCUMENT_COLLECTION_URI_JUDGMENT,
     DOCUMENT_COLLECTION_URI_PRESS_SUMMARY,
-    DocumentHasNoTypeCollection,
     MarklogicApiClient,
 )
-from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 
@@ -80,5 +77,4 @@ class TestGetDocumentTypeFromUri(TestCase):
     ):
         mock_get_marklogic_response.return_value = []
 
-        with pytest.raises(DocumentHasNoTypeCollection):
-            self.client.get_document_type_from_uri(uri=DocumentURIString("test/1234"))
+        self.client.get_document_type_from_uri(uri=DocumentURIString("test/1234")) == Document


### PR DESCRIPTION
## Summary of changes

Documents in the database can have no relevant type (i.e. old parser logs.) We should not block getting the document if that's the case.