### PR TITLE
bump: version 37.3.1 → 37.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v37.4.0 (2025-06-04)
 
 ### Feat
 
 - **Identifier**: add the ability to store and retrieve if an identifier is deprecated
-- **Document**: add case number and category to the document body if available in the xml
 
 ### Fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.3.1"
+version = "37.4.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **Identifier**: add the ability to store and retrieve if an identifier is deprecated

### Fix

- **deps**: update dependency boto3 to v1.38.27
- **deps**: update dependency mypy-boto3-s3 to v1.38.26
- **deps**: update dependency boto3 to v1.38.24
