### PR TITLE
[FCL-1137] Fix adding new identifiers whilst a document is published

### DIFF
--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -169,7 +169,7 @@ class Identifier(ABC):
             for resolution in api_client.resolve_from_identifier_value(
                 identifier_value=self.value, published_only=False
             )
-            if resolution.identifier_namespace == self.schema.namespace
+            if resolution.identifier_namespace == self.schema.namespace and resolution.identifier_uuid != self.uuid
         ]
         if len(resolutions) > 0:
             return SuccessFailureMessageTuple(

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -166,7 +166,9 @@ class Identifier(ABC):
         """
         resolutions = [
             resolution
-            for resolution in api_client.resolve_from_identifier_value(identifier_value=self.value)
+            for resolution in api_client.resolve_from_identifier_value(
+                identifier_value=self.value, published_only=False
+            )
             if resolution.identifier_namespace == self.schema.namespace
         ]
         if len(resolutions) > 0:

--- a/tests/models/identifiers/test_identifier_constraints.py
+++ b/tests/models/identifiers/test_identifier_constraints.py
@@ -44,15 +44,15 @@ class TestIncorrectDocumentType(Document):
     {"test": TestGloballyUniqueIdentifier, "other-namespace": TestGloballyUniqueIdentifier},
 )
 class TestRequireGloballyUniqueIdentifierConstraint:
-    def test_adding_id_if_duplicate_exists(self, mock_api_client):
+    def test_adding_id_if_exists_with_different_uuid(self, mock_api_client):
         resolutions = IdentifierResolutionsFactory.build(
             [
-                IdentifierResolutionFactory.build(namespace="test", value="TEST-123"),
+                IdentifierResolutionFactory.build(resolution_uuid="a1b2c3", namespace="test", value="TEST-123"),
             ]
         )
         mock_api_client.resolve_from_identifier_value.return_value = resolutions
 
-        new_identifier = TestGloballyUniqueIdentifier(value="TEST-123")
+        new_identifier = TestGloballyUniqueIdentifier(uuid="d4e5f6", value="TEST-123")
 
         validation = new_identifier.validate_require_globally_unique(api_client=mock_api_client)
         mock_api_client.resolve_from_identifier_value.assert_called_once_with(
@@ -61,6 +61,23 @@ class TestRequireGloballyUniqueIdentifierConstraint:
 
         assert validation.success is False
         assert validation.messages == ['Identifiers in scheme "test" must be unique; "TEST-123" already exists!']
+
+    def test_adding_id_if_exists_with_same_uuid(self, mock_api_client):
+        resolutions = IdentifierResolutionsFactory.build(
+            [
+                IdentifierResolutionFactory.build(resolution_uuid="a1b2c3", namespace="test", value="TEST-123"),
+            ]
+        )
+        mock_api_client.resolve_from_identifier_value.return_value = resolutions
+
+        new_identifier = TestGloballyUniqueIdentifier(uuid="a1b2c3", value="TEST-123")
+
+        validation = new_identifier.validate_require_globally_unique(api_client=mock_api_client)
+        mock_api_client.resolve_from_identifier_value.assert_called_once_with(
+            identifier_value="TEST-123", published_only=False
+        )
+
+        assert validation.success is True
 
     def test_adding_id_if_no_resolutions(self, mock_api_client):
         resolutions = IdentifierResolutionsFactory.build([])

--- a/tests/models/identifiers/test_identifier_constraints.py
+++ b/tests/models/identifiers/test_identifier_constraints.py
@@ -55,7 +55,9 @@ class TestRequireGloballyUniqueIdentifierConstraint:
         new_identifier = TestGloballyUniqueIdentifier(value="TEST-123")
 
         validation = new_identifier.validate_require_globally_unique(api_client=mock_api_client)
-        mock_api_client.resolve_from_identifier_value.assert_called_once_with(identifier_value="TEST-123")
+        mock_api_client.resolve_from_identifier_value.assert_called_once_with(
+            identifier_value="TEST-123", published_only=False
+        )
 
         assert validation.success is False
         assert validation.messages == ['Identifiers in scheme "test" must be unique; "TEST-123" already exists!']
@@ -67,7 +69,9 @@ class TestRequireGloballyUniqueIdentifierConstraint:
         new_identifier = TestGloballyUniqueIdentifier(value="TEST-123")
 
         validation = new_identifier.validate_require_globally_unique(api_client=mock_api_client)
-        mock_api_client.resolve_from_identifier_value.assert_called_once_with(identifier_value="TEST-123")
+        mock_api_client.resolve_from_identifier_value.assert_called_once_with(
+            identifier_value="TEST-123", published_only=False
+        )
 
         assert validation.success is True
         assert validation.messages == []
@@ -83,7 +87,9 @@ class TestRequireGloballyUniqueIdentifierConstraint:
         new_identifier = TestGloballyUniqueIdentifier(value="TEST-123")
 
         validation = new_identifier.validate_require_globally_unique(api_client=mock_api_client)
-        mock_api_client.resolve_from_identifier_value.assert_called_once_with(identifier_value="TEST-123")
+        mock_api_client.resolve_from_identifier_value.assert_called_once_with(
+            identifier_value="TEST-123", published_only=False
+        )
 
         assert validation.success is True
         assert validation.messages == []


### PR DESCRIPTION
## Summary of changes

Duplicate identifier detection wasn't correctly ignoring where the current identifier had been saved to the database. However, this was being masked by also not correctly checking identifiers of unpublished documents.

This PR fixes both.

## Jira

FCL-1137

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
