### PR TITLE
bump: version 35.1.1 → 36.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v36.0.0 (2025-04-28)
 
 ### BREAKING CHANGE
 
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- **deps**: update dependency certifi to >=2025.4.26,<2025.5.0
+- **deps**: update dependency boto3 to v1.38.2
+- **deps**: update dependency boto3 to v1.37.38
 - **deps**: update dependency ds-caselaw-utils to v2.4.3
 - **deps**: update dependency ds-caselaw-utils to v2.4.2
 - **deps**: update dependency ds-caselaw-utils to v2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "35.1.1"
+version = "36.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- An identifier's document_published is natively boolean from MarkLogic, treat it as such
- `NeutralCitationNumber`s must now be valid in all conditions, including under test.

### Feat

- **NeutralCitationNumber**: validating an NCN now checks it can be converted to a URL
- **Identifiers**: run identifier validation methods on init