### PR TITLE
[FCL-1007] Refactor identifier collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
+- `identifiers.Identifiers` is now `identifiers.collection.IdentifierCollection`
 - `Identifiers.validate()` is now `Identifiers.validate_uuids_match_keys()`
 - `IdentifierSchema.validate_identifier` has been renamed `IdentifierSchema.validate_identifier_value`
 
 ### Feat
 
+- **identifiers**: canonical list of supported identifiers now lives in identifiers.collection
 - **Document**: saving identifiers now correctly raises exception when validation fails
 - move to using structured objects to represent validation failures rather than exceptions
 - **Identifiers**: validating identifiers now performs a full check of all individual identifiers
@@ -23,6 +25,9 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- **deps**: update dependency boto3 to v1.38.42
+- **deps**: update boto packages to v1.38.39
+- **deps**: update dependency boto3 to v1.38.37
 - **deps**: update dependency certifi to >=2025.6.15,<2025.7.0
 - **deps**: update dependency boto3 to v1.38.36
 - **deps**: update dependency boto3 to v1.38.33
@@ -34,6 +39,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Refactor
 
+- **Identifiers**: rename Identifiers to IdentifierCollection and move to submodule
 - refine how identifiers validity checks are performed
 
 ## v37.4.0 (2025-06-04)

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -7,7 +7,8 @@ from caselawclient.Client import MarklogicApiClient
 from caselawclient.identifier_resolution import IdentifierResolution, IdentifierResolutions
 from caselawclient.models.documents import Document
 from caselawclient.models.documents.body import DocumentBody
-from caselawclient.models.identifiers import Identifier, Identifiers
+from caselawclient.models.identifiers import Identifier
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.models.judgments import Judgment
@@ -188,7 +189,7 @@ class SearchResultFactory(SimpleFactory[SearchResult]):
         "matches": None,
         "slug": "uksc/2025/1",
         "content_hash": "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
-        "identifiers": Identifiers(
+        "identifiers": IdentifiersCollection(
             {
                 "id-1": NeutralCitationNumber("[2025] UKSC 123", "id-1"),
                 "id-2": FindCaseLawIdentifier("bcdfghjk", "id-2"),

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -1,15 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
 from lxml import etree
 
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue, SuccessFailureMessageTuple
 
-from .exceptions import (
-    IdentifierValidationException,
-    UUIDMismatchError,
-)
+from .exceptions import IdentifierValidationException
 
 if TYPE_CHECKING:
     from caselawclient.Client import MarklogicApiClient
@@ -209,84 +206,3 @@ class Identifier(ABC):
             messages += validation.messages
 
         return SuccessFailureMessageTuple(success, messages)
-
-
-class Identifiers(dict[str, Identifier]):
-    def validate_uuids_match_keys(self) -> None:
-        for uuid, identifier in self.items():
-            if uuid != identifier.uuid:
-                msg = "Key of {identifier} in Identifiers is {uuid} not {identifier.uuid}"
-                raise UUIDMismatchError(msg)
-
-    def perform_all_validations(
-        self, document_type: type["Document"], api_client: "MarklogicApiClient"
-    ) -> SuccessFailureMessageTuple:
-        self.validate_uuids_match_keys()
-
-        success = True
-        messages: list[str] = []
-
-        for _, identifier in self.items():
-            validations = identifier.perform_all_validations(document_type=document_type, api_client=api_client)
-            if validations.success is False:
-                success = False
-
-            messages += validations.messages
-
-        return SuccessFailureMessageTuple(success, messages)
-
-    def contains(self, other_identifier: Identifier) -> bool:
-        "Do the identifier's value and namespace already exist in this group?"
-        return any(other_identifier.same_as(identifier) for identifier in self.values())
-
-    def add(self, identifier: Identifier) -> None:
-        if not self.contains(identifier):
-            self[identifier.uuid] = identifier
-
-    def __delitem__(self, key: Union[Identifier, str]) -> None:
-        if isinstance(key, Identifier):
-            super().__delitem__(key.uuid)
-        else:
-            super().__delitem__(key)
-
-    def of_type(self, identifier_type: type[Identifier]) -> list[Identifier]:
-        """Return a list of all identifiers of a given type."""
-        uuids = self.keys()
-        return [self[uuid] for uuid in list(uuids) if isinstance(self[uuid], identifier_type)]
-
-    def delete_type(self, deleted_identifier_type: type[Identifier]) -> None:
-        "For when we want an identifier to be the only valid identifier of that type, delete the others first"
-        uuids = self.keys()
-        for uuid in list(uuids):
-            # we could use compare to .schema instead, which would have diffferent behaviour for subclasses
-            if isinstance(self[uuid], deleted_identifier_type):
-                del self[uuid]
-
-    @property
-    def as_etree(self) -> etree._Element:
-        """Return an etree representation of all the Document's identifiers."""
-        identifiers_root = etree.Element("identifiers")
-
-        for identifier in self.values():
-            identifiers_root.append(identifier.as_xml_tree)
-
-        return identifiers_root
-
-    def by_score(self, type: Optional[type[Identifier]] = None) -> list[Identifier]:
-        """
-        :param type: Optionally, an identifier type to constrain this list to.
-
-        :return: Return a list of identifiers, sorted by their score in descending order.
-        """
-        identifiers = self.of_type(type) if type else list(self.values())
-        return sorted(identifiers, key=lambda v: v.score, reverse=True)
-
-    def preferred(self, type: Optional[type[Identifier]] = None) -> Optional[Identifier]:
-        """
-        :param type: Optionally, an identifier type to constrain the results to.
-
-        :return: Return the highest scoring identifier of the given type (or of any type, if none is specified). Returns `None` if no identifier is available.
-        """
-        if len(self.by_score(type)) == 0:
-            return None
-        return self.by_score(type)[0]

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -1,0 +1,93 @@
+from typing import TYPE_CHECKING, Optional, Union
+
+from lxml import etree
+
+from caselawclient.types import SuccessFailureMessageTuple
+
+from . import Identifier
+from .exceptions import UUIDMismatchError
+
+if TYPE_CHECKING:
+    from caselawclient.Client import MarklogicApiClient
+    from caselawclient.models.documents import Document
+
+
+class IdentifiersCollection(dict[str, Identifier]):
+    def validate_uuids_match_keys(self) -> None:
+        for uuid, identifier in self.items():
+            if uuid != identifier.uuid:
+                msg = "Key of {identifier} in Identifiers is {uuid} not {identifier.uuid}"
+                raise UUIDMismatchError(msg)
+
+    def perform_all_validations(
+        self, document_type: type["Document"], api_client: "MarklogicApiClient"
+    ) -> SuccessFailureMessageTuple:
+        self.validate_uuids_match_keys()
+
+        success = True
+        messages: list[str] = []
+
+        for _, identifier in self.items():
+            validations = identifier.perform_all_validations(document_type=document_type, api_client=api_client)
+            if validations.success is False:
+                success = False
+
+            messages += validations.messages
+
+        return SuccessFailureMessageTuple(success, messages)
+
+    def contains(self, other_identifier: Identifier) -> bool:
+        "Do the identifier's value and namespace already exist in this group?"
+        return any(other_identifier.same_as(identifier) for identifier in self.values())
+
+    def add(self, identifier: Identifier) -> None:
+        if not self.contains(identifier):
+            self[identifier.uuid] = identifier
+
+    def __delitem__(self, key: Union[Identifier, str]) -> None:
+        if isinstance(key, Identifier):
+            super().__delitem__(key.uuid)
+        else:
+            super().__delitem__(key)
+
+    def of_type(self, identifier_type: type[Identifier]) -> list[Identifier]:
+        """Return a list of all identifiers of a given type."""
+        uuids = self.keys()
+        return [self[uuid] for uuid in list(uuids) if isinstance(self[uuid], identifier_type)]
+
+    def delete_type(self, deleted_identifier_type: type[Identifier]) -> None:
+        "For when we want an identifier to be the only valid identifier of that type, delete the others first"
+        uuids = self.keys()
+        for uuid in list(uuids):
+            # we could use compare to .schema instead, which would have diffferent behaviour for subclasses
+            if isinstance(self[uuid], deleted_identifier_type):
+                del self[uuid]
+
+    @property
+    def as_etree(self) -> etree._Element:
+        """Return an etree representation of all the Document's identifiers."""
+        identifiers_root = etree.Element("identifiers")
+
+        for identifier in self.values():
+            identifiers_root.append(identifier.as_xml_tree)
+
+        return identifiers_root
+
+    def by_score(self, type: Optional[type[Identifier]] = None) -> list[Identifier]:
+        """
+        :param type: Optionally, an identifier type to constrain this list to.
+
+        :return: Return a list of identifiers, sorted by their score in descending order.
+        """
+        identifiers = self.of_type(type) if type else list(self.values())
+        return sorted(identifiers, key=lambda v: v.score, reverse=True)
+
+    def preferred(self, type: Optional[type[Identifier]] = None) -> Optional[Identifier]:
+        """
+        :param type: Optionally, an identifier type to constrain the results to.
+
+        :return: Return the highest scoring identifier of the given type (or of any type, if none is specified). Returns `None` if no identifier is available.
+        """
+        if len(self.by_score(type)) == 0:
+            return None
+        return self.by_score(type)[0]

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -6,10 +6,19 @@ from caselawclient.types import SuccessFailureMessageTuple
 
 from . import Identifier
 from .exceptions import UUIDMismatchError
+from .fclid import FindCaseLawIdentifier
+from .neutral_citation import NeutralCitationNumber
+from .press_summary_ncn import PressSummaryRelatedNCNIdentifier
 
 if TYPE_CHECKING:
     from caselawclient.Client import MarklogicApiClient
     from caselawclient.models.documents import Document
+
+SUPPORTED_IDENTIFIER_TYPES: list[type["Identifier"]] = [
+    FindCaseLawIdentifier,
+    NeutralCitationNumber,
+    PressSummaryRelatedNCNIdentifier,
+]
 
 
 class IdentifiersCollection(dict[str, Identifier]):

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -4,16 +4,11 @@ from warnings import warn
 from lxml import etree
 
 from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier
-from .collection import IdentifiersCollection
+from .collection import SUPPORTED_IDENTIFIER_TYPES, IdentifiersCollection
 from .exceptions import InvalidIdentifierXMLRepresentationException
-from .fclid import FindCaseLawIdentifier
-from .neutral_citation import NeutralCitationNumber
-from .press_summary_ncn import PressSummaryRelatedNCNIdentifier
 
 IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
-    "fclid": FindCaseLawIdentifier,
-    "ukncn": NeutralCitationNumber,
-    "uksummaryofncn": PressSummaryRelatedNCNIdentifier,
+    identifier_type.schema.namespace: identifier_type for identifier_type in SUPPORTED_IDENTIFIER_TYPES
 }
 
 

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -3,7 +3,8 @@ from warnings import warn
 
 from lxml import etree
 
-from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier, Identifiers
+from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier
+from .collection import IdentifiersCollection
 from .exceptions import InvalidIdentifierXMLRepresentationException
 from .fclid import FindCaseLawIdentifier
 from .neutral_citation import NeutralCitationNumber
@@ -16,9 +17,9 @@ IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
 }
 
 
-def unpack_all_identifiers_from_etree(identifiers_etree: Optional[etree._Element]) -> Identifiers:
+def unpack_all_identifiers_from_etree(identifiers_etree: Optional[etree._Element]) -> IdentifiersCollection:
     """This expects the entire <identifiers> tag, and unpacks all Identifiers inside it"""
-    identifiers = Identifiers()
+    identifiers = IdentifiersCollection()
     if identifiers_etree is None:
         return identifiers
     for identifier_etree in identifiers_etree.findall("identifier"):

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -12,7 +12,7 @@ from ds_caselaw_utils.types import CourtCode, JurisdictionCode
 from lxml import etree
 
 from caselawclient.Client import MarklogicApiClient
-from caselawclient.models.identifiers import Identifiers
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
 from caselawclient.types import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
@@ -180,7 +180,7 @@ class SearchResult:
         )
 
     @property
-    def identifiers(self) -> Identifiers:
+    def identifiers(self) -> IdentifiersCollection:
         identifiers_etrees = self._get_xpath(".//identifiers")
         count = len(identifiers_etrees)
         if count != 1:

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -14,7 +14,7 @@ from caselawclient.models.documents import (
     DocumentNotSafeForDeletion,
     DocumentURIString,
 )
-from caselawclient.models.identifiers import Identifiers
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier
 from caselawclient.models.judgments import Judgment
@@ -31,7 +31,7 @@ class TestDocumentSaveIdentifiers:
         calls set_property_as_node with expected values (edited)
         """
         document = Document(DocumentURIString("test/1234"), mock_api_client)
-        document.identifiers = Mock(autospec=Identifiers)
+        document.identifiers = Mock(autospec=IdentifiersCollection)
         document.identifiers.as_etree = "fake_node"
 
         document.identifiers.perform_all_validations.return_value = SuccessFailureMessageTuple(True, [])
@@ -47,7 +47,7 @@ class TestDocumentSaveIdentifiers:
         Check that if validating identifiers at save time fails then an exception is raised and the save is not performed
         """
         document = Document(DocumentURIString("test/1234"), mock_api_client)
-        document.identifiers = Mock(autospec=Identifiers)
+        document.identifiers = Mock(autospec=IdentifiersCollection)
         document.identifiers.as_etree = "fake_node"
 
         document.identifiers.perform_all_validations.return_value = SuccessFailureMessageTuple(

--- a/tests/models/identifiers/test_identifer_unpacking.py
+++ b/tests/models/identifiers/test_identifer_unpacking.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from lxml import etree
 from test_identifiers import TestIdentifier
 
-from caselawclient.models.identifiers import Identifiers
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.unpacker import (
     IDENTIFIER_NAMESPACE_MAP,
     unpack_all_identifiers_from_etree,
@@ -119,7 +119,7 @@ class TestIdentifierUnpacking(unittest.TestCase):
         with self.assertWarnsRegex(Warning, "Identifier type unknown is not known."):
             unpacked_identifiers = unpack_all_identifiers_from_etree(xml_tree)
 
-        assert type(unpacked_identifiers) is Identifiers
+        assert type(unpacked_identifiers) is IdentifiersCollection
         assert len(unpacked_identifiers) == 1
         assert type(unpacked_identifiers["2d80bf1d-e3ea-452f-965c-041f4399f2dd"]) is TestIdentifier
         assert "86888618-a9a0-44e3-af4a-5b10dbb910c0" not in unpacked_identifiers
@@ -143,7 +143,7 @@ class TestIdentifierPackUnpackRoundTrip:
     @patch("caselawclient.models.identifiers.unpacker.IDENTIFIER_NAMESPACE_MAP", {"test": TestIdentifier})
     def test_roundtrip_identifiers(self):
         """Check that if we convert multiple identifiers to XML and back again we get the same things out at the far end."""
-        original_identifiers = Identifiers()
+        original_identifiers = IdentifiersCollection()
         original_identifiers.add(TestIdentifier(uuid="id-a1", value="TEST-123"))
         original_identifiers.add(TestIdentifier(uuid="id-b2", value="TEST-456", deprecated=True))
 

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -6,7 +6,7 @@ from ds_caselaw_utils.courts import Court
 from lxml import etree
 
 from caselawclient.Client import MarklogicApiClient
-from caselawclient.models.identifiers import Identifiers
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.responses.search_result import (
     EditorPriority,
     EditorStatus,
@@ -184,7 +184,7 @@ class TestSearchResult:
         node = etree.fromstring(xml)
         search_result = SearchResult(node, self.client)
         identifiers = search_result.identifiers
-        assert isinstance(identifiers, Identifiers)
+        assert isinstance(identifiers, IdentifiersCollection)
         (identifier_1,) = identifiers.values()
         assert identifier_1.value == "[1901] UKSC 1"
         assert search_result.slug == "uksc/1901/1"
@@ -206,7 +206,7 @@ class TestSearchResult:
         node = etree.fromstring(xml)
         search_result = SearchResult(node, self.client)
         identifiers = search_result.identifiers
-        assert isinstance(identifiers, Identifiers)
+        assert isinstance(identifiers, IdentifiersCollection)
         assert not identifiers
         with pytest.raises(RuntimeError):
             search_result.slug
@@ -248,7 +248,7 @@ class TestSearchResult:
         node = etree.fromstring(xml)
         search_result = SearchResult(node, self.client)
         identifiers = search_result.identifiers
-        assert isinstance(identifiers, Identifiers)
+        assert isinstance(identifiers, IdentifiersCollection)
         (identifier_1,) = identifiers.values()
         assert identifier_1.value == "[1901] UKSC 1"
         assert search_result.slug == "uksc/1901/1"


### PR DESCRIPTION
## Summary of changes

Move where we define the concept of a collection of identifiers around, so we can avoid circular import problems in future.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
