### PR TITLE
[FCL-49] Add supporting functions for issuing FCLIDs to all documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **MarklogicApiClient**: add new method for getting list of documents missing a FCLID
+
+### Fix
+
+- **deps**: update dependency ds-caselaw-utils to v2.4.4
+
+### Refactor
+
+- break FCLID minting into its own function at document level
+
 ## v37.0.2 (2025-05-13)
 
 ### Fix

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1198,6 +1198,24 @@ class MarklogicApiClient:
 
         return results
 
+    def get_missing_fclid(
+        self,
+        maximum_records: int = 50,
+    ) -> list[str]:
+        """Retrieve documents which do not have an FCLID."""
+        vars: query_dicts.GetMissingFclidDict = {
+            "maximum_records": maximum_records,
+        }
+
+        results: list[str] = get_multipart_strings_from_marklogic_response(
+            self._send_to_eval(
+                vars,
+                "get_missing_fclid.xqy",
+            )
+        )
+
+        return results
+
     def resolve_from_identifier_slug(
         self, identifier_slug: DocumentIdentifierSlug, published_only: bool = True
     ) -> IdentifierResolutions:

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1202,7 +1202,7 @@ class MarklogicApiClient:
         self,
         maximum_records: int = 50,
     ) -> list[str]:
-        """Retrieve documents which do not have an FCLID."""
+        """Retrieve the URIs of published documents which do not have an identifier in the `fclid` schema."""
         vars: query_dicts.GetMissingFclidDict = {
             "maximum_records": maximum_records,
         }

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -378,6 +378,13 @@ class Document:
         """
         return self.api_client.validate_document(self.uri)
 
+    def mint_fclid(self) -> None:
+        """Mint a new FCLID if needed, and save."""
+        if len(self.identifiers.of_type(FindCaseLawIdentifier)) < 1:
+            document_fclid = FindCaseLawIdentifierSchema.mint(self.api_client)
+            self.identifiers.add(document_fclid)
+            self.save_identifiers()
+
     def publish(self) -> None:
         """
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
@@ -387,10 +394,7 @@ class Document:
             raise CannotPublishUnpublishableDocument
 
         ## If it doesn't already have one, get a new FCLID for this document and assign
-        if len(self.identifiers.of_type(FindCaseLawIdentifier)) < 1:
-            document_fclid = FindCaseLawIdentifierSchema.mint(self.api_client)
-            self.identifiers.add(document_fclid)
-            self.save_identifiers()
+        self.mint_fclid()
 
         publish_documents(self.uri)
         self.api_client.set_published(self.uri, True)

--- a/src/caselawclient/xquery/get_missing_fclid.xqy
+++ b/src/caselawclient/xquery/get_missing_fclid.xqy
@@ -1,0 +1,25 @@
+xquery version "1.0-ml";
+
+declare variable $maximum_records as xs:int? external := 1000;
+
+for $doc in fn:subsequence(
+  cts:search(
+    fn:collection(),
+    cts:and-query(
+      (
+        cts:properties-fragment-query(
+          cts:element-value-query(xs:QName("published"), "true")
+        ),
+        cts:not-query(
+          cts:properties-fragment-query(
+            cts:element-value-query(xs:QName("namespace"), "fclid")
+          )
+        )
+      )
+    )
+  ),
+  1,
+  $maximum_records
+)
+
+return fn:base-uri($doc)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -86,6 +86,11 @@ class GetLastModifiedDict(MarkLogicAPIDict):
     uri: MarkLogicDocumentURIString
 
 
+# get_missing_fclid.xqy
+class GetMissingFclidDict(MarkLogicAPIDict):
+    maximum_records: Optional[int]
+
+
 # get_pending_enrichment_for_version.xqy
 class GetPendingEnrichmentForVersionDict(MarkLogicAPIDict):
     maximum_records: Optional[int]


### PR DESCRIPTION
## Summary of changes

To support being able to issue FCLIDs to all documents without them:

- Make safe FCLID minting its own function
- Add query to retrieve documents without an FCLID

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
