### PR TITLE
Correctly exclude document versions from checking for duplicate hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- **has_unique_content_hash**: correctly exclude document versions from checking for duplicate hashes
+
 ## v41.1.0 (2025-09-09)
 
 ### Feat

--- a/src/caselawclient/xquery/check_content_hash_unique_by_uri.xqy
+++ b/src/caselawclient/xquery/check_content_hash_unique_by_uri.xqy
@@ -5,5 +5,11 @@ declare variable $uri as xs:string external;
 
 let $doc := doc($uri)
 let $hash := $doc//uk:hash/text()
-let $count := count(cts:search(fn:doc(), cts:element-value-query(xs:QName("uk:hash"), $hash)))
-return $count = 1
+let $count := count(cts:uris(
+  (), (),
+  cts:and-query((
+    cts:element-value-query(xs:QName("uk:hash"), $hash),
+    cts:collection-query("http://marklogic.com/collections/dls/latest-version")
+  ))
+))
+return $count


### PR DESCRIPTION
The query was returning the document proper, as well as versions of that document. This meant we were always counting at least two documents with a matching hash, which violates the unique document check.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
