### PR TITLE
Multiple identifiers of the same type allowed for future identifier schemas

### DIFF
--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -46,7 +46,10 @@ class IdentifierSchema(ABC):
     """ Should editors be allowed to manually manipulate identifiers under this schema? """
 
     require_globally_unique: bool = True
-    """ Must this identifier be globally unique? """
+    """ Must this identifier be globally unique? (appear on no other documents) """
+
+    allow_multiple: bool = False
+    """ May documents have more than one non-deprecated identifier of this type? """
 
     document_types: Optional[list[str]] = None
     """

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -43,6 +43,8 @@ class IdentifiersCollection(dict[str, Identifier]):
         """Check that only one non-deprecated identifier exists per schema where that schema does not allow multiples."""
 
         for schema, identifiers in self._list_all_identifiers_by_schema().items():
+            if schema.allow_multiple:
+                continue
             non_deprecated_identifiers = [i for i in identifiers if not i.deprecated]
             if len(non_deprecated_identifiers) > 1:
                 return SuccessFailureMessageTuple(


### PR DESCRIPTION
## Summary of changes

Part of https://national-archives.atlassian.net/browse/FCL-1062

Flesh out the support for future identifier schemas to allow multiple identifiers of a type by adding a property to the schema and updating the "this is allowed" logic

<!-- Replace this with a short summary of changes in this PR -->

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
