### PR TITLE
Add only_with_html_representation field to SearchParameters dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v37.3.0 (2025-05-22)
+
+### Feat
+
+- Add `only_with_html_representation` field to `SearchParameters` dataclass
+
 ## v37.2.0 (2025-05-20)
 
 ### Feat

--- a/src/caselawclient/search_parameters.py
+++ b/src/caselawclient/search_parameters.py
@@ -23,6 +23,7 @@ class SearchParameters:
     page_size: int = RESULTS_PER_PAGE
     show_unpublished: bool = False
     only_unpublished: bool = False
+    only_with_html_representation: bool = False
     collections: Optional[List[str]] = None
 
     def as_marklogic_payload(self) -> Dict[str, Any]:
@@ -44,6 +45,7 @@ class SearchParameters:
             "to": str(self.date_to or ""),
             "show_unpublished": str(self.show_unpublished).lower(),
             "only_unpublished": str(self.only_unpublished).lower(),
+            "only_with_html_representation": str(self.only_with_html_representation).lower(),
             "collections": self._marklogic_collections,
             "quoted_phrases": self._quoted_phrases,
         }

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -44,6 +44,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "to": "",
                         "show_unpublished": "false",
                         "only_unpublished": "false",
+                        "only_with_html_representation": "false",
                         "collections": "",
                         "quoted_phrases": [],
                     },
@@ -76,6 +77,7 @@ class TestAdvancedSearch(unittest.TestCase):
                     page_size=10,
                     show_unpublished=False,
                     only_unpublished=False,
+                    only_with_html_representation=False,
                     collections=[" foo ", "abc def", " bar"],
                 ),
             )
@@ -97,6 +99,7 @@ class TestAdvancedSearch(unittest.TestCase):
                         "to": "2010-12-31",
                         "show_unpublished": "false",
                         "only_unpublished": "false",
+                        "only_with_html_representation": "false",
                         "collections": "foo,abcdef,bar",
                         "quoted_phrases": [],
                     },
@@ -162,6 +165,7 @@ class TestAdvancedSearch(unittest.TestCase):
                 "to": "",
                 "show_unpublished": "false",
                 "only_unpublished": "false",
+                "only_with_html_representation": "false",
                 "collections": "",
                 "quoted_phrases": [],
             }

--- a/tests/client/test_search_parameters.py
+++ b/tests/client/test_search_parameters.py
@@ -25,6 +25,7 @@ class TestSearchParametersToMarklogicData:
             "to": "",
             "show_unpublished": "false",
             "only_unpublished": "false",
+            "only_with_html_representation": "false",
             "collections": "",
             "quoted_phrases": [],
         }
@@ -49,6 +50,7 @@ class TestSearchParametersToMarklogicData:
             page_size=10,
             show_unpublished=False,
             only_unpublished=False,
+            only_with_html_representation=False,
             collections=[" foo ", "abc def", " bar"],
         )
         assert search_parameters.as_marklogic_payload() == {
@@ -65,6 +67,7 @@ class TestSearchParametersToMarklogicData:
             "to": "2022-01-31",
             "show_unpublished": "false",
             "only_unpublished": "false",
+            "only_with_html_representation": "false",
             "collections": "foo,abcdef,bar",
             "quoted_phrases": [],
         }


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-558

## Summary of changes

- Add only_with_html_representation field to SearchParameters dataclass so we can pass this argument when making searches from the PUI (specifically for filtering those without html reps from atom feed)

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
