### PR TITLE
Update version of Poetry used in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
         with:
-          poetry-version: 1.4.2
+          poetry-version: 2.1.1
 
       - run: poetry install --with docs
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
         with:
-          poetry-version: 1.4.2
+          poetry-version: 2.1.1
       - name: Build with poetry
         run: poetry build
       - name: Publish distribution to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
         with:
-          poetry-version: 1.4.2
+          poetry-version: 2.1.1
 
       - name: Install libraries
         run: poetry install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - **Identifier**: add the ability to store and retrieve if an identifier is deprecated
 
+### Fix
+
+- **deps**: update dependency boto3 to v1.38.27
+- **deps**: update dependency mypy-boto3-s3 to v1.38.26
+- **deps**: update dependency boto3 to v1.38.24
+
 ## v37.3.1 (2025-05-28)
 
 ### Fix


### PR DESCRIPTION
## Summary of changes

Bump our version of Poetry used from 1.4.2 to 2.1.1.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
