### PR TITLE
Don't insert akn namespaces unnecessarily

### DIFF
--- a/src/caselawclient/xslt/modify_xml_live.xsl
+++ b/src/caselawclient/xslt/modify_xml_live.xsl
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn' xmlns:akn='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'>
-
+<xsl:stylesheet version="1.0"
+    xmlns='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'
+    xmlns:akn='http://docs.oasis-open.org/legaldocml/ns/akn/3.0'
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:uk='https://caselaw.nationalarchives.gov.uk/akn'>
     <xsl:param name="work_uri" />
     <xsl:param name="expression_uri" />
     <xsl:param name="manifestation_uri" />
@@ -16,51 +19,51 @@
     <!-- <xsl:template match="akn:identification/FRBRWork/FRBRthistext/text()"><xsl:copy-of select="$cat" /></xsl:template> -->
 
     <xsl:template match="akn:identification/akn:FRBRWork/akn:FRBRthis">
-        <akn:FRBRthis>
+        <FRBRthis>
             <xsl:attribute name="value">
                 <xsl:value-of select="$work_uri" />
             </xsl:attribute>
-        </akn:FRBRthis>
+        </FRBRthis>
     </xsl:template>
 
     <xsl:template match="akn:identification/akn:FRBRWork/akn:FRBRuri">
-        <akn:FRBRuri>
+        <FRBRuri>
             <xsl:attribute name="value">
                 <xsl:value-of select="$work_uri" />
             </xsl:attribute>
-        </akn:FRBRuri>
+        </FRBRuri>
     </xsl:template>
 
     <xsl:template match="akn:identification/akn:FRBRExpression/akn:FRBRthis">
-        <akn:FRBRthis>
+        <FRBRthis>
             <xsl:attribute name="value">
                 <xsl:value-of select="$expression_uri" />
             </xsl:attribute>
-        </akn:FRBRthis>
+        </FRBRthis>
     </xsl:template>
 
     <xsl:template match="akn:identification/akn:FRBRExpression/akn:FRBRuri">
-        <akn:FRBRuri>
+        <FRBRuri>
             <xsl:attribute name="value">
                 <xsl:value-of select="$expression_uri" />
             </xsl:attribute>
-        </akn:FRBRuri>
+        </FRBRuri>
     </xsl:template>
 
     <xsl:template match="akn:identification/akn:FRBRManifestation/akn:FRBRthis">
-        <akn:FRBRthis>
+        <FRBRthis>
             <xsl:attribute name="value">
                 <xsl:value-of select="$manifestation_uri" />
             </xsl:attribute>
-        </akn:FRBRthis>
+        </FRBRthis>
     </xsl:template>
 
     <xsl:template match="akn:identification/akn:FRBRManifestation/akn:FRBRuri">
-        <akn:FRBRuri>
+        <FRBRuri>
             <xsl:attribute name="value">
                 <xsl:value-of select="$manifestation_uri" />
             </xsl:attribute>
-        </akn:FRBRuri>
+        </FRBRuri>
     </xsl:template>
 
 

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -319,11 +319,15 @@ class TestDocumentXMLWithCorrectFRBR:
         with open(
             os.path.join(os.path.dirname(os.path.realpath(__file__)), "xslt", "test_standard_judgment.xml"), "r"
         ) as file:
+            xml_string = file.read()
             doc = DocumentFactory.build(
-                uri=DocumentURIString("d-1234"), body=DocumentBodyFactory.build(name="docname", xml_string=file.read())
+                uri=DocumentURIString("d-1234"), body=DocumentBodyFactory.build(name="docname", xml_string=xml_string)
             )
 
+        assert "akn:" not in xml_string
         root = etree.fromstring(doc.xml_with_correct_frbr())
+        assert b"akn:" not in etree.tostring(root, method="c14n")
+
         assert root.xpath("//akn:FRBRWork/akn:FRBRthis/@value", namespaces=DEFAULT_NAMESPACES) == [
             "https://caselaw.nationalarchives.gov.uk/id/doc/tn4t35ts"
         ]
@@ -342,3 +346,5 @@ class TestDocumentXMLWithCorrectFRBR:
         assert root.xpath("//akn:FRBRManifestation/akn:FRBRuri/@value", namespaces=DEFAULT_NAMESPACES) == [
             "https://caselaw.nationalarchives.gov.uk/d-1234/data.xml"
         ]
+
+        assert b"<FRBRthis" in etree.tostring(root, method="c14n")


### PR DESCRIPTION
## Summary of changes

In order to use v1 canonicalisation to support non-messy ref tags, ensure that we don't insert spurious akn namespaces into the middle of the document.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
