### PR TITLE
bump: version 41.1.2 -> 41.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v41.1.3 (2025-09-10)
+
+### Feat
+
+- **Search**: adds neutral_citation and consignment_number as search options
+
 ## v41.1.2 (2025-09-10)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "41.1.2"
+version = "41.1.3"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
## v41.1.3 (2025-09-10)

### Feat

- **Search**: adds neutral_citation and consignment_number as search options