### PR TITLE
ci(release.yml): add GitHub release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: What's new
+      labels:
+        - "*"
+      exclude:
+        authors:
+          - "renovate[bot]"
+          - "renovate"
+    - title: Renovate
+      labels:
+        - "*"
+      authors:
+        - "renovate[bot]"
+        - "renovate"


### PR DESCRIPTION
This allows GitHub to autogenerate decent release notes for this repository.

nb: Eventually we want to move to a place where this is handled as part of a `cz bump` operation by a workflow, but for now this is an improvement.