### PR TITLE
[FCL-1272] first_published_datetime now interprets sentinel values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Document**: first_published_datetime now interprets sentinel values
+
+### Fix
+
+- **deps**: update dependency boto3 to v1.40.25
+- **deps**: update dependency boto3 to v1.40.22
+- **deps**: update dependency ds-caselaw-utils to v2.7.1
+- **deps**: update dependency ds-caselaw-utils to v2.7.0
+- **deps**: update dependency boto3 to v1.40.20
+- **deps**: update dependency boto3 to v1.40.17
+- **deps**: update dependency typing-extensions to v4.15.0
+- **deps**: update dependency boto3 to v1.40.16
+- **deps**: update dependency lxml to v6.0.1
+- **deps**: update dependency boto3 to v1.40.13
+
+## v40.0.0 (2025-08-20)
+
 ## v41.0.0 (2025-09-02)
 
 - Added `api_client.has_unique_content_hash`

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -312,10 +312,37 @@ class Document:
 
     @cached_property
     def first_published_datetime(self) -> Optional[datetime.datetime]:
+        """
+        Return the database value for the date and time this document was first published.
+
+        :return: The datetime value in the database for "first published".
+        """
         return self.api_client.get_datetime_property(self.uri, "first_published_datetime")
 
     @cached_property
+    def first_published_datetime_display(self) -> Optional[datetime.datetime]:
+        """
+        Return the display value for the date and time this document was first published.
+
+        A value of 1970-01-01 00:00 indicates that the document has been published previously, but the exact date and time is unknown. In this case, return `None`. This can be used alongside `has_ever_been_published` to indicate an "unknown" state.
+
+        :return: The datetime value to be displayed to end users for "first published".
+        """
+
+        if self.first_published_datetime == datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc):
+            return None
+
+        return self.first_published_datetime
+
+    @cached_property
     def has_ever_been_published(self) -> bool:
+        """
+        Do we consider this document to have ever been published?
+
+        This is `True` if either the document is currently published, or if `first_published_datetime` has any value (including the sentinel value).
+
+        :return: A boolean indicating if the document has ever been published.
+        """
         return self.is_published or self.first_published_datetime is not None
 
     @cached_property

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -203,6 +203,29 @@ class TestDocument:
         )
         mock_api_client.get_datetime_property.assert_called_once_with("test/1234", "first_published_datetime")
 
+    def test_document_first_published_datetime_display(self, mock_api_client):
+        mock_api_client.get_datetime_property.return_value = datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.first_published_datetime_display == datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+        mock_api_client.get_datetime_property.assert_called_once_with("test/1234", "first_published_datetime")
+
+    def test_document_first_published_datetime_display_sentinel(self, mock_api_client):
+        """We expect that our sentinel value will return `None`."""
+        mock_api_client.get_datetime_property.return_value = datetime.datetime(
+            1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.first_published_datetime_display is None
+        mock_api_client.get_datetime_property.assert_called_once_with("test/1234", "first_published_datetime")
+
     @pytest.mark.parametrize(
         "is_published, first_published_datetime, expected_outcome",
         [
@@ -210,6 +233,8 @@ class TestDocument:
             (True, None, True),
             (False, datetime.datetime(2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc), True),
             (True, datetime.datetime(2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc), True),
+            (False, datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), True),
+            (True, datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), True),
         ],
     )
     def test_document_has_ever_been_published(


### PR DESCRIPTION
## Summary of changes

A sentinel value of `1970-01-01 00:00`` indicates that we know a document has previously been published, but not exactly when. `has_ever_been_published` already interprets this correctly, but we add a new test for this.

We also add `first_published_datetime_display` which will return a `None` where the value matches this sentinel, and this can be used in combination with `has_ever_been_published` to indicate an "unknown" state.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
