### PR TITLE
[FCL-1278] Fix return signature for unique document xquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- **has_unique_content_hash**: fix return signature for unique document xquery
+
 ## v41.1.1 (2025-09-10)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v41.1.2 (2025-09-10)
 
 ### Fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "41.1.1"
+version = "41.1.2"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/src/caselawclient/xquery/check_content_hash_unique_by_uri.xqy
+++ b/src/caselawclient/xquery/check_content_hash_unique_by_uri.xqy
@@ -12,4 +12,4 @@ let $count := count(cts:uris(
     cts:collection-query("http://marklogic.com/collections/dls/latest-version")
   ))
 ))
-return $count
+return $count = 1


### PR DESCRIPTION
## Summary of changes

Correctly return a boolean from the xquery, rather than an integer

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
