### PR TITLE
Use `/id/doc` namespace for work with no `tna.` prefix

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -570,7 +570,7 @@ class Document:
     def xml_with_correct_frbr(self) -> bytes:
         """Dynamically modify FRBR uris to reflect current storage location and FCL id"""
         fcl_identifiers = self.identifiers.of_type(FindCaseLawIdentifier)
-        work_uri = f"https://caselaw.nationalarchives.gov.uk/id/{fcl_identifiers[0].url_slug}"
+        work_uri = f"https://caselaw.nationalarchives.gov.uk/id/doc/{fcl_identifiers[0].value}"
         expression_uri = f"https://caselaw.nationalarchives.gov.uk/{self.uri.lstrip('/')}"
         manifestation_uri = f"https://caselaw.nationalarchives.gov.uk/{self.uri.lstrip('/')}/data.xml"
         return self.body.apply_xslt(

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -325,10 +325,10 @@ class TestDocumentXMLWithCorrectFRBR:
 
         root = etree.fromstring(doc.xml_with_correct_frbr())
         assert root.xpath("//akn:FRBRWork/akn:FRBRthis/@value", namespaces=DEFAULT_NAMESPACES) == [
-            "https://caselaw.nationalarchives.gov.uk/id/tna.tn4t35ts"
+            "https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"
         ]
         assert root.xpath("//akn:FRBRWork/akn:FRBRuri/@value", namespaces=DEFAULT_NAMESPACES) == [
-            "https://caselaw.nationalarchives.gov.uk/id/tna.tn4t35ts"
+            "https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"
         ]
         assert root.xpath("//akn:FRBRExpression/akn:FRBRthis/@value", namespaces=DEFAULT_NAMESPACES) == [
             "https://caselaw.nationalarchives.gov.uk/d-1234"


### PR DESCRIPTION
## Summary of changes

We agreed now is a good time to migrate to `/id/doc/tn4t35ts` as a URI.
https://dxw.slack.com/archives/C04FQ3GFGUQ/p1751972123605659

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
