### PR TITLE
test(pre-commit): improve regex used for renovate-config-validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
     hooks:
       - id: renovate-config-validator
         args: [--strict]
-        files: renovate.json
+        files: (^|/)renovate\\.json$
 
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.23.1


### PR DESCRIPTION
This improves the regex by only matching files in the root, and properly escaping the `.` in the filename.