### PR TITLE
bump: version 37.3.0 → 37.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v37.3.1 (2025-05-28)
 
 ### Fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.3.0"
+version = "37.3.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Fix

- **extract_version**: update version decoding regex so it accepts new-style URIs
- **deps**: update dependency boto3 to v1.38.22

### Refactor

- remove unused namespace declarations from codebase
- **Document**: improve type hints for versions_as_documents