### PR TITLE
Delete only non-tar.gz files from bucket

### DIFF
--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -15,6 +15,7 @@ from caselawclient.models.utilities.aws import (
     build_new_key,
     check_docx_exists,
     copy_assets,
+    delete_non_targz_from_bucket,
 )
 
 
@@ -85,6 +86,17 @@ class TestAWSUtils:
             {"Bucket": "MY_BUCKET", "Key": "uksc/2023/1/uksc_2023_1.docx"},
             "MY_BUCKET",
             "ukpc/1999/9/ukpc_1999_9.docx",
+        )
+
+    @patch("caselawclient.models.utilities.aws.create_s3_client")
+    def test_delete_non_tar_gz(self, client):
+        client.return_value.list_objects.return_value = {
+            "Contents": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}, {"Key": "uksc/2023/1/TDR-2023-AAA.tar.gz"}]
+        }
+        delete_non_targz_from_bucket(DocumentURIString("uksc/2023/1"), "fake_bucket")
+        client.return_value.list_objects.assert_called_with(Bucket="fake_bucket", Prefix="uksc/2023/1/")
+        client.return_value.delete_objects.assert_called_with(
+            Bucket="fake_bucket", Delete={"Objects": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}]}
         )
 
 


### PR DESCRIPTION
## Summary of changes

part of https://national-archives.atlassian.net/browse/FCL-1062

`aws.delete_from_bucket` does not seem to have been used or tested; we want to be able to delete items from the bucket that aren't tar.gz files to erase it back to a sensible state. We also rewrite delete from bucket in terms of a function that filters the objects in an S3 prefix.

Non-tar-gz-delete might want to be private bucket only

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
