### PR TITLE
Fix incorrect return type in SearchResultFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v37.0.2 (2025-05-13)
+
+### Fix
+
+- **SearchResultFactory**: fix type mismatch in factory default
+
 ## v37.0.1 (2025-05-13)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.0.1"
+version = "37.0.2"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -151,7 +151,7 @@ class SearchResultFactory(SimpleFactory):
         "name": "Judgment v Judgement",
         "neutral_citation": "[2025] UKSC 123",
         "court": "Court of Testing",
-        "date": datetime.datetime(2023, 2, 3).isoformat(),
+        "date": datetime.datetime(2023, 2, 3),
         "transformation_date": datetime.datetime(2023, 2, 3, 12, 34).isoformat(),
         "metadata": SearchResultMetadataFactory.build(),
         "is_failure": False,


### PR DESCRIPTION
## Summary of changes

We were returning a `str` when we should have been returning a `datetime`.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
