### PR TITLE
v38.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v38.0.0 (2025-07-07)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "37.4.0"
+version = "38.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## Summary of changes
### BREAKING CHANGE

- `identifiers.Identifiers` is now `identifiers.collection.IdentifierCollection`
- `Identifiers.validate()` is now `Identifiers.validate_uuids_match_keys()`
- `IdentifierSchema.validate_identifier` has been renamed `IdentifierSchema.validate_identifier_value`

### Feat

- **identifiers**: canonical list of supported identifiers now lives in identifiers.collection
- **Document**: saving identifiers now correctly raises exception when validation fails
- move to using structured objects to represent validation failures rather than exceptions
- **Identifiers**: validating identifiers now performs a full check of all individual identifiers
- **Identifier**: add ability to validate that an identifier is acceptable for a given document class
- **IdentifierSchema**: rename validate_identifier to validate_identifier_value
- **Identifier**: add ability to validate that identifiers are globally unique
- **IdentifierSchema**: add new allow_editing flag to identifier schemas
- **Document**: expose xml with dynamic FRBR uris from document properties using XLST

### Fix

- **deps**: update dependency boto3 to v1.38.42
- **deps**: update boto packages to v1.38.39
- **deps**: update dependency boto3 to v1.38.37
- **deps**: update dependency certifi to >=2025.6.15,<2025.7.0
- **deps**: update dependency boto3 to v1.38.36
- **deps**: update dependency boto3 to v1.38.33
- **deps**: update dependency requests to v2.32.4 [security]
- **deps**: update dependency ds-caselaw-utils to v2.4.7
- **deps**: update dependency boto3 to v1.38.31
- **deps**: update dependency boto3 to v1.38.28
- **deps**: update dependency typing-extensions to v4.14.0

### Refactor

- **Identifiers**: rename Identifiers to IdentifierCollection and move to submodule
- refine how identifiers validity checks are performed