### PR TITLE
FCL-890 | add extra categories to document body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### Feat
+
+- **DocumentBody**: update category to match the first category without a parent
+- **DocumentBody**: add secondary_category
+- **DocumentBody**: add subcategory
+- **DocumentBody**: add secondary_subcategory
+
 ### BREAKING CHANGE
 
 - `SearchResult` will no longer return `""` when a Neutral Citation Number is missing. Instead, it will return `None`.

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -53,7 +53,27 @@ class DocumentBody:
 
     @cached_property
     def category(self) -> Optional[str]:
-        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category/text()")
+        return self.get_xpath_match_string(
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category[not(@parent)][1]/text()"
+        )
+
+    @cached_property
+    def secondary_category(self) -> Optional[str]:
+        return self.get_xpath_match_string(
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category[not(@parent)][2]/text()"
+        )
+
+    @cached_property
+    def subcategory(self) -> Optional[str]:
+        return self.get_xpath_match_string(
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category[@parent][1]/text()"
+        )
+
+    @cached_property
+    def secondary_subcategory(self) -> Optional[str]:
+        return self.get_xpath_match_string(
+            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category[@parent][2]/text()"
+        )
 
     @cached_property
     def case_number(self) -> Optional[str]:

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -137,6 +137,87 @@ class TestDocumentBody:
             ('doc name="pressSummary"', "doc"),
         ],
     )
+    def test_subcategory(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:category>Breach of code of standards</uk:category>
+                            <uk:category parent="Breach of code of standards">Standards not met</uk:category>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.subcategory == "Standards not met"
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
+    def test_secondary_category(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:category>Breach of code of standards</uk:category>
+                            <uk:category parent="Breach of code of standards">Standards not met</uk:category>
+                            <uk:category>Appeals</uk:category>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.secondary_category == "Appeals"
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
+    def test_secondary_subcategory(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:category>Breach of code of standards</uk:category>
+                            <uk:category parent="Breach of code of standards">Standards not met</uk:category>
+                            <uk:category>Appeals</uk:category>
+                            <uk:category parent="Appeals">Registration variation</uk:category>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.secondary_subcategory == "Registration variation"
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
     def test_case_number(self, opening_tag, closing_tag):
         body = DocumentBody(
             f"""


### PR DESCRIPTION
## Summary of changes

Adds the subcategory, secondary category and secondary subcategory to the document body.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
