### PR TITLE
Remove warning about viewing unpublished judgments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **MarklogicApiClient**: add new method for getting list of documents missing a FCLID
+- Remove warning about `verify unpublished judgments` being called.
 
 ### Fix
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1047,10 +1047,6 @@ class MarklogicApiClient:
         if show_unpublished and not self.user_can_view_unpublished_judgments(
             self.username,
         ):
-            # The user cannot view unpublished judgments but is requesting to see them
-            logging.warning(
-                f"User {self.username} is attempting to view unpublished judgments but does not have that privilege.",
-            )
             return False
         return show_unpublished
 

--- a/tests/client/test_advanced_search.py
+++ b/tests/client/test_advanced_search.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import unittest
 from unittest.mock import patch
 
@@ -212,7 +211,7 @@ class TestAdvancedSearch(unittest.TestCase):
         Scenario: User cannot view unpublished but show unpublished is true
         Given a client instance with a user who is not allowed to view unpublished judgments
         When the advanced_search method is called with the show_unpublished parameter set to True
-        Then it should call the MarkLogic module with the show_unpublished parameter set to False and log a warning
+        Then it should call the MarkLogic module with the show_unpublished parameter set to False
         """
         with (
             patch.object(self.client, "invoke") as patched_invoke,
@@ -221,7 +220,6 @@ class TestAdvancedSearch(unittest.TestCase):
                 "user_can_view_unpublished_judgments",
                 return_value=False,
             ),
-            patch.object(logging, "warning") as mock_logging,
         ):
             self.client.advanced_search(
                 SearchParameters(
@@ -236,7 +234,6 @@ class TestAdvancedSearch(unittest.TestCase):
             )
 
             assert '"show_unpublished": "false"' in patched_invoke.call_args.args[1]
-            mock_logging.assert_called()
 
     def test_no_page_0(self):
         """

--- a/tests/client/test_eval_xslt.py
+++ b/tests/client/test_eval_xslt.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import unittest
 from unittest.mock import patch
@@ -40,7 +39,7 @@ class TestEvalXslt(unittest.TestCase):
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_user_cannot_view_unpublished(self):
         """The user is not permitted to see unpublished judgments but is attempting to view them
-        Set `show_unpublished` to false and log a warning"""
+        Set `show_unpublished` to false"""
         with (
             patch.object(self.client, "eval") as mock_eval,
             patch.object(
@@ -48,7 +47,6 @@ class TestEvalXslt(unittest.TestCase):
                 "user_can_view_unpublished_judgments",
                 return_value=False,
             ),
-            patch.object(logging, "warning") as mock_logging,
         ):
             uri = DocumentURIString("judgment/uri")
             expected_vars: XsltTransformDict = {
@@ -65,7 +63,6 @@ class TestEvalXslt(unittest.TestCase):
             assert mock_eval.call_args.kwargs["vars"] == json.dumps(
                 expected_vars,
             )
-            mock_logging.assert_called()
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     def test_eval_xslt_with_filename(self):

--- a/tests/client/test_verify_show_unpublished.py
+++ b/tests/client/test_verify_show_unpublished.py
@@ -1,4 +1,3 @@
-import logging
 import unittest
 from unittest.mock import patch
 
@@ -13,18 +12,13 @@ class TestVerifyShowUnpublished(unittest.TestCase):
     # and with them asking for unpublished judgments or not
     def test_hide_published_if_unauthorised_and_user_asks_for_unpublished(self):
         # User cannot view unpublished but is asking to view unpublished judgments
-        with (
-            patch.object(
-                self.client,
-                "user_can_view_unpublished_judgments",
-                return_value=False,
-            ),
-            patch.object(logging, "warning") as mock_logger,
+        with patch.object(
+            self.client,
+            "user_can_view_unpublished_judgments",
+            return_value=False,
         ):
             result = self.client.verify_show_unpublished(True)
             assert result is False
-            # Check the logger was called
-            mock_logger.assert_called()
 
     def test_show_unpublished_if_authorised_and_asks_for_unpublished(self):
         # User can view unpublished and is asking to view unpublished judgments


### PR DESCRIPTION
## Summary of changes
`verify_show_unpublished` is typically being called to return a boolean which determines if unpublished documents should be shown: calls to it that fail do not imply a security issue, and this message is spammy and unhelpful.

> May 27 12:32:20 PM [35.176.221.42](https://my.na-01.cloud.solarwinds.com/226497157428851712/logs?q=host%3A%2235.176.221.42%22&focus=1863983586311602192&selected=1863983586311602192) [dxw-dalmatian-caselaw-prod-public-48b33d0444c4](https://my.na-01.cloud.solarwinds.com/226497157428851712/logs?q=program%3A%22dxw-dalmatian-caselaw-prod-public-48b33d0444c4%22&focus=1863983586311602192&selected=1863983586311602192) WARNING 2025-05-27 11:32:20,578 Client 1837 139660198599552 User caselaw-public-ui is attempting to view unpublished judgments but does not have that privilege.

<!-- Replace this with a short summary of changes in this PR -->