### PR TITLE
Enrich-on-publish is allowed to fail if the document is unenrichable

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -422,7 +422,7 @@ class Document:
             uri=self.uri,
             status="publish",
         )
-        self.enrich()
+        self.enrich(accept_failures=True)
 
     def unpublish(self) -> None:
         self.api_client.break_checkout(self.uri)


### PR DESCRIPTION
## Summary of changes

Calling `document.publish()` on an unenrichable document should not crash, but instead simply not accept that it cannot be enriched.

https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-ingester/161#detail

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
