### PR TITLE
[FCL-799] Reinstate PRIVATE_ASSET_BUCKET_REGION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v35.1.1 (2025-04-17)
+
+### Fix
+
+- Reinstate PRIVATE_ASSET_BUCKET_REGION environment variable to fix NoRegionError
+
 ## v35.1.0 (2025-04-16)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "35.1.0"
+version = "35.1.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -50,6 +50,7 @@ def create_aws_client(service: Literal["s3", "sns"]) -> Any:
     aws = boto3.session.Session()
     return aws.client(
         service,
+        region_name=env("PRIVATE_ASSET_BUCKET_REGION", default=None),
         config=botocore.client.Config(signature_version="s3v4"),
     )
 


### PR DESCRIPTION
## Summary of changes

Reinstate environment variable so AWS knows what region it's in
Also bumps version

https://national-archives.atlassian.net/browse/FCL-799

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
