### PR TITLE
[FCL-818] Make sure values are validated when Identifier objects are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Identifiers**: run identifier validation methods on init
+
+### Fix
+
+- **deps**: update dependency ds-caselaw-utils to v2.4.3
+- **deps**: update dependency ds-caselaw-utils to v2.4.2
+- **deps**: update dependency ds-caselaw-utils to v2.4.1
+- **deps**: update dependency boto3 to v1.37.35
+
 ## v35.1.1 (2025-04-17)
 
 ### Fix

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -85,7 +85,7 @@ class DocumentFactory:
         document.body = kwargs.pop("body") if "body" in kwargs else DocumentBodyFactory.build()
 
         if identifiers is None:
-            document.identifiers.add(FindCaseLawIdentifier(value="a1b2c3"))
+            document.identifiers.add(FindCaseLawIdentifier(value="tn4t35ts"))
         else:
             for identifier in identifiers:
                 document.identifiers.add(identifier)

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -6,6 +6,8 @@ from lxml import etree
 
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue
 
+from .exceptions import IdentifierValidationException, UUIDMismatchError
+
 IDENTIFIER_PACKABLE_ATTRIBUTES: list[str] = [
     "uuid",
     "value",
@@ -16,14 +18,6 @@ IDENTIFIER_UNPACKABLE_ATTRIBUTES: list[str] = [
     "uuid",
     "value",
 ]
-
-
-class InvalidIdentifierXMLRepresentationException(Exception):
-    pass
-
-
-class UUIDMismatchError(Exception):
-    pass
 
 
 class IdentifierSchema(ABC):
@@ -89,6 +83,11 @@ class Identifier(ABC):
         return self.value
 
     def __init__(self, value: str, uuid: Optional[str] = None) -> None:
+        if not self.schema.validate_identifier(value=value):
+            raise IdentifierValidationException(
+                f'Identifier value "{value}" is not valid according to the {self.schema.name} schema.'
+            )
+
         self.value = DocumentIdentifierValue(value)
         if uuid:
             self.uuid = uuid

--- a/src/caselawclient/models/identifiers/exceptions.py
+++ b/src/caselawclient/models/identifiers/exceptions.py
@@ -1,0 +1,10 @@
+class InvalidIdentifierXMLRepresentationException(Exception):
+    pass
+
+
+class UUIDMismatchError(Exception):
+    pass
+
+
+class IdentifierValidationException(Exception):
+    pass

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -3,7 +3,8 @@ from warnings import warn
 
 from lxml import etree
 
-from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier, Identifiers, InvalidIdentifierXMLRepresentationException
+from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier, Identifiers
+from .exceptions import InvalidIdentifierXMLRepresentationException
 from .fclid import FindCaseLawIdentifier
 from .neutral_citation import NeutralCitationNumber
 from .press_summary_ncn import PressSummaryRelatedNCNIdentifier

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -95,12 +95,12 @@ class TestDocumentPublish:
     ):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.is_publishable = True
-        document.identifiers.add(FindCaseLawIdentifier(value="abcd1234"))
+        document.identifiers.add(FindCaseLawIdentifier(value="tn4t35ts"))
         mock_api_client.get_next_document_sequence_number.return_value = 123
         document.publish()
 
         assert len(document.identifiers.of_type(FindCaseLawIdentifier)) == 1
-        assert [identifier.value for identifier in document.identifiers.of_type(FindCaseLawIdentifier)][0] == "abcd1234"
+        assert [identifier.value for identifier in document.identifiers.of_type(FindCaseLawIdentifier)][0] == "tn4t35ts"
 
 
 class TestDocumentUnpublish:

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -40,7 +40,7 @@ class TestDocument:
 
     def test_public_uri(self):
         document = DocumentFactory.build()
-        assert document.public_uri == "https://caselaw.nationalarchives.gov.uk/tna.a1b2c3"
+        assert document.public_uri == "https://caselaw.nationalarchives.gov.uk/tna.tn4t35ts"
 
     def test_document_exists_check(self, mock_api_client):
         mock_api_client.document_exists.return_value = False

--- a/tests/models/test_judgments.py
+++ b/tests/models/test_judgments.py
@@ -24,7 +24,7 @@ class TestJudgment:
 
         preferred_identifier = judgment.identifiers.preferred()
         assert preferred_identifier
-        assert preferred_identifier.value == "a1b2c3"
+        assert preferred_identifier.value == "tn4t35ts"
 
 
 class TestJudgmentValidation:

--- a/tests/models/test_press_summaries.py
+++ b/tests/models/test_press_summaries.py
@@ -24,7 +24,7 @@ class TestPressSummary:
 
         preferred_identifier = summary.identifiers.preferred()
         assert preferred_identifier
-        assert preferred_identifier.value == "a1b2c3"
+        assert preferred_identifier.value == "tn4t35ts"
 
 
 class TestPressSummaryValidation:


### PR DESCRIPTION
## Summary of changes

We aren't currently checking that identifier values are valid when we try to initialise the object. We should do so, so that we can't then save invalid identifier values to the database.

This PR adds running the `schema.validate_identifier()` method to the `__init__` method for `Identifier`s (with attendant test changes, now that test identifiers must also be valid).

## Jira

FCL-818

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
