### PR TITLE
bump: version 37.1.0 → 37.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v37.2.0 (2025-05-20)
 
 ### Feat
 
 - **SearchResultFactory**: search result factory now includes identifier map
+
+### Fix
+
+- **deps**: update dependency boto3 to v1.38.17
+- **deps**: update dependency sqids to v0.5.2
+- **deps**: update dependency ds-caselaw-utils to v2.4.6
 
 ## v37.1.0 (2025-05-15)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.1.0"
+version = "37.2.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **SearchResultFactory**: search result factory now includes identifier map

### Fix

- **deps**: update dependency boto3 to v1.38.17
- **deps**: update dependency sqids to v0.5.2
- **deps**: update dependency ds-caselaw-utils to v2.4.6