### PR TITLE
Make the package version number in the docs dynamic

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,12 +11,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PDOC_DYNAMIC_VERSION: 1
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.13
 
@@ -28,7 +30,7 @@ jobs:
 
       - run: poetry run pdoc -o docs/ src/caselawclient
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/
 
@@ -43,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/src/caselawclient/__init__.py
+++ b/src/caselawclient/__init__.py
@@ -1,4 +1,21 @@
-"""
+import os
+
+if os.getenv("PDOC_DYNAMIC_VERSION") == "1":
+    from pathlib import Path
+
+    import tomllib
+
+    pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        __version__ = tomllib.load(f)["tool"]["poetry"]["version"]
+        __pip_version_string__ = f"~={__version__}"
+        __poetry_version_string__ = f' = "^{__version__}"'
+
+else:
+    __pip_version_string__ = ""
+    __poetry_version_string__ = ""
+
+__doc__ = f"""
 
 # Installation
 
@@ -15,7 +32,13 @@ poetry add ds-caselaw-marklogic-api-client
 or in your projects `requirements.txt` with:
 
 ```text
-ds-caselaw-marklogic-api-client~=12.0.0
+ds-caselaw-marklogic-api-client{__pip_version_string__}
+```
+
+or `pyproject.toml` for Poetry with:
+
+```text
+ds-caselaw-marklogic-api-client{__poetry_version_string__}
 ```
 
 # Usage


### PR DESCRIPTION
## Summary of changes

Previously, the generated documentation was using a static version number for the library (v12). Make it dynamic, so people blindly copying and pasting will always get the latest version.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
