### PR TITLE
[FCL-1325] Add new methods to check if a document is safe to use as a merge source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- **Document**: merge source checks now ensure a document is safe to delete
 - **Document**: merge source checks now ensure a document has never been published
 - **Document**: add new methods to check if a document is safe to use as merge source
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -330,6 +330,16 @@ class Document:
 
         return SuccessFailureMessageTuple(True, [])
 
+    def check_is_safe_to_delete(self) -> SuccessFailureMessageTuple:
+        """Make sure the document is safe to delete."""
+        if not self.safe_to_delete:
+            return SuccessFailureMessageTuple(
+                False,
+                ["This document cannot be deleted because it is published"],
+            )
+
+        return SuccessFailureMessageTuple(True, [])
+
     def check_is_safe_as_merge_source(self) -> SuccessFailureMessageTuple:
         """
         Is this document safe to be considered as a merge source, ie the document which will make a new version atop a target.
@@ -338,6 +348,7 @@ class Document:
         validations = [
             self.check_has_only_one_version(),
             self.check_has_never_been_published(),
+            self.check_is_safe_to_delete(),
         ]
 
         success = True

--- a/tests/models/documents/test_document_merge.py
+++ b/tests/models/documents/test_document_merge.py
@@ -55,24 +55,46 @@ class TestDocumentSafeAsMergeSource:
         assert check_result.success is False
         assert check_result.messages == ["This document has previously been published"]
 
+    def test_check_is_safe_to_delete_if_safe(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.safe_to_delete = True
+
+        check_result = document.check_is_safe_to_delete()
+
+        assert check_result.success is True
+        assert check_result.messages == []
+
+    def test_check_is_safe_to_delete_if_unsafe(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.safe_to_delete = False
+
+        check_result = document.check_is_safe_to_delete()
+
+        assert check_result.success is False
+        assert check_result.messages == ["This document cannot be deleted because it is published"]
+
     def test_check_is_safe_as_merge_source_runs_expected_checks(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
 
         with (
             patch.object(document, "check_has_only_one_version") as mock_check_has_only_one_version,
             patch.object(document, "check_has_never_been_published") as mock_check_has_never_been_published,
+            patch.object(document, "check_is_safe_to_delete") as mock_check_is_safe_to_delete,
         ):
             mock_check_has_only_one_version.return_value = SuccessFailureMessageTuple(True, [])
             mock_check_has_never_been_published.return_value = SuccessFailureMessageTuple(True, [])
+            mock_check_is_safe_to_delete.return_value = SuccessFailureMessageTuple(True, [])
 
             document.check_is_safe_as_merge_source()
 
             mock_check_has_only_one_version.assert_called_once()
             mock_check_has_never_been_published.assert_called_once()
+            mock_check_is_safe_to_delete.assert_called_once()
 
     def test_check_is_safe_as_merge_source_bubbles_success_or_failure_on_single_failure(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         document.has_ever_been_published = False
+        document.safe_to_delete = True
 
         with (
             patch.object(document, "check_has_only_one_version") as mock_check_has_only_one_version,
@@ -88,6 +110,7 @@ class TestDocumentSafeAsMergeSource:
 
     def test_check_is_safe_as_merge_source_bubbles_success_or_failure_on_multiple_failures(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.safe_to_delete = True
 
         with (
             patch.object(document, "check_has_only_one_version") as mock_check_has_only_one_version,


### PR DESCRIPTION
## Summary of changes

The API Client should be able to identify if a source document is a suitable candidate for merging onto a target document. Namely:

- [x] The document only has one version
- [x] The document has never been published
- [ ] The document is in a state where it’s safe to delete

This does not cover working out if a source document is safe to merge given a specific target, only that the source document is in a state where it’s safe to even consider as a merge source.

## Checklist

- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
- [ ] I have updated the changelog (if necessary)
