### PR TITLE
[FCL-886] Add the ability to store and retrieve if an identifier is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Identifier**: add the ability to store and retrieve if an identifier is deprecated
+
 ## v37.3.1 (2025-05-28)
 
 ### Fix

--- a/tests/models/documents/test_document_identifiers.py
+++ b/tests/models/documents/test_document_identifiers.py
@@ -29,7 +29,7 @@ class TestDocumentIdentifiers:
         document = DocumentFactory.build(identifiers=[])
 
         identifier_1 = TestIdentifier(uuid="e28e3ef1-85ed-4997-87ee-e7428a6cc02e", value="TEST-123")
-        identifier_2 = TestIdentifier(uuid="14ce4b3b-03c8-44f9-a29e-e02ce35fe136", value="TEST-456")
+        identifier_2 = TestIdentifier(uuid="14ce4b3b-03c8-44f9-a29e-e02ce35fe136", value="TEST-456", deprecated=True)
         document.identifiers.add(identifier_1)
         document.identifiers.add(identifier_2)
 
@@ -39,12 +39,14 @@ class TestDocumentIdentifiers:
                     <namespace>test</namespace>
                     <uuid>e28e3ef1-85ed-4997-87ee-e7428a6cc02e</uuid>
                     <value>TEST-123</value>
+                    <deprecated>false</deprecated>
                     <url_slug>test-123</url_slug>
                 </identifier>
                 <identifier>
                     <namespace>test</namespace>
                     <uuid>14ce4b3b-03c8-44f9-a29e-e02ce35fe136</uuid>
                     <value>TEST-456</value>
+                    <deprecated>true</deprecated>
                     <url_slug>test-456</url_slug>
                 </identifier>
             </identifiers>

--- a/tests/models/identifiers/test_identifer_unpacking.py
+++ b/tests/models/identifiers/test_identifer_unpacking.py
@@ -37,6 +37,53 @@ class TestIdentifierUnpacking(unittest.TestCase):
         assert unpacked_identifier.value == "TEST-123"
 
     @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
+    def test_unpack_identifier_deprecated(self):
+        xml_tree = etree.fromstring("""
+            <identifier>
+                <namespace>test</namespace>
+                <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
+                <value>TEST-123</value>
+                <deprecated>true</deprecated>
+            </identifier>
+        """)
+
+        unpacked_identifier = unpack_an_identifier_from_etree(xml_tree)
+
+        assert type(unpacked_identifier) is TestIdentifier
+        assert unpacked_identifier.deprecated is True
+
+    @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
+    def test_unpack_identifier_undeprecated_without_value(self):
+        xml_tree = etree.fromstring("""
+            <identifier>
+                <namespace>test</namespace>
+                <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
+                <value>TEST-123</value>
+            </identifier>
+        """)
+
+        unpacked_identifier = unpack_an_identifier_from_etree(xml_tree)
+
+        assert type(unpacked_identifier) is TestIdentifier
+        assert unpacked_identifier.deprecated is False
+
+    @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
+    def test_unpack_identifier_undeprecated_with_value(self):
+        xml_tree = etree.fromstring("""
+            <identifier>
+                <namespace>test</namespace>
+                <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
+                <value>TEST-123</value>
+                <deprecated>false</deprecated>
+            </identifier>
+        """)
+
+        unpacked_identifier = unpack_an_identifier_from_etree(xml_tree)
+
+        assert type(unpacked_identifier) is TestIdentifier
+        assert unpacked_identifier.deprecated is False
+
+    @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
     def test_unpack_unknown_identifier(self):
         xml_tree = etree.fromstring("""
             <identifier>
@@ -81,7 +128,7 @@ class TestIdentifierUnpacking(unittest.TestCase):
 class TestIdentifierPackUnpackRoundTrip:
     @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
     def test_roundtrip_identifier(self):
-        """Check that if we convert an Identifier to XML and back again we get the same thing out at the far end."""
+        """Check that if we convert a single Identifier to XML and back again we get the same thing out at the far end."""
 
         original_identifier = TestIdentifier(value="TEST-123")
 
@@ -95,16 +142,24 @@ class TestIdentifierPackUnpackRoundTrip:
 
     @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
     def test_roundtrip_identifiers(self):
-        """Check that if we convert an Identifier to XML and back again we get the same thing out at the far end."""
-        uuid = "id-1"
+        """Check that if we convert multiple identifiers to XML and back again we get the same things out at the far end."""
         original_identifiers = Identifiers()
-        original_identifiers.add(TestIdentifier(uuid=uuid, value="TEST-123"))
+        original_identifiers.add(TestIdentifier(uuid="id-a1", value="TEST-123"))
+        original_identifiers.add(TestIdentifier(uuid="id-b2", value="TEST-456", deprecated=True))
 
         xml_tree = original_identifiers.as_etree
 
         unpacked_identifiers = unpack_all_identifiers_from_etree(xml_tree)
-        unpacked_identifier = unpacked_identifiers[uuid]
 
-        assert type(unpacked_identifier) is TestIdentifier
-        assert unpacked_identifier.uuid == uuid
-        assert unpacked_identifier.value == "TEST-123"
+        unpacked_identifier_1 = unpacked_identifiers["id-a1"]
+        unpacked_identifier_2 = unpacked_identifiers["id-b2"]
+
+        assert type(unpacked_identifier_1) is TestIdentifier
+        assert unpacked_identifier_1.uuid == "id-a1"
+        assert unpacked_identifier_1.value == "TEST-123"
+        assert unpacked_identifier_1.deprecated is False
+
+        assert type(unpacked_identifier_1) is TestIdentifier
+        assert unpacked_identifier_2.uuid == "id-b2"
+        assert unpacked_identifier_2.value == "TEST-456"
+        assert unpacked_identifier_2.deprecated is True

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -75,6 +75,7 @@ class TestIdentifierBase:
                 <namespace>test</namespace>
                 <uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>
                 <value>TEST-123</value>
+                <deprecated>false</deprecated>
                 <url_slug>test-123</url_slug>
             </identifier>
         """


### PR DESCRIPTION
This allows us to record the fact that an identifier - although previously used to refer to a document - should no longer be promoted.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
