### PR TITLE
bump: version 41.0.0 → 41.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v41.1.0 (2025-09-09)
 
 ### Feat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "41.0.0"
+version = "41.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **Document**: first_published_datetime now interprets sentinel values

### Fix

- **DocumentFactory**: document factories now correctly set a default first published datetime
- **deps**: update dependency boto3 to v1.40.25
- **deps**: update dependency boto3 to v1.40.22
- **deps**: update dependency ds-caselaw-utils to v2.7.1
- **deps**: update dependency ds-caselaw-utils to v2.7.0
- **deps**: update dependency boto3 to v1.40.20
- **deps**: update dependency boto3 to v1.40.17
- **deps**: update dependency typing-extensions to v4.15.0
- **deps**: update dependency boto3 to v1.40.16
- **deps**: update dependency lxml to v6.0.1
- **deps**: update dependency boto3 to v1.40.13