### PR TITLE
Restrict codecov results upload to JUnit file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,5 +75,6 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         with:
+          files: ./junit.xml
           flags: py${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary of changes

Previously this was also accidentally discovering and uploading test document XML, which doesn't contain usable test report data.

## Checklist

- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
- [x] I have updated the changelog (if necessary)
