### PR TITLE
[FCL-1178] neutral_citation of a SearchResult will now correctly be None if not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
+- `SearchResult` will no longer return `""` when a Neutral Citation Number is missing. Instead, it will return `None`.
 - Minimum Python version has changed from 3.10 to 3.12
 
 ### Feat
 
+- **SearchResult**: neutral_citation of a search result is now derived from structured identifiers
 - change minimum Python version from 3.10 to 3.12
 
 ## v39.2.1 (2025-08-14)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,19 @@ def valid_search_result_xml_fixture() -> str:
         '<FRBRname value="Another made up case name" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
         '<FRBRdate date="2023-04-09T18:05:45" name="transform" xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>'
         '<uk:court xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">A-C</uk:court>'
-        '<uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2015] A 20 (C)</uk:cite>'
+        '<uk:cite xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">[2015] UKSC 123</uk:cite>'
         '<uk:hash xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">test_content_hash</uk:hash>'
-        '<neutralCitation xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">[2015] A 0020 (C)</neutralCitation>'
+        '<neutralCitation xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">[2015] UKSC 123</neutralCitation>'
+        "</search:extracted>"
+        '<search:extracted kind="identifiers">'
+        "<identifiers>"
+        "<identifier>"
+        "<namespace>ukncn</namespace>"
+        "<uuid>2d80bf1d-e3ea-452f-965c-041f4399f2dd</uuid>"
+        "<value>[2015] UKSC 123</value>"
+        "<url_slug>uksc/2015/123</url_slug>"
+        "</identifier>"
+        "</identifiers>"
         "</search:extracted>"
         "</search:result>"
     )

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -45,7 +45,7 @@ class TestSearchResult:
             search_result = SearchResult(node, self.client)
 
             assert search_result.uri == "a/c/2015/20"
-            assert search_result.neutral_citation == "[2015] A 20 (C)"
+            assert search_result.neutral_citation == "[2015] UKSC 123"
             assert search_result.name == "Another made up case name"
             assert search_result.date == datetime.datetime(2017, 8, 8, 0, 0)
             assert search_result.court is None
@@ -59,7 +59,7 @@ class TestSearchResult:
             assert search_result.metadata.last_modified == "bar"
             assert (
                 str(search_result)
-                == "<SearchResult a/c/2015/20 **NO SLUG** Another made up case name 2017-08-08 00:00:00>"
+                == "<SearchResult a/c/2015/20 uksc/2015/123 Another made up case name 2017-08-08 00:00:00>"
             )
 
     def test_create_from_node_with_unparsable_date(self):
@@ -158,6 +158,17 @@ class TestSearchResult:
 
         assert search_result.court and search_result.court.name == "First-tier Tribunal (General Regulatory Chamber)"
 
+
+class TestSearchResultIdentifierHandling:
+    def setup_method(self):
+        self.client = MarklogicApiClient(
+            host="",
+            username="",
+            password="",
+            use_https=False,
+            user_agent="marklogic-api-client-test",
+        )
+
     def test_has_identifiers(self):
         """
         GIVEN an XML node with identifiers
@@ -186,6 +197,7 @@ class TestSearchResult:
         identifiers = search_result.identifiers
         assert isinstance(identifiers, IdentifiersCollection)
         (identifier_1,) = identifiers.values()
+        assert search_result.neutral_citation == "[1901] UKSC 1"
         assert identifier_1.value == "[1901] UKSC 1"
         assert search_result.slug == "uksc/1901/1"
         assert str(search_result) == "<SearchResult a/c/2015/20 uksc/1901/1 **NO NAME** None>"
@@ -206,6 +218,7 @@ class TestSearchResult:
         node = etree.fromstring(xml)
         search_result = SearchResult(node, self.client)
         identifiers = search_result.identifiers
+        assert search_result.neutral_citation is None
         assert isinstance(identifiers, IdentifiersCollection)
         assert not identifiers
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary of changes

This was previously always returning a `str`, even if that string was `""`. In those cases the API client will now correctly return a `None`.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
