### PR TITLE
Canonicalise with v2

### DIFF
--- a/src/caselawclient/models/documents/xml.py
+++ b/src/caselawclient/models/documents/xml.py
@@ -59,7 +59,7 @@ class XML:
         passable_values = {k: etree.XSLT.strparam(v) for k, v in values.items()}
         xslt_transform = etree.XSLT(etree.fromstring(xslt))
         noncanonical_xml = xslt_transform(self.xml_as_tree, profile_run=False, **passable_values)
-        return etree.tostring(noncanonical_xml, method="c14n")
+        return etree.tostring(noncanonical_xml, method="c14n2")
 
     def apply_xslt(self, xslt_filename: str, **values: str) -> bytes:
         """XSLT transform this XML, given a path to a stylesheet"""

--- a/tests/models/documents/test_document_xml.py
+++ b/tests/models/documents/test_document_xml.py
@@ -47,3 +47,11 @@ class TestDocumentXml:
         assert root.xpath("//akn:attribute/@attribute", namespaces=DEFAULT_NAMESPACES) == ["wolf"]
         # but text does not contain wierd namespacing artifacts
         assert b"<text>lion</text>" in modified_xml
+
+    def test_modify_leaves_okay_namespaces(self):
+        document_xml = XML(b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                           <judgment name="decision"> <meta> <identification source="#tna">
+                           <FRBRWork> <akn:FRBRthis xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" value="https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"></akn:FRBRthis>
+                           </FRBRWork> </identification></meta><header></header><judgmentBody><decision><p>This is a document.</p></decision></judgmentBody></judgment></akomaNtoso>""")
+        modified_xml = document_xml.apply_xslt("sample.xsl")
+        assert b"<FRBRthis" in modified_xml


### PR DESCRIPTION
v1 canonicalisation leaves namespaces everywhere -- e.g. <akn:FRBRuri> tags rather than just <FRBRuri> tags so we should use v2, now we've established that the reason for not using v2 was probably incorrect -- the issues were probably caused by not following the schema

Abbrieviated output of canonicalisation methods:

```
etree.tostring(root, method = "c14n")
<akn:FRBRuri xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" value="https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"></akn:FRBRuri>

etree.tostring(root, method = "c14n2")
<FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"></FRBRuri>

etree.canonicalize(root)
<FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"></FRBRuri>
```