### PR TITLE
bump: version 35.0.0 → 35.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v35.1.0 (2025-04-16)
 
 ### Feat
 
 - **identifiers**: swap priorities of FCLID and PressSummaryRelatedNCNIdentifier
+
+### Fix
+
+- **deps**: update dependency boto3 to v1.37.34
+- **deps**: update dependency lxml to v5.3.2
+- **deps**: update dependency boto3 to v1.37.31
+- **deps**: update dependency typing-extensions to v4.13.2
 
 ## v35.0.0 (2025-04-03)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "35.0.0"
+version = "35.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **identifiers**: swap priorities of FCLID and PressSummaryRelatedNCNIdentifier

### Fix

- **deps**: update dependency boto3 to v1.37.34
- **deps**: update dependency lxml to v5.3.2
- **deps**: update dependency boto3 to v1.37.31
- **deps**: update dependency typing-extensions to v4.13.2