### PR TITLE
feat: add `assert_is_publishable` to give reasons for `CannotPublishUnpublishableDocument`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+##  Unreleased
+
+- Add `assert_is_publishable` to give reasons for `CannotPublishUnpublishableDocument`
+
 ## v44.4.5 (2026-02-24)
 
 - Ensure PDFs aren't force-downloaded in Edge (content-disposition was wrong)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,7 +1099,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Release 5.1.2]
 
-** This release had a bug where the Editor UI was unusable. **
+**This release had a bug where the Editor UI was unusable.**
 
 - Ensure Work Date and Court values are returned as text
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -320,6 +320,19 @@ class Document:
         # An empty list (which is falsy) therefore means the judgment can be published safely.
         return not self.validation_failure_messages
 
+    def assert_is_publishable(self) -> None:
+        """
+        Assert that this document is in a state where it can be published, and raise an exception if not.
+
+        :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
+        such cannot be published.
+        """
+        if not self.is_publishable:
+            raise CannotPublishUnpublishableDocument(
+                f"{self.document_noun.capitalize()} {self.uri} cannot be published due to the following issues: "
+                + ", ".join(self.validation_failure_messages),
+            )
+
     @cached_property
     def first_published_datetime(self) -> Optional[datetime.datetime]:
         """
@@ -479,8 +492,7 @@ class Document:
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
         such cannot be published.
         """
-        if not self.is_publishable:
-            raise CannotPublishUnpublishableDocument
+        self.assert_is_publishable()
 
         ## Make sure the document has an FCLID
         self.assign_fclid_if_missing()

--- a/tests/models/documents/test_document_validation.py
+++ b/tests/models/documents/test_document_validation.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from caselawclient.models.documents import Document, DocumentURIString
+from caselawclient.models.documents.exceptions import CannotPublishUnpublishableDocument
 
 
 class TestDocumentValidation:
@@ -154,3 +155,31 @@ class TestDocumentValidation:
                 "The court for this document is not valid",
             ],
         )
+
+    def test_assert_is_publishable_raises_error_if_single_issue(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.has_valid_court = False
+        document.has_name = True
+        document.has_unique_content_hash = True
+
+        msg = "^Document test/1234 cannot be published due to the following issues: The court for this document is not valid$"
+        with pytest.raises(CannotPublishUnpublishableDocument, match=msg):
+            document.assert_is_publishable()
+
+    def test_assert_is_publishable_raises_error_if_multiple_issues(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.has_valid_court = False
+        document.has_name = True
+        document.has_unique_content_hash = False
+
+        msg = "^Document test/1234 cannot be published due to the following issues: The court for this document is not valid, There is another document with identical content$"
+        with pytest.raises(CannotPublishUnpublishableDocument, match=msg):
+            document.assert_is_publishable()
+
+    def test_assert_is_publishable_does_nothing_if_no_issues(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.has_valid_court = True
+        document.has_name = True
+        document.has_unique_content_hash = True
+
+        document.assert_is_publishable()  # doesn't raise an exception


### PR DESCRIPTION
When `publish()`ing an unpublishable document, `CannotPublishUnpublishableDocument` is raises with no explanatory reasons for why it's not publishable. Make a new function that tells you.

<!-- Replace this with a short summary of changes in this PR -->

## Jira

FCLC-556

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
