### PR TITLE
bump: version 39.2.1 → 40.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v40.0.0 (2025-08-20)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "39.2.1"
+version = "40.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- `SearchResult` will no longer return `""` when a Neutral Citation Number is missing. Instead, it will return `None`.
- Minimum Python version has changed from 3.10 to 3.12

### Feat

- **Document**: add new has_ever_been_published property
- **Document**: documents can now retrieve and will set first_published_datetime
- **Client**: add methods for getting/setting datetime properties in MarkLogic
- **SearchResult**: neutral_citation of a search result is now derived from structured identifiers
- change minimum Python version from 3.10 to 3.12