### PR TITLE
[FCL-889] Don't enrich if no content

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -34,7 +34,7 @@ from caselawclient.models.utilities.aws import (
 from caselawclient.types import DocumentURIString
 
 from .body import DocumentBody
-from .exceptions import CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
+from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
 
 MINIMUM_ENRICHMENT_TIME = datetime.timedelta(minutes=20)
@@ -341,22 +341,34 @@ class Document:
             now.isoformat(),
         )
 
+        if not self.can_enrich:
+            msg = f"{self.uri} has no docx"
+            raise CannotEnrichUnenrichableDocument(msg)
+
         announce_document_event(
             uri=self.uri,
             status="enrich",
             enrich=True,
         )
 
-    def enrich(self) -> bool:
+    def enrich(self, even_if_recent: bool = False, accept_failures: bool = False) -> bool:
         """
         Request enrichment of a document, if it's sensible to do so.
         """
-        if self.enriched_recently is False:
-            print("Enrichment requested")
+        if not (even_if_recent) and self.enriched_recently:
+            print("Enrichment not requested as document was enriched recently")
+            return False
+
+        print("Enrichment requested")
+
+        try:
             self.force_enrich()
-            return True
-        print("Enrichment not requested as document was enriched recently")
-        return False
+        except CannotEnrichUnenrichableDocument as e:
+            if not accept_failures:
+                raise e
+            return False
+
+        return True
 
     @cached_property
     def enriched_recently(self) -> bool:
@@ -499,6 +511,13 @@ class Document:
     def can_reparse(self) -> bool:
         """
         Is it sensible to reparse this document?
+        """
+        return self.docx_exists()
+
+    @cached_property
+    def can_enrich(self) -> bool:
+        """
+        Is it possible to enrich this document?
         """
         return self.docx_exists()
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -342,7 +342,7 @@ class Document:
         )
 
         if not self.can_enrich:
-            msg = f"{self.uri} has no docx"
+            msg = f"{self.uri} cannot be enriched"
             raise CannotEnrichUnenrichableDocument(msg)
 
         announce_document_event(
@@ -519,7 +519,7 @@ class Document:
         """
         Is it possible to enrich this document?
         """
-        return self.docx_exists()
+        return self.body.has_content
 
     def save_identifiers(self) -> None:
         """Validate the identifiers, and if the validation passes save them to MarkLogic"""

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -2,5 +2,9 @@ class CannotPublishUnpublishableDocument(Exception):
     """A document which has failed publication safety checks in `Document.is_publishable` cannot be published."""
 
 
+class CannotEnrichUnenrichableDocument(Exception):
+    """We tried to enrich a document without a docx"""
+
+
 class DocumentNotSafeForDeletion(Exception):
     """A document which is not safe for deletion cannot be deleted."""

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -3,7 +3,7 @@ class CannotPublishUnpublishableDocument(Exception):
 
 
 class CannotEnrichUnenrichableDocument(Exception):
-    """We tried to enrich a document without a docx"""
+    """A document which cannot be enriched (see `Document.can_enrich`) tried to be sent to enrichment"""
 
 
 class DocumentNotSafeForDeletion(Exception):

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -154,7 +154,8 @@ class TestDocumentUnpublish:
 class TestDocumentEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
-    def test_force_enrich(self, mock_announce_document_event, mock_api_client):
+    @patch("caselawclient.models.documents.Document.can_enrich", return_value=True)
+    def test_force_enrich(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.force_enrich()
 

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -1,13 +1,14 @@
 import datetime
 import json
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 import time_machine
 
 from caselawclient.factories import JudgmentFactory
 from caselawclient.models.documents import (
+    CannotEnrichUnenrichableDocument,
     CannotPublishUnpublishableDocument,
     Document,
     DocumentNotSafeForDeletion,
@@ -151,10 +152,10 @@ class TestDocumentUnpublish:
         )
 
 
-class TestDocumentEnrich:
+class TestDocumentForceEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
-    @patch("caselawclient.models.documents.Document.can_enrich", return_value=True)
+    @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=True)
     def test_force_enrich(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.force_enrich()
@@ -171,6 +172,60 @@ class TestDocumentEnrich:
             enrich=True,
         )
 
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @patch("caselawclient.models.documents.announce_document_event")
+    @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
+    def test_force_enrich_but_no_docx(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.can_enrich = False
+        with pytest.raises(CannotEnrichUnenrichableDocument):
+            document.force_enrich()
+
+        mock_api_client.set_property.assert_called_once_with(
+            "test/1234",
+            "last_sent_to_enrichment",
+            "1955-11-05T06:00:00+00:00",
+        )
+
+        mock_announce_document_event.assert_not_called()
+
+
+class TestDocumentEnrich:
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @patch("caselawclient.models.documents.announce_document_event")
+    @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
+    def test_enrich_with_no_docx(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.can_enrich = False
+        with pytest.raises(CannotEnrichUnenrichableDocument):
+            document.enrich()
+
+        mock_api_client.set_property.assert_called_once_with(
+            "test/1234",
+            "last_sent_to_enrichment",
+            "1955-11-05T06:00:00+00:00",
+        )
+
+        mock_announce_document_event.assert_not_called()
+
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @patch("caselawclient.models.documents.announce_document_event")
+    @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
+    def test_enrich_with_no_docx_and_exception_ignored(
+        self, mock_can_enrich, mock_announce_document_event, mock_api_client
+    ):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.can_enrich = False
+        document.enrich(accept_failures=True)
+
+        mock_api_client.set_property.assert_called_once_with(
+            "test/1234",
+            "last_sent_to_enrichment",
+            "1955-11-05T06:00:00+00:00",
+        )
+
+        mock_announce_document_event.assert_not_called()
+
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.force_enrich")
     def test_enrich_not_recently_enriched(self, mock_force_enrich, mock_announce_document_event, mock_api_client):
@@ -181,7 +236,6 @@ class TestDocumentEnrich:
 
         assert result is True
         mock_force_enrich.assert_called_once()
-        mock_announce_document_event.assert_not_called()
 
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.force_enrich")
@@ -193,7 +247,19 @@ class TestDocumentEnrich:
 
         assert result is False
         mock_force_enrich.assert_not_called()
-        mock_announce_document_event.assert_not_called()
+
+    @patch("caselawclient.models.documents.announce_document_event")
+    @patch("caselawclient.models.documents.Document.force_enrich")
+    def test_enrich_recently_enriched_but_ignore_it(
+        self, mock_force_enrich, mock_announce_document_event, mock_api_client
+    ):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.enriched_recently = True
+
+        result = document.enrich(even_if_recent=True)
+
+        assert result is True
+        mock_force_enrich.assert_called_once()
 
 
 class TestDocumentHold:

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -175,7 +175,7 @@ class TestDocumentForceEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
-    def test_force_enrich_but_no_docx(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
+    def test_force_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.can_enrich = False
         with pytest.raises(CannotEnrichUnenrichableDocument):
@@ -194,7 +194,7 @@ class TestDocumentEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
-    def test_enrich_with_no_docx(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
+    def test_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.can_enrich = False
         with pytest.raises(CannotEnrichUnenrichableDocument):
@@ -211,7 +211,7 @@ class TestDocumentEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
-    def test_enrich_with_no_docx_and_exception_ignored(
+    def test_enrich_of_unenrichable_but_exception_ignored(
         self, mock_can_enrich, mock_announce_document_event, mock_api_client
     ):
         document = Document(DocumentURIString("test/1234"), mock_api_client)


### PR DESCRIPTION
## Summary of changes

If a document doesn't have a docx, it should not be enriched; when enrichment is attempted, fail gracefully but record that an attempt was made to ensure it doesn't block other enrichment.

Difficult to manually test locally -- worth additional scrutiny in staging?

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-889

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
