### PR TITLE
None not acceptable Access Key ID -- omit entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+- Allow AWS client to be initalised without an AccessKey.
+
 ## v34.1.1 (2025-03-13)
 
 ## Fix

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -47,10 +47,13 @@ def create_aws_client(service: Literal["sns"]) -> SNSClient: ...
 
 
 def create_aws_client(service: Literal["s3", "sns"]) -> Any:
-    aws = boto3.session.Session(
-        aws_access_key_id=env("AWS_ACCESS_KEY_ID", default=None),
-        aws_secret_access_key=env("AWS_SECRET_KEY", default=None),
-    )
+    if env("AWS_ACCESS_KEY_ID", None):
+        aws = boto3.session.Session(
+            aws_access_key_id=env("AWS_ACCESS_KEY_ID", default=None),
+            aws_secret_access_key=env("AWS_SECRET_KEY", default=None),
+        )
+    else:
+        aws = boto3.session.Session()
     return aws.client(
         service,
         endpoint_url=env("AWS_ENDPOINT_URL", default=None),


### PR DESCRIPTION
## Summary of changes


We were getting 

`ClientError An error occurred (InvalidAccessKeyId) when calling the ListObjects operation: The AWS Access Key Id you provided does not exist in our records.` [[rollbar](https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-ingester/136?utm_source=rollbar-notification&utm_medium=slack&utm_campaign=exp_repeat_item_message)]

This is probably caused by trying to pass None as the AccessKey when establishing the api_client. This should be entirely unnecessary.


<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
