### PR TITLE
Add XDMP-LOCKED as MarklogicResourceLockedError

### DIFF
--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -170,6 +170,7 @@ class MarklogicApiClient:
     error_code_classes: dict[str, Type[MarklogicAPIError]] = {
         "XDMP-DOCNOTFOUND": MarklogicResourceNotFoundError,
         "XDMP-LOCKCONFLICT": MarklogicResourceLockedError,
+        "XDMP-LOCKED": MarklogicResourceLockedError,
         "DLS-UNMANAGED": MarklogicResourceUnmanagedError,
         "DLS-NOTCHECKEDOUT": MarklogicResourceNotCheckedOutError,
         "DLS-CHECKOUTCONFLICT": MarklogicCheckoutConflictError,


### PR DESCRIPTION
## Summary of changes

The reparse process is stopping because an unanticipated XDMP-LOCKED error is being treated as a fatal error.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
