### PR TITLE
[FCL-880] Support direct manipulation of identifiers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- IdentifiersCollection.validate_uuids_match_keys() now returns SuccessFailureMessageTuple instead of None
+
+### Feat
+
+- **IdentifiersCollection**: add method to return all possible new identifier types for collection
+- **IdentifiersCollection**: add validation for only one non-deprecated identifier of type
+- **IdentifiersCollection**: validating UUID integrity now returns success/failure and message rather than exception
+- **Document**: break identifier validation into own method
+- **Identifier**: deprecated identifiers score 0 during ranking
+
+### Refactor
+
+- **IdentifiersCollection**: break up validation functions to improve readability
+- **IdentifiersCollection**: refactor how we run collection-level validations to support message bubbling
+
 ## v38.0.0 (2025-07-07)
 
 ### BREAKING CHANGE

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -31,7 +31,7 @@ from caselawclient.models.utilities.aws import (
     request_parse,
     unpublish_documents,
 )
-from caselawclient.types import DocumentURIString
+from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple
 
 from .body import DocumentBody
 from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
@@ -521,9 +521,12 @@ class Document:
         """
         return self.body.has_content
 
+    def validate_identifiers(self) -> SuccessFailureMessageTuple:
+        return self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)
+
     def save_identifiers(self) -> None:
         """Validate the identifiers, and if the validation passes save them to MarkLogic"""
-        validations = self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)
+        validations = self.validate_identifiers()
         if validations.success is True:
             self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers.as_etree)
         else:

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -149,6 +149,9 @@ class Identifier(ABC):
     @property
     def score(self) -> float:
         """Return the score of this identifier, used to calculate the preferred identifier for a document."""
+        if self.deprecated:
+            return 0
+
         return 1 * self.schema.base_score_multiplier
 
     def same_as(self, other: "Identifier") -> bool:

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -5,7 +5,6 @@ from lxml import etree
 from caselawclient.types import SuccessFailureMessageTuple
 
 from . import Identifier
-from .exceptions import UUIDMismatchError
 from .fclid import FindCaseLawIdentifier
 from .neutral_citation import NeutralCitationNumber
 from .press_summary_ncn import PressSummaryRelatedNCNIdentifier
@@ -22,11 +21,14 @@ SUPPORTED_IDENTIFIER_TYPES: list[type["Identifier"]] = [
 
 
 class IdentifiersCollection(dict[str, Identifier]):
-    def validate_uuids_match_keys(self) -> None:
+    def validate_uuids_match_keys(self) -> SuccessFailureMessageTuple:
         for uuid, identifier in self.items():
             if uuid != identifier.uuid:
-                msg = "Key of {identifier} in Identifiers is {uuid} not {identifier.uuid}"
-                raise UUIDMismatchError(msg)
+                return SuccessFailureMessageTuple(
+                    False, [f"Key of {identifier} in Identifiers is {uuid} not {identifier.uuid}"]
+                )
+
+        return SuccessFailureMessageTuple(True, [])
 
     def perform_all_validations(
         self, document_type: type["Document"], api_client: "MarklogicApiClient"

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -30,17 +30,19 @@ class IdentifiersCollection(dict[str, Identifier]):
 
         return SuccessFailureMessageTuple(True, [])
 
+    def _list_all_identifiers_by_schema(self) -> dict[type[IdentifierSchema], list[Identifier]]:
+        """Get a list of all identifiers, grouped by their schema."""
+        identifiers_by_schema: dict[type[IdentifierSchema], list[Identifier]] = {}
+
+        for identifier in self.values():
+            identifiers_by_schema.setdefault(identifier.schema, []).append(identifier)
+
+        return identifiers_by_schema
+
     def check_only_single_non_deprecated_identifier_where_multiples_not_allowed(self) -> SuccessFailureMessageTuple:
         """Check that only one non-deprecated identifier exists per schema where that schema does not allow multiples."""
 
-        schema_to_identifiers: dict[type[IdentifierSchema], list[Identifier]] = {}
-
-        for identifier in self.values():
-            schema = getattr(identifier, "schema", None)
-            if schema is not None:
-                schema_to_identifiers.setdefault(schema, []).append(identifier)
-
-        for schema, identifiers in schema_to_identifiers.items():
+        for schema, identifiers in self._list_all_identifiers_by_schema().items():
             non_deprecated_identifiers = [i for i in identifiers if not i.deprecated]
             if len(non_deprecated_identifiers) > 1:
                 return SuccessFailureMessageTuple(

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -33,10 +33,18 @@ class IdentifiersCollection(dict[str, Identifier]):
     def perform_all_validations(
         self, document_type: type["Document"], api_client: "MarklogicApiClient"
     ) -> SuccessFailureMessageTuple:
-        self.validate_uuids_match_keys()
-
         success = True
         messages: list[str] = []
+
+        # Run collection-level validations
+        collection_validations_to_run: list[SuccessFailureMessageTuple] = [
+            self.validate_uuids_match_keys(),
+        ]
+
+        for validation in collection_validations_to_run:
+            if not validation.success:
+                success = False
+                messages += validation.messages
 
         for _, identifier in self.items():
             validations = identifier.perform_all_validations(document_type=document_type, api_client=api_client)

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -86,6 +86,15 @@ class IdentifiersCollection(dict[str, Identifier]):
         if not self.contains(identifier):
             self[identifier.uuid] = identifier
 
+    def valid_new_identifier_types(self, document_type: type["Document"]) -> list[type[Identifier]]:
+        """Return a list of identifier types which can be added to a document of the given type, given identifiers already in this collection."""
+        return [
+            t
+            for t in SUPPORTED_IDENTIFIER_TYPES
+            if t.schema.allow_editing
+            and (not t.schema.document_types or document_type.__name__ in t.schema.document_types)
+        ]
+
     def __delitem__(self, key: Union[Identifier, str]) -> None:
         if isinstance(key, Identifier):
             super().__delitem__(key.uuid)

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -46,7 +46,7 @@ class IdentifiersCollection(dict[str, Identifier]):
         return SuccessFailureMessageTuple(success, messages)
 
     def contains(self, other_identifier: Identifier) -> bool:
-        "Do the identifier's value and namespace already exist in this group?"
+        """Does the identifier's value and namespace already exist in this group?"""
         return any(other_identifier.same_as(identifier) for identifier in self.values())
 
     def add(self, identifier: Identifier) -> None:

--- a/src/caselawclient/models/identifiers/exceptions.py
+++ b/src/caselawclient/models/identifiers/exceptions.py
@@ -2,9 +2,5 @@ class InvalidIdentifierXMLRepresentationException(Exception):
     pass
 
 
-class UUIDMismatchError(Exception):
-    pass
-
-
 class IdentifierValidationException(Exception):
     pass

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -157,6 +157,10 @@ class TestIdentifierScoring:
         identifier = TestIdentifier(value="TEST-123")
         assert identifier.score == 2.5
 
+    def test_deprecated_identifier_scoring(self):
+        identifier = TestIdentifier(value="TEST-123", deprecated=True)
+        assert identifier.score == 0
+
     def test_sorting(self, mixed_identifiers: IdentifiersCollection):
         assert mixed_identifiers.by_score() == [TEST_IDENTIFIER_999, TEST_NCN_1701, TEST_NCN_1234]
 

--- a/tests/models/identifiers/test_identifiers.py
+++ b/tests/models/identifiers/test_identifiers.py
@@ -6,7 +6,7 @@ from lxml import etree
 from caselawclient.models.documents import Document
 from caselawclient.models.identifiers import Identifier, IdentifierSchema
 from caselawclient.models.identifiers.collection import IdentifiersCollection
-from caselawclient.models.identifiers.exceptions import IdentifierValidationException, UUIDMismatchError
+from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.types import DocumentIdentifierSlug
 
@@ -177,13 +177,14 @@ class TestIdentifierScoring:
 class TestIdentifierValidation:
     def test_validate_uuids_match_keys(self):
         identifiers = IdentifiersCollection({"id-1": TestIdentifier(uuid="id-2", value="TEST-123")})
-        with pytest.raises(UUIDMismatchError):
-            identifiers.validate_uuids_match_keys()
+        validate_uuids_match_keys = identifiers.validate_uuids_match_keys()
+        assert validate_uuids_match_keys.success is False
+        assert validate_uuids_match_keys.messages == ["Key of TEST-123 in Identifiers is id-1 not id-2"]
 
     def test_perform_all_validations_runs_expected_validations(self, mock_api_client):
         """Check that when we try to validate an entire set of Identifiers we do what is expected"""
         identifier_1 = TestIdentifier(uuid="id-1", value="TEST-123")
-        identifier_2 = TestIdentifier(uuid="id-2", value="TEST-456")
+        identifier_2 = TestIdentifier(uuid="id-2", value="TEST-456", deprecated=True)
         identifiers = IdentifiersCollection(
             {
                 "id-1": identifier_1,


### PR DESCRIPTION
## Summary of changes

Changes to the API client to support the EUI being able to directly manipulate the list of identifiers.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)

## Jira

- FCL-880
- FCL-994