### PR TITLE
Add timeout for marklogic eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unpublished
+
+- **Eval**: Set configurable timeouts when evaling against MarkLogic: default 3.05s (connect) and 10s (read)
+
 ## v39.1.1 (2025-08-07)
 
 - **Github Actions**: Migrate from CodeClimate to Codecov
-- **Eval**: Set configurable timeouts when evaling against MarkLogic: default 3.05s (connect) and 27s (read)
 
 ## v39.1.0 (2025-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## v39.1.1 (2025-08-07)
 
 - **Github Actions**: Migrate from CodeClimate to Codecov
+- **Eval**: Set configurable timeouts when evaling against MarkLogic: default 3.05s (connect) and 27s (read)
 
 ## v39.1.0 (2025-07-28)
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -59,7 +59,7 @@ env = environ.Env()
 
 # Requests timeouts: https://requests.readthedocs.io/en/latest/user/advanced/
 CONNECT_TIMEOUT = float(os.environ.get("CONNECT_TIMEOUT", "3.05"))
-READ_TIMEOUT = float(os.environ.get("READ_TIMEOUT", "27"))
+READ_TIMEOUT = float(os.environ.get("READ_TIMEOUT", "10.0"))
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
@@ -323,11 +323,13 @@ class MarklogicApiClient:
         self,
         vars: query_dicts.MarkLogicAPIDict,
         xquery_file_name: str,
+        timeout: tuple[float, float] = (CONNECT_TIMEOUT, READ_TIMEOUT),
     ) -> requests.Response:
         return self.eval(
             self._xquery_path(xquery_file_name),
             vars=json.dumps(vars),
             accept_header="application/xml",
+            timeout=timeout,
         )
 
     def _eval_and_decode(
@@ -730,6 +732,7 @@ class MarklogicApiClient:
         xquery_path: str,
         vars: str,
         accept_header: str = "multipart/mixed",
+        timeout: tuple[float, float] = (CONNECT_TIMEOUT, READ_TIMEOUT),
     ) -> requests.Response:
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
@@ -749,7 +752,7 @@ class MarklogicApiClient:
             url=self._path_to_request_url(path),
             headers=headers,
             data=data,
-            timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+            timeout=timeout,
         )
         # Raise relevant exception for an erroneous response
         self._raise_for_status(response)

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -56,6 +56,11 @@ from .errors import (
 )
 
 env = environ.Env()
+
+# Requests timeouts: https://requests.readthedocs.io/en/latest/user/advanced/
+CONNECT_TIMEOUT = float(os.environ.get("CONNECT_TIMEOUT", "3.05"))
+READ_TIMEOUT = float(os.environ.get("READ_TIMEOUT", "27"))
+
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
 
@@ -744,6 +749,7 @@ class MarklogicApiClient:
             url=self._path_to_request_url(path),
             headers=headers,
             data=data,
+            timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
         )
         # Raise relevant exception for an erroneous response
         self._raise_for_status(response)

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -2,7 +2,7 @@ import json
 import os
 import unittest
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
@@ -27,6 +27,7 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "checkout_judgment.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )
 
     def test_checkout_judgment_with_midnight_timeout(self):
@@ -147,4 +148,5 @@ class TestGetCheckoutStatus(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "break_judgment_checkout.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -9,6 +9,8 @@ import responses
 from requests import Request
 
 from caselawclient.Client import (
+    CONNECT_TIMEOUT,
+    READ_TIMEOUT,
     MarklogicApiClient,
     MultipartResponseLongerThanExpected,
     get_multipart_strings_from_marklogic_response,
@@ -137,6 +139,7 @@ class ApiClientTest(unittest.TestCase):
                     "Accept": "multipart/mixed",
                 },
                 data={"xquery": "mock-query", "vars": '{{"testvar":"test"}}'},
+                timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
             )
 
     @patch("caselawclient.Client.Path")

--- a/tests/client/test_get_set_metadata.py
+++ b/tests/client/test_get_set_metadata.py
@@ -2,7 +2,7 @@ import json
 import os
 import unittest
 import warnings
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
@@ -169,6 +169,7 @@ class TestGetSetMetadata(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "set_metadata_this_uri.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )
 
     def test_set_internal_uri_no_leading_slash(self):

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -1,7 +1,7 @@
 import json
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
@@ -25,6 +25,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )
 
     def test_set_boolean_property_false(self):
@@ -41,6 +42,7 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "set_boolean_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )
 
     def test_get_unset_boolean_property(self):
@@ -109,4 +111,5 @@ class TestGetSetJudgmentProperties(unittest.TestCase):
                 os.path.join(ROOT_DIR, "xquery", "set_property.xqy"),
                 vars=json.dumps(expected_vars),
                 accept_header="application/xml",
+                timeout=ANY,
             )


### PR DESCRIPTION
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-1056
## Summary of changes

<!-- Replace this with a short summary of changes in this PR -->

Adds optional environment variables `CONNECT_TIMEOUT` and `READ_TIMEOUT` with default values borrowed from https://requests.readthedocs.io/en/latest/user/advanced/#timeouts (slightly more than a TCP retry window and slightly less than a default gunicorn timeout, respectively)

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
