### PR TITLE
Identifier's document_published is a boolean out of MarkLogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
+- An identifier's document_published is natively boolean from MarkLogic, treat it as such
 - `NeutralCitationNumber`s must now be valid in all conditions, including under test.
 
 ### Feat

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -173,7 +173,7 @@ class IdentifierResolutionFactory:
             "documents.compiled_url_slugs.identifier_uuid": resolution_uuid or "24b9a384-8bcf-4f20-996a-5c318f8dc657",
             "documents.compiled_url_slugs.document_uri": document_uri or "/ewca/civ/2003/547.xml",
             "documents.compiled_url_slugs.identifier_slug": identifier_slug or "ewca/civ/2003/54721",
-            "documents.compiled_url_slugs.document_published": "true" if published else "false",
+            "documents.compiled_url_slugs.document_published": published,
             "documents.compiled_url_slugs.identifier_namespace": namespace or "ukncn",
             "documents.compiled_url_slugs.identifier_value": value or "[2003] EWCA 54721 (Civ)",
         }

--- a/src/caselawclient/identifier_resolution.py
+++ b/src/caselawclient/identifier_resolution.py
@@ -45,7 +45,7 @@ class IdentifierResolution(NamedTuple):
             identifier_uuid=row["documents.compiled_url_slugs.identifier_uuid"],
             document_uri=MarkLogicDocumentURIString(row["documents.compiled_url_slugs.document_uri"]),
             identifier_slug=DocumentIdentifierSlug(row["documents.compiled_url_slugs.identifier_slug"]),
-            document_published=row["documents.compiled_url_slugs.document_published"] == "true",
+            document_published=row["documents.compiled_url_slugs.document_published"],
             identifier_value=DocumentIdentifierValue(row["documents.compiled_url_slugs.identifier_value"]),
             identifier_namespace=identifier_namespace,
             identifier_type=IDENTIFIER_NAMESPACE_MAP[identifier_namespace],

--- a/tests/client/test_identifier_resolution.py
+++ b/tests/client/test_identifier_resolution.py
@@ -6,7 +6,7 @@ raw_marklogic_resolutions = [
                                  {"documents.compiled_url_slugs.identifier_uuid":"id-24b9a384-8bcf-4f20-996a-5c318f8dc657",
                                   "documents.compiled_url_slugs.document_uri":"/ewca/civ/2003/547.xml",
                                   "documents.compiled_url_slugs.identifier_slug":"ewca/civ/2003/54721",
-                                  "documents.compiled_url_slugs.document_published":"false",
+                                  "documents.compiled_url_slugs.document_published": false,
                                   "documents.compiled_url_slugs.identifier_namespace":"ukncn",
                                   "documents.compiled_url_slugs.identifier_value":"[2003] EWCA 54721 (Civ)"
                                   }
@@ -15,7 +15,7 @@ raw_marklogic_resolutions = [
                                  {"documents.compiled_url_slugs.identifier_uuid":"id-04026b8d-3b34-4603-86cd-da145ce6ec26",
                                   "documents.compiled_url_slugs.document_uri":"/uksc/2025/123.xml",
                                   "documents.compiled_url_slugs.identifier_slug":"uksc/2025/123",
-                                  "documents.compiled_url_slugs.document_published":"true",
+                                  "documents.compiled_url_slugs.document_published": true,
                                   "documents.compiled_url_slugs.identifier_namespace":"ukncn",
                                   "documents.compiled_url_slugs.identifier_value":"[2025] UKSC 123"
                                   }

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -292,7 +292,7 @@ class TestLinkedDocumentResolutions:
         mock_api_client.resolve_from_identifier_value.return_value = resolutions
         doc = JudgmentFactory.build(neutral_citation="[2003] UKSC 1", uri=DocumentURIString("thisone"))
         doc.api_client = mock_api_client
-        resolutions = doc.linked_document_resolutions(["ukncn"])
+        resolutions = doc.linked_document_resolutions(["ukncn"], only_published=True)
         match_uuids = [x.identifier_uuid for x in resolutions]
         assert match_uuids == ["okay-pub", "okay-multi"]
 


### PR DESCRIPTION
## Summary of changes

The related documents panel on PUI was not showing up because document_published was always false, because MarkLogic emits a JSON `True` not string `"True"`

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
