### PR TITLE
Add logging for 403 on attempted docx read

### DIFF
--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -96,6 +96,8 @@ def check_docx_exists(uri: DocumentURIString) -> bool:
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "404":
             return False
+        if e.response["Error"]["Code"] == "403":
+            e.add_note("403 on reading {s3_key}")
         raise
 
 


### PR DESCRIPTION
## Summary of changes

Reparsing is hitting issues where documents are 403ing. Further information would be useful.

(This might not be neccessary -- what it should actually do is print the filenames every time, even not on error)

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
