### PR TITLE
bump: version 36.0.0 → 36.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v36.0.1 (2025-04-30)
+
+### Feat
+
+- **SearchResultFactory**: now closer matches a real `SearchResult` so it's more useful downstream
+
 ## v36.0.0 (2025-04-28)
 
 ### BREAKING CHANGE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "36.0.0"
+version = "36.0.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **SearchResultFactory**: now closer matches a real `SearchResult` so it's more useful downstream