### PR TITLE
FCL 1132: Block enrichment and reparsing if tribunal backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## Unpublished
+
 - **Reparse/Enrichment**: Don't reparse/enrich documents that have external data
 
 ## v40.0.0 (2025-08-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unpublished
+- **Reparse/Enrichment**: Don't reparse/enrich documents that have external data
+
 ## v40.0.0 (2025-08-20)
 
 ### Feat

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -540,14 +540,14 @@ class Document:
         """
         Is it sensible to reparse this document?
         """
-        return self.docx_exists()
+        return self.docx_exists() and not self.body.has_external_data
 
     @cached_property
     def can_enrich(self) -> bool:
         """
         Is it possible to enrich this document?
         """
-        return self.body.has_content
+        return self.body.has_content and not self.body.has_external_data
 
     def validate_identifiers(self) -> SuccessFailureMessageTuple:
         return self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -186,6 +186,13 @@ class DocumentBody:
 
         return False
 
+    @cached_property
+    def has_external_data(self) -> bool:
+        """Is there data which is not present within the source document:
+        is there a spreadsheet which has populated some fields. The current implementation
+        "is there a uk:party tag" is intended as a stopgap whilst we're not importing that data."""
+        return bool(self._xml.xml_as_tree.xpath("//uk:party", namespaces=DEFAULT_NAMESPACES))
+
     @cache
     def content_html(self, image_prefix: str) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -429,5 +429,16 @@ class TestDocumentBody:
 
     def test_minimal_xml_behaves_ok(self):
         body = DocumentBodyFactory.build("""
-            <akomaNtoso/>""")
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"/>
+            """)
         assert not (body.has_content)
+        assert not body.has_external_data
+
+    def test_uk_party(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <sometag>
+                    <uk:party type='example'>someone</uk:party>
+                </sometag>
+            </akomaNtoso>""")
+        assert body.has_external_data


### PR DESCRIPTION
## Summary of changes

https://national-archives.atlassian.net/browse/FCL-1132

Using the presence of `uk:party` as a temporary measure before building a proper way of dealing with the additional data, block enrichment and reparsing of documents from the tribunal backlog.

Reparsing is definately needed, enrichment might be safe (but pointless)
