### PR TITLE
⚠️ Fix asset location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- content_as_html renamed to content_html to fix assets not rendering
+  - signature changed, now takes full prefix to folder containing assets
+  - location of assets now mandatory
+
 ## v36.0.2 (2025-05-01)
 
 ### Fix

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import warnings
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Optional
@@ -529,3 +530,7 @@ class Document:
             Document(resolution.document_uri.as_document_uri(), api_client=self.api_client)
             for resolution in resolutions
         ]
+
+    def content_as_html(self) -> str | None:
+        xlst_image_location = os.getenv("XSLT_IMAGE_LOCATION", "")
+        return self.body.content_html(f"{xlst_image_location}/{self.uri}")

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -137,8 +137,11 @@ class DocumentBody:
         return False
 
     @cache
-    def content_as_html(self, image_base_url: Optional[str] = None) -> Optional[str]:
+    def content_html(self, image_prefix: str) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""
+        """This used to be called content_as_html but we have changed the parameter passed to it from the
+        domain of the assets to the path in which the assets are stored (from assets to assets/d-a1b2c3)
+        and made the image_prefix mandatory"""
         if not self.has_content:
             return None
 
@@ -150,8 +153,8 @@ class DocumentBody:
 
             executable = xslt_processor.compile_stylesheet(stylesheet_file=html_xslt_location)
 
-            if image_base_url:
-                executable.set_parameter("image-base", proc.make_string_value(image_base_url))
+            if image_prefix:
+                executable.set_parameter("image-prefix", proc.make_string_value(image_prefix))
 
             return str(executable.transform_to_string(xdm_node=document))
 

--- a/src/caselawclient/models/documents/transforms/html.xsl
+++ b/src/caselawclient/models/documents/transforms/html.xsl
@@ -13,7 +13,7 @@
 <xsl:strip-space elements="*" />
 <xsl:preserve-space elements="p block num heading span a courtType date docDate docTitle docketNumber judge lawyer location neutralCitation party role time" />
 
-<xsl:param name="image-base" as="xs:string" select="'https://assets.caselaw.nationalarchives.gov.uk/'" />
+<xsl:param name="image-prefix" as="xs:string" />
 
 <xsl:function name="uk:link-is-supported" as="xs:boolean">
 	<xsl:param name="href" as="attribute()?" />
@@ -741,7 +741,7 @@
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">
-		<xsl:sequence select="concat($image-base, $doc-id, '/', .)" />
+		<xsl:sequence select="concat($image-prefix, '/', .)" />
 	</xsl:attribute>
 </xsl:template>
 

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -277,7 +277,7 @@ class TestDocumentBody:
         assert body.get_latest_manifestation_datetime() is None
         assert body.get_manifestation_datetimes("any") == []
 
-    def test_content_as_html_for_standard_judgment(self):
+    def test_content_html_for_standard_judgment(self):
         """Run our HTML XSLT on a judgment to make sure it's formatting as we expect."""
 
         with open(
@@ -292,7 +292,7 @@ class TestDocumentBody:
             prettified_target_html = BeautifulSoup(target_html, features="html.parser").prettify()
 
         body = DocumentBody(xml_document.encode())
-        transformed_html = body.content_as_html(image_base_url="https://test.caselaw.nationalarchives.gov.uk/")
+        transformed_html = body.content_html("https://test.caselaw.nationalarchives.gov.uk/d-a1b2c3")
         assert transformed_html
         prettified_transformed_html = BeautifulSoup(transformed_html, features="html.parser").prettify()
 

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -1,6 +1,7 @@
 import datetime
+import os
 import warnings
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -299,3 +300,13 @@ class TestLinkedDocumentResolutions:
         resolutions_unpub = doc.linked_document_resolutions(["ukncn"], only_published=False)
         unpub_uuids = [x.identifier_uuid for x in resolutions_unpub]
         assert unpub_uuids == ["okay-pub", "okay-multi", "maybe-unpub"]
+
+    @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
+    class TestDocumentContentAsHtml:
+        def test_document_content_as_html_calls_with_uri(self):
+            doc = DocumentFactory.build(
+                uri=DocumentURIString("test/1234"), body=DocumentBodyFactory.build(name="docname")
+            )
+            doc.body.content_html = Mock()
+            doc.content_as_html()
+            doc.body.content_html.assert_called_with("imagepath/test/1234")

--- a/tests/models/documents/xslt/test_standard_judgment.html
+++ b/tests/models/documents/xslt/test_standard_judgment.html
@@ -2,7 +2,7 @@
   <header class="judgment-header">
     <div class="judgment-header__logo">
       <img
-        src="https://test.caselaw.nationalarchives.gov.uk/uksc/2024/1234/image1.png"
+        src="https://test.caselaw.nationalarchives.gov.uk/d-a1b2c3/image1.png"
         style="width:99.05pt;height:99.05pt"
       />
     </div>


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-822

Breaking change -- we change the signature of content_as_html to take uri paths, not asset domains and make the prefix mandatory, and rename it to content_html to avoid broken functionality by causing more major errors where it hasn't been updated.

## Summary of changes

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
