### PR TITLE
bump: version 37.0.2 → 37.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v37.1.0 (2025-05-15)
 
 ### Feat
 
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- **deps**: update dependency ds-caselaw-utils to v2.4.5
+- **deps**: update dependency boto3 to v1.38.14
 - **deps**: update dependency ds-caselaw-utils to v2.4.4
 
 ### Refactor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.0.2"
+version = "37.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **MarklogicApiClient**: add new method for getting list of documents missing a FCLID

### Fix

- **deps**: update dependency ds-caselaw-utils to v2.4.5
- **deps**: update dependency boto3 to v1.38.14
- **deps**: update dependency ds-caselaw-utils to v2.4.4

### Refactor

- break FCLID minting into its own function at document level