### PR TITLE
[FCL-1912] Add XML mutation helper methods to XML class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- `get_xpath_match_string`/`get_xpath_match_strings`/`get_xpath_nodes` on both `Body` and `XML` no longer accept namespaces, and will always use the expected default namespaces for documents.
+
+### Feat
+
+- Add XML mutation helper methods to XML class
+
 ## v44.5.0 (2026-04-13)
 
 ### Feat

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -29,14 +29,14 @@ class DocumentBody:
         self._xml = XML(xml_bytestring=xml_bytestring)
         """ This is an instance of the `Document.XML` class for manipulation of the XML document itself. """
 
-    def get_xpath_match_string(self, xpath: str, namespaces: dict[str, str] = DEFAULT_NAMESPACES) -> str:
-        return self._xml.get_xpath_match_string(xpath, namespaces)
+    def get_xpath_match_string(self, xpath: str) -> str:
+        return self._xml.get_xpath_match_string(xpath)
 
-    def get_xpath_match_strings(self, xpath: str, namespaces: dict[str, str] = DEFAULT_NAMESPACES) -> list[str]:
-        return self._xml.get_xpath_match_strings(xpath, namespaces)
+    def get_xpath_match_strings(self, xpath: str) -> list[str]:
+        return self._xml.get_xpath_match_strings(xpath)
 
-    def get_xpath_nodes(self, xpath: str, namespaces: dict[str, str] = DEFAULT_NAMESPACES) -> list[etree._Element]:
-        return self._xml.get_xpath_nodes(xpath, namespaces)
+    def get_xpath_nodes(self, xpath: str) -> list[etree._Element]:
+        return self._xml.get_xpath_nodes(xpath)
 
     @cached_property
     def name(self) -> str:
@@ -55,7 +55,7 @@ class DocumentBody:
     @cached_property
     def categories(self) -> list[DocumentCategory]:
         xpath = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
-        nodes = self.get_xpath_nodes(xpath, DEFAULT_NAMESPACES)
+        nodes = self.get_xpath_nodes(xpath)
 
         categories: dict[str, DocumentCategory] = {}
         children_map: dict[str, list[DocumentCategory]] = {}

--- a/src/caselawclient/models/documents/xml.py
+++ b/src/caselawclient/models/documents/xml.py
@@ -2,7 +2,13 @@ import os
 
 from lxml import etree
 
-from caselawclient.xml_helpers import get_xpath_match_string, get_xpath_match_strings, get_xpath_nodes
+from caselawclient.xml_helpers import (
+    DEFAULT_NAMESPACES,
+    Element,
+    get_xpath_match_string,
+    get_xpath_match_strings,
+    get_xpath_nodes,
+)
 
 
 def _xslt_path(xslt_file_name: str) -> str:
@@ -25,7 +31,7 @@ class XML:
         :raises NonXMLDocumentError: This document is not valid XML
         """
         try:
-            self.xml_as_tree: etree._Element = etree.fromstring(xml_bytestring)
+            self.xml_as_tree: Element = etree.fromstring(xml_bytestring)
         except etree.XMLSyntaxError:
             raise NonXMLDocumentError
 
@@ -37,21 +43,26 @@ class XML:
         return str(etree.tostring(self.xml_as_tree).decode(encoding="utf-8"))
 
     @property
+    def xml_as_bytes(self) -> bytes:
+        """
+        Return XML tree as bytes (namespace-aware, canonicalized).
+
+        :return: The XML tree serialized to bytes
+        """
+        return etree.tostring(self.xml_as_tree, method="c14n2")
+
+    @property
     def root_element(self) -> str:
         return str(self.xml_as_tree.tag)
 
-    def get_xpath_match_string(self, xpath: str, namespaces: dict[str, str]) -> str:
-        return get_xpath_match_string(self.xml_as_tree, xpath, namespaces)
+    def get_xpath_match_string(self, xpath: str) -> str:
+        return get_xpath_match_string(self.xml_as_tree, xpath, DEFAULT_NAMESPACES)
 
-    def get_xpath_match_strings(
-        self,
-        xpath: str,
-        namespaces: dict[str, str],
-    ) -> list[str]:
-        return get_xpath_match_strings(self.xml_as_tree, xpath, namespaces)
+    def get_xpath_match_strings(self, xpath: str) -> list[str]:
+        return get_xpath_match_strings(self.xml_as_tree, xpath, DEFAULT_NAMESPACES)
 
-    def get_xpath_nodes(self, xpath: str, namespaces: dict[str, str]) -> list[etree._Element]:
-        return get_xpath_nodes(self.xml_as_tree, xpath, namespaces)
+    def get_xpath_nodes(self, xpath: str) -> list[Element]:
+        return get_xpath_nodes(self.xml_as_tree, xpath, DEFAULT_NAMESPACES)
 
     def _modified(
         self,
@@ -70,3 +81,71 @@ class XML:
         with open(full_xslt_filename) as f:
             xslt = f.read()
         return self._modified(xslt, **values)
+
+    def get_or_create_element(self, parent_xpath: str, element_name: str, namespace: str | None = None) -> Element:
+        """
+        Get an existing child element or create a new one.
+
+        :param parent_xpath: XPath expression to find the parent element
+        :param element_name: Name of the child element (local name without prefix)
+        :param namespace: Optional namespace URI. Must exist in DEFAULT_NAMESPACES values if provided.
+        :return: The existing or newly created element
+        :raises ValueError: If parent not found at xpath, if multiple parents found, or if namespace not in DEFAULT_NAMESPACES
+        """
+        parent_nodes = self.get_xpath_nodes(parent_xpath)
+        if not parent_nodes:
+            raise ValueError(f"No parent element found at xpath: {parent_xpath}")
+        if len(parent_nodes) > 1:
+            raise ValueError(
+                f"XPath expression matches {len(parent_nodes)} parent elements, expected exactly 1: {parent_xpath}"
+            )
+
+        parent = parent_nodes[0]
+
+        # Validate namespace if provided
+        if namespace is not None:
+            valid_namespaces = set(DEFAULT_NAMESPACES.values())
+            if namespace not in valid_namespaces:
+                raise ValueError(f"Namespace not in DEFAULT_NAMESPACES: {namespace}")
+            qname = etree.QName(namespace, element_name)
+        else:
+            qname = etree.QName(element_name)
+
+        # Safety check: ensure no duplicate children exist
+        existing_children = parent.findall(qname)
+        if len(existing_children) > 1:
+            raise ValueError(
+                f"Multiple child elements with name {element_name} already exist in parent at {parent_xpath}"
+            )
+
+        # Check if child already exists
+        existing = existing_children[0] if existing_children else None
+        if existing is not None:
+            return existing
+
+        # Create new child element
+        new_element = etree.SubElement(parent, qname)
+        return new_element
+
+    def set_element_attribute(self, element: Element, attribute_name: str, attribute_value: str) -> None:
+        """
+        Set an attribute on an element.
+
+        :param element: The element to modify
+        :param attribute_name: Name of the attribute to set
+        :param attribute_value: Value to set
+        """
+        element.set(attribute_name, attribute_value)
+
+    def set_element_value(
+        self,
+        element: Element,
+        value: str,
+    ) -> None:
+        """
+        Set an element's text value.
+
+        :param element: The element to modify
+        :param value: Value to set as text content
+        """
+        element.text = value

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -31,13 +31,7 @@ class Judgment(NeutralCitationMixin, Document):
 
     @cached_property
     def neutral_citation(self) -> Optional[NeutralCitationString]:
-        value_in_xml = self.body.get_xpath_match_string(
-            "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:cite/text()",
-            {
-                "uk": "https://caselaw.nationalarchives.gov.uk/akn",
-                "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
-            },
-        )
+        value_in_xml = self.body.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:cite/text()")
         if value_in_xml:
             return NeutralCitationString(value_in_xml)
         return None

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -33,10 +33,7 @@ class PressSummary(NeutralCitationMixin, Document):
     @cached_property
     def neutral_citation(self) -> Optional[NeutralCitationString]:
         value_in_xml = self.body.get_xpath_match_string(
-            "/akn:akomaNtoso/akn:doc/akn:preface/akn:p/akn:neutralCitation/text()",
-            {
-                "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
-            },
+            "/akn:akomaNtoso/akn:doc/akn:preface/akn:p/akn:neutralCitation/text()"
         )
         if value_in_xml:
             return NeutralCitationString(value_in_xml)

--- a/tests/models/documents/test_document_xml.py
+++ b/tests/models/documents/test_document_xml.py
@@ -1,8 +1,18 @@
+import os
+
 import pytest
 from lxml import etree
 
 from caselawclient.models.documents.body import DEFAULT_NAMESPACES
 from caselawclient.models.documents.xml import XML, NonXMLDocumentError
+
+
+@pytest.fixture
+def full_document_xml():
+    """Load the test document XML from file."""
+    test_file_path = os.path.join(os.path.dirname(__file__), "xslt", "test_standard_judgment.xml")
+    with open(test_file_path, "rb") as f:
+        return f.read()
 
 
 class TestDocumentXml:
@@ -55,3 +65,230 @@ class TestDocumentXml:
                            </FRBRWork> </identification></meta><header></header><judgmentBody><decision><p>This is a document.</p></decision></judgmentBody></judgment></akomaNtoso>""")
         modified_xml = document_xml.apply_xslt("sample.xsl")
         assert b"<FRBRthis" in modified_xml
+
+    def test_xml_as_bytes_returns_canonicalized_xml(self, full_document_xml):
+        """Test that xml_as_bytes returns canonicalized XML bytes."""
+        document_xml = XML(full_document_xml)
+        result = document_xml.xml_as_bytes
+
+        # Should be bytes
+        assert isinstance(result, bytes)
+
+        # Should be parseable XML
+        tree = etree.fromstring(result)
+        assert tree.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}akomaNtoso"
+
+    def test_set_element_attribute_updates_existing_attribute(self, full_document_xml):
+        """Test that set_element_attribute updates an existing attribute value."""
+        document_xml = XML(full_document_xml)
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname"
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 1
+
+        document_xml.set_element_attribute(nodes[0], "value", "New Case Name")
+
+        # Verify the attribute was updated
+        result = document_xml.get_xpath_match_string(xpath + "/@value")
+        assert result == "New Case Name"
+
+    def test_get_xpath_nodes_returns_empty_for_nonexistent_element(self, full_document_xml):
+        """Test that get_xpath_nodes returns empty list for non-existent elements."""
+        document_xml = XML(full_document_xml)
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:NonExistentElement"
+
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 0
+
+    def test_set_element_attribute_detects_multiple_matches(self):
+        """Test that get_xpath_nodes can return multiple elements."""
+        # Create XML with multiple matching elements
+        multi_match_xml = b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+            <judgment>
+                <p>First</p>
+                <p>Second</p>
+                <p>Third</p>
+            </judgment>
+        </akomaNtoso>"""
+        document_xml = XML(multi_match_xml)
+        # XPath that matches multiple <p> elements
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:p"
+
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 3
+        # Caller must validate before using set_element_attribute
+        assert len(nodes) > 1
+
+    def test_get_or_create_element_returns_existing_element(self, full_document_xml):
+        """Test that get_or_create_element returns existing child element."""
+        document_xml = XML(full_document_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork"
+
+        # Get existing FRBRname element
+        result = document_xml.get_or_create_element(
+            parent_xpath, "FRBRname", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+        )
+
+        # Should return the existing element with its current value
+        assert result is not None
+        assert result.get("value") is not None
+
+    def test_get_or_create_element_creates_new_element(self, full_document_xml):
+        """Test that get_or_create_element creates a new element if it doesn't exist."""
+        document_xml = XML(full_document_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork"
+
+        # Create a new element that doesn't exist
+        result = document_xml.get_or_create_element(
+            parent_xpath, "FRBRcustom", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+        )
+
+        # Should return the new element
+        assert result is not None
+        assert result.tag == "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}FRBRcustom"
+
+        # Verify it's in the tree
+        verify_xpath = parent_xpath + "/akn:FRBRcustom"
+        nodes = document_xml.get_xpath_nodes(verify_xpath)
+        assert len(nodes) == 1
+        assert nodes[0] is result
+
+    def test_get_or_create_element_with_namespace_prefix(self, full_document_xml):
+        """Test that get_or_create_element correctly handles namespace URIs."""
+        document_xml = XML(full_document_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary"
+
+        # Create element with explicit uk namespace
+        result = document_xml.get_or_create_element(
+            parent_xpath, "customElement", "https://caselaw.nationalarchives.gov.uk/akn"
+        )
+
+        assert result is not None
+        assert result.tag == "{https://caselaw.nationalarchives.gov.uk/akn}customElement"
+
+        # Verify it's in the tree under the correct namespace
+        verify_xpath = parent_xpath + "/uk:customElement"
+        nodes = document_xml.get_xpath_nodes(verify_xpath)
+        assert len(nodes) == 1
+
+    def test_get_or_create_element_raises_error_if_parent_not_found(self, full_document_xml):
+        """Test that get_or_create_element raises ValueError if parent element doesn't exist."""
+        document_xml = XML(full_document_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:NonExistent"
+
+        with pytest.raises(ValueError, match="No parent element found"):
+            document_xml.get_or_create_element(
+                parent_xpath, "child", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+            )
+
+    def test_get_or_create_element_raises_error_if_multiple_parents_match(self):
+        """Test that get_or_create_element raises ValueError if XPath matches multiple parent elements."""
+        # Create XML with multiple matching parent elements
+        multi_parent_xml = b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+            <judgment>
+                <section><p>First</p></section>
+                <section><p>Second</p></section>
+                <section><p>Third</p></section>
+            </judgment>
+        </akomaNtoso>"""
+        document_xml = XML(multi_parent_xml)
+        # XPath that matches multiple <section> elements
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:section"
+
+        with pytest.raises(ValueError, match="XPath expression matches 3 parent elements, expected exactly 1"):
+            document_xml.get_or_create_element(
+                parent_xpath, "child", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+            )
+
+    def test_get_or_create_element_raises_error_if_invalid_namespace(self, full_document_xml):
+        """Test that get_or_create_element raises ValueError if namespace is not in DEFAULT_NAMESPACES."""
+        document_xml = XML(full_document_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork"
+
+        with pytest.raises(ValueError, match="Namespace not in DEFAULT_NAMESPACES"):
+            document_xml.get_or_create_element(parent_xpath, "child", "http://invalid.namespace.org/")
+
+    def test_get_or_create_element_raises_error_if_duplicate_children_exist(self):
+        """Test that get_or_create_element raises ValueError if multiple children with same name already exist."""
+        # Create XML with duplicate children
+        duplicate_children_xml = b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+            <judgment>
+                <meta>
+                    <identification>
+                        <FRBRWork>
+                            <FRBRname value="first"/>
+                            <FRBRname value="second"/>
+                        </FRBRWork>
+                    </identification>
+                </meta>
+            </judgment>
+        </akomaNtoso>"""
+        document_xml = XML(duplicate_children_xml)
+        parent_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork"
+
+        with pytest.raises(ValueError, match="Multiple child elements with name FRBRname already exist"):
+            document_xml.get_or_create_element(
+                parent_xpath, "FRBRname", "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+            )
+
+    def test_set_element_value_sets_text_on_existing_element(self, full_document_xml):
+        """Test that set_element_value sets element text on existing element."""
+        document_xml = XML(full_document_xml)
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court"
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 1
+
+        document_xml.set_element_value(nodes[0], "Supreme Court")
+
+        # Verify the value was set
+        result = document_xml.get_xpath_match_string(xpath + "/text()")
+        assert result == "Supreme Court"
+
+    def test_mutation_persists_in_tree(self, full_document_xml):
+        """Test that mutations persist in the XML tree and can be retrieved."""
+        document_xml = XML(full_document_xml)
+
+        # Perform multiple mutations
+        name_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname"
+        name_nodes = document_xml.get_xpath_nodes(name_xpath)
+        assert len(name_nodes) == 1
+        document_xml.set_element_attribute(name_nodes[0], "value", "Updated Case Name")
+
+        court_xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court"
+        court_nodes = document_xml.get_xpath_nodes(court_xpath)
+        assert len(court_nodes) == 1
+        document_xml.set_element_value(court_nodes[0], "New Court")
+
+        # Verify both mutations persisted by re-querying
+        assert document_xml.get_xpath_match_string(name_xpath + "/@value") == "Updated Case Name"
+        assert document_xml.get_xpath_match_string(court_xpath + "/text()") == "New Court"
+
+    def test_mutation_reflects_in_serialized_xml(self, full_document_xml):
+        """Test that mutations reflect in serialized XML output."""
+        document_xml = XML(full_document_xml)
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname"
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 1
+
+        document_xml.set_element_attribute(nodes[0], "value", "Updated Title")
+
+        # Get serialized XML
+        serialized = document_xml.xml_as_bytes.decode("utf-8")
+
+        # Verify the updated value is in the serialized output
+        assert "Updated Title" in serialized
+
+    def test_namespace_preservation_in_mutations(self, full_document_xml):
+        """Test that namespace declarations are preserved after mutations."""
+        document_xml = XML(full_document_xml)
+        xpath = "/akn:akomaNtoso/akn:judgment/akn:meta/akn:proprietary/uk:court"
+        nodes = document_xml.get_xpath_nodes(xpath)
+        assert len(nodes) == 1
+
+        document_xml.set_element_value(nodes[0], "Updated")
+
+        # Serialize and check namespace declarations
+        serialized = document_xml.xml_as_bytes.decode("utf-8")
+
+        # Both namespace declarations should still be present
+        assert "http://docs.oasis-open.org/legaldocml/ns/akn/3.0" in serialized
+        assert "https://caselaw.nationalarchives.gov.uk/akn" in serialized

--- a/tests/models/documents/xslt/test_standard_judgment.xml
+++ b/tests/models/documents/xslt/test_standard_judgment.xml
@@ -27,6 +27,10 @@
                     <FRBRformat value="application/xml" />
                 </FRBRManifestation>
             </identification>
+            <proprietary>
+                <uk:court>Original Court</uk:court>
+                <uk:jurisdiction>Original Jurisdiction</uk:jurisdiction>
+            </proprietary>
         </meta>
         <header>
             <p><img src="image1.png" style="width:99.05pt;height:99.05pt"/></p>


### PR DESCRIPTION
These methods support the in-memory XML mutations needed for the upcoming `Document.set_*()` setter methods.

- Add xml_as_bytes property to serialize XML to canonicalized bytes
- Add set_element_attribute() for setting element attributes by XPath
- Add get_or_create_element() to get or create child elements
- Add set_element_element_value() for setting element text values by XPath

## Jira

FCL-1912

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
