### PR TITLE
Do not enrich if the document does not validate. Warn instead.

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -35,7 +35,12 @@ from caselawclient.models.utilities.aws import (
 from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple
 
 from .body import DocumentBody
-from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
+from .exceptions import (
+    CannotEnrichUnenrichableDocument,
+    CannotPublishUnpublishableDocument,
+    DocumentDoesNotValidateWarning,
+    DocumentNotSafeForDeletion,
+)
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
 
 MINIMUM_ENRICHMENT_TIME = datetime.timedelta(minutes=20)
@@ -524,6 +529,9 @@ class Document:
         """
         Is it possible to enrich this document?
         """
+        if not self.validates_against_schema:
+            msg = f"{self.uri} does not validate against the schema"
+            warnings.warn(msg, DocumentDoesNotValidateWarning)
         return self.body.has_content
 
     def validate_identifiers(self) -> SuccessFailureMessageTuple:

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -8,3 +8,7 @@ class CannotEnrichUnenrichableDocument(Exception):
 
 class DocumentNotSafeForDeletion(Exception):
     """A document which is not safe for deletion cannot be deleted."""
+
+
+class DocumentDoesNotValidateWarning(UserWarning):
+    """We tried to validate a document when attempting an operation expecting it to succeed and it failed."""


### PR DESCRIPTION
## Summary of changes

Privileged API returns a `422 Unprocessable Entity` if the document fails to validate against the schema. This is usually because the document is not valid in MarkLogic. Push the logic into the API client so the Editor can not send faulty info to the enrichment process.

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
