### PR TITLE
FCL-890 | add case number and category from xml to document body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **Identifier**: add the ability to store and retrieve if an identifier is deprecated
+- **Document**: add case number and category to the document body if available in the xml
 
 ### Fix
 

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -51,6 +51,14 @@ class DocumentBody:
     def jurisdiction(self) -> str:
         return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdiction/text()")
 
+    @cached_property
+    def category(self) -> Optional[str]:
+        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category/text()")
+
+    @cached_property
+    def case_number(self) -> Optional[str]:
+        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()")
+
     @property
     def court_and_jurisdiction_identifier_string(self) -> CourtCode:
         if self.jurisdiction != "":

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -112,6 +112,56 @@ class TestDocumentBody:
             ('doc name="pressSummary"', "doc"),
         ],
     )
+    def test_category(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:category>Breach of code of standards</uk:category>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.category == "Breach of code of standards"
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
+    def test_case_number(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:caseNumber>2010/1/dis</uk:caseNumber>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.case_number == "2010/1/dis"
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
     def test_court_and_jurisdiction_with_jurisdiction(
         self,
         opening_tag,


### PR DESCRIPTION
## Summary of changes

Adds the case number and category to the document body from the xml if available.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
