### PR TITLE
Canonicalise XML output of apply_xslt to avoid weird namespacing artifacts

### DIFF
--- a/src/caselawclient/models/documents/xml.py
+++ b/src/caselawclient/models/documents/xml.py
@@ -59,7 +59,7 @@ class XML:
         passable_values = {k: etree.XSLT.strparam(v) for k, v in values.items()}
         xslt_transform = etree.XSLT(etree.fromstring(xslt))
         noncanonical_xml = xslt_transform(self.xml_as_tree, profile_run=False, **passable_values)
-        return etree.canonicalize(noncanonical_xml).encode("utf-8")
+        return etree.tostring(noncanonical_xml, method="c14n")
 
     def apply_xslt(self, xslt_filename: str, **values: str) -> bytes:
         """XSLT transform this XML, given a path to a stylesheet"""

--- a/src/caselawclient/models/documents/xml.py
+++ b/src/caselawclient/models/documents/xml.py
@@ -58,7 +58,8 @@ class XML:
         """XSLT transform this XML, given a stylesheet"""
         passable_values = {k: etree.XSLT.strparam(v) for k, v in values.items()}
         xslt_transform = etree.XSLT(etree.fromstring(xslt))
-        return etree.tostring(xslt_transform(self.xml_as_tree, profile_run=False, **passable_values))
+        noncanonical_xml = xslt_transform(self.xml_as_tree, profile_run=False, **passable_values)
+        return etree.canonicalize(noncanonical_xml).encode("utf-8")
 
     def apply_xslt(self, xslt_filename: str, **values: str) -> bytes:
         """XSLT transform this XML, given a path to a stylesheet"""

--- a/tests/models/documents/test_document_xml.py
+++ b/tests/models/documents/test_document_xml.py
@@ -42,5 +42,8 @@ class TestDocumentXml:
 
         modified_xml = document_xml.apply_xslt("sample.xsl", cat="lion", dog="wolf")
         root = etree.fromstring(modified_xml)
+        # XML is correctly namespaced
         assert root.xpath("//akn:text/text()", namespaces=DEFAULT_NAMESPACES) == ["lion"]
         assert root.xpath("//akn:attribute/@attribute", namespaces=DEFAULT_NAMESPACES) == ["wolf"]
+        # but text does not contain wierd namespacing artifacts
+        assert b"<text>lion</text>" in modified_xml


### PR DESCRIPTION
## Summary of changes

Whilst the XML was correctly namespaced, the apply_xlst function was namespacing far too much in the output bytes (`<akn:FRBRthis xmlns:akn="...">`)

Fix this by canonicalising.

One side effect of canonicalising the XML is that all tags are `<a></a>` rather than `<a/>`

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
