### PR TITLE
[FCL-2498] Add document save method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
           - types-python-dateutil==2.9.0.20260408
           - types-pytz==2026.1.1.20260408
           - types-lxml==2026.2.16
+          - types-defusedxml==0.7.0.20260408
           - ds-caselaw-utils==4.2.0
           - pydantic==2.13.3
         exclude: ^smoketest/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Document**: add method to save document to MarkLogic
+
 ## v45.0.1 (2026-04-28)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - **Document**: add method to save document to MarkLogic
 
+### Refactor
+
+- swap from defusedxml to lxml for serialisation
+
 ## v45.0.1 (2026-04-28)
 
 ### Fix

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -269,12 +269,13 @@ class MarklogicApiClient:
             return "Unknown error, Marklogic returned a null or empty response"
         try:
             xml = fromstring(content_as_xml)
-            return str(
-                xml.find(
-                    "message-code",
-                    namespaces={"": "http://marklogic.com/xdmp/error"},
-                ).text
+            message_code_element = xml.find(
+                "message-code",
+                namespaces={"": "http://marklogic.com/xdmp/error"},
             )
+            if message_code_element is None or message_code_element.text is None:
+                return "Unknown error, Marklogic returned a null or empty response"
+            return str(message_code_element.text)
         except (ParseError, TypeError, AttributeError):
             return "Unknown error, Marklogic returned a null or empty response"
 
@@ -592,7 +593,7 @@ class MarklogicApiClient:
 
         :return: The response object from MarkLogic
         """
-        xml = ElementTree.tostring(document_xml)
+        xml = etree.tostring(document_xml)
 
         uri = self._format_uri_for_marklogic(document_uri)
 
@@ -625,7 +626,7 @@ class MarklogicApiClient:
 
         :return: The response object from MarkLogic
         """
-        xml = ElementTree.tostring(document_xml)
+        xml = etree.tostring(document_xml)
 
         uri = self._format_uri_for_marklogic(document_uri)
 
@@ -697,12 +698,13 @@ class MarklogicApiClient:
         if content == "":
             return None
         response_xml = ElementTree.fromstring(content)
-        return str(
-            response_xml.find(
-                "dls:annotation",
-                namespaces={"dls": "http://marklogic.com/xdmp/dls"},
-            ).text
+        annotation_element = response_xml.find(
+            "dls:annotation",
+            namespaces={"dls": "http://marklogic.com/xdmp/dls"},
         )
+        if annotation_element is None or annotation_element.text is None:
+            return None
+        return str(annotation_element.text)
 
     def get_judgment_version(
         self,

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -7,7 +7,6 @@ import warnings
 from datetime import datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Optional, Type, Union
-from xml.etree.ElementTree import Element
 
 import environ
 import requests
@@ -33,6 +32,7 @@ from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities import move
 from caselawclient.search_parameters import SearchParameters
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue, DocumentLock, DocumentURIString
+from caselawclient.xml_helpers import Element
 from caselawclient.xquery_type_dicts import (
     CheckContentHashUniqueByUriDict,
     MarkLogicDocumentURIString,

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -18,7 +18,7 @@ from caselawclient.errors import (
     OnlySupportedOnVersion,
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
-from caselawclient.models.documents.versions import AnnotationDataDict
+from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier, FindCaseLawIdentifierSchema
@@ -487,6 +487,28 @@ class Document:
             return document_fclid
 
         return None
+
+    def save(self, message: str) -> None:
+        """
+        Save the document's XML representation back to MarkLogic as a new version.
+
+        Creates a new version with type EDIT, recording the changes made to the document.
+
+        :param message: Human-readable message describing the changes made.
+        """
+        # Create annotation for this version
+        annotation = VersionAnnotation(
+            version_type=VersionType.EDIT,
+            automated=False,
+            message=message,
+        )
+
+        # Update the document XML in MarkLogic
+        self.api_client.update_document_xml(
+            self.uri,
+            self.body.content_as_xml_tree,
+            annotation,
+        )
 
     def publish(self) -> None:
         """

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -11,7 +11,7 @@ from saxonche import PySaxonProcessor
 
 from caselawclient.models.utilities.dates import parse_string_date_as_utc
 from caselawclient.types import DocumentCategory
-from caselawclient.xml_helpers import DEFAULT_NAMESPACES
+from caselawclient.xml_helpers import DEFAULT_NAMESPACES, Element
 
 from .xml import XML
 
@@ -168,6 +168,11 @@ class DocumentBody:
     @cached_property
     def content_as_xml(self) -> str:
         return self._xml.xml_as_string
+
+    @property
+    def content_as_xml_tree(self) -> Element:
+        """Get the XML tree representation of the document."""
+        return self._xml.xml_as_tree
 
     @cached_property
     def has_content(self) -> bool:

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -125,6 +125,49 @@ class TestGetCheckoutStatus(unittest.TestCase):
             result = self.client.get_judgment_checkout_status_message(DocumentURIString("ewca/2002/2"))
             assert result is None
 
+    def test_get_checkout_status_message_missing_annotation_element(self):
+        with patch.object(MarklogicApiClient, "eval") as mock_eval:
+            mock_eval.return_value.text = "true"
+            mock_eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
+            }
+            # XML response without dls:annotation element
+            mock_eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"Content-Type: application/xml\r\n"
+                b"X-Primitive: element()\r\n"
+                b"X-Path: /*\r\n\r\n"
+                b'<dls:checkout xmlns:dls="http://marklogic.com/xdmp/dls">'
+                b"<dls:document-uri>/ukpc/2022/17.xml</dls:document-uri>"
+                b"<dls:timeout>0</dls:timeout>"
+                b"</dls:checkout>"
+                b"\r\n--595658fa1db1aa98--\r\n"
+            )
+            result = self.client.get_judgment_checkout_status_message(DocumentURIString("ewca/2002/2"))
+            assert result is None
+
+    def test_get_checkout_status_message_annotation_element_no_text(self):
+        with patch.object(MarklogicApiClient, "eval") as mock_eval:
+            mock_eval.return_value.text = "true"
+            mock_eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
+            }
+            # XML response with dls:annotation element but no text content
+            mock_eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"Content-Type: application/xml\r\n"
+                b"X-Primitive: element()\r\n"
+                b"X-Path: /*\r\n\r\n"
+                b'<dls:checkout xmlns:dls="http://marklogic.com/xdmp/dls">'
+                b"<dls:document-uri>/ukpc/2022/17.xml</dls:document-uri>"
+                b"<dls:annotation></dls:annotation>"
+                b"<dls:timeout>0</dls:timeout>"
+                b"</dls:checkout>"
+                b"\r\n--595658fa1db1aa98--\r\n"
+            )
+            result = self.client.get_judgment_checkout_status_message(DocumentURIString("ewca/2002/2"))
+            assert result is None
+
     def test_calculate_seconds_until_midnight(self):
         dt = datetime.strptime(
             "2020-01-01 23:00",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -234,3 +234,17 @@ class ApiClientTest(unittest.TestCase):
             result,
             "Unknown error, Marklogic returned a null or empty response",
         )
+
+    def test_get_error_code_message_code_element_no_text(self):
+        xml_string = """
+        <error-response xmlns="http://marklogic.com/xdmp/error">
+            <status-code>500</status-code>
+            <status>Internal Server Error</status>
+            <message-code></message-code>
+        </error-response>
+        """
+        result = self.client._get_error_code(xml_string)
+        self.assertEqual(
+            result,
+            "Unknown error, Marklogic returned a null or empty response",
+        )

--- a/tests/client/test_save_copy_delete_judgment.py
+++ b/tests/client/test_save_copy_delete_judgment.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import pytest
-from defusedxml import ElementTree
+from lxml import etree
 
 import caselawclient.Client
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
@@ -28,7 +28,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             uri = DocumentURIString("ewca/civ/2004/632")
             judgment_str = "<root>My updated judgment</root>"
-            judgment_xml = ElementTree.fromstring(judgment_str)
+            judgment_xml = etree.fromstring(judgment_str)
             expected_vars = {
                 "uri": "/ewca/civ/2004/632.xml",
                 "judgment": judgment_str,
@@ -128,7 +128,7 @@ class TestSaveCopyDeleteJudgment(unittest.TestCase):
         with patch.object(self.client, "eval") as mock_eval:
             uri = DocumentURIString("ewca/civ/2004/632")
             document_str = "<root>My judgment</root>"
-            document_xml = ElementTree.fromstring(document_str)
+            document_xml = etree.fromstring(document_str)
             expected_vars = {
                 "uri": "/ewca/civ/2004/632.xml",
                 "type_collection": "judgment",

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -1,0 +1,63 @@
+"""Tests for Document.save() method."""
+
+from unittest.mock import patch
+
+from caselawclient.factories import DocumentFactory
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.versions import VersionAnnotation, VersionType
+
+
+class TestDocumentSave:
+    """Tests for the Document.save() method."""
+
+    def test_save_calls_update_document_xml(self):
+        """Test that save() calls update_document_xml exactly once."""
+        uri = DocumentURIString("test/2023/101")
+        document = DocumentFactory.build(uri=uri)
+
+        with patch.object(document.api_client, "update_document_xml") as mock_update:
+            document.save(message="Changed document")
+
+            mock_update.assert_called_once()
+
+    def test_save_creates_edit_annotation(self):
+        """Test that save() creates an EDIT annotation with automated=False."""
+        uri = DocumentURIString("test/2023/123")
+        document = DocumentFactory.build(uri=uri)
+
+        with patch.object(document.api_client, "update_document_xml") as mock_update:
+            document.save(message="Changed document")
+
+            # Verify the annotation was created correctly
+            call_args = mock_update.call_args
+            annotation = call_args[0][2]
+            assert isinstance(annotation, VersionAnnotation)
+            assert annotation.version_type == VersionType.EDIT
+            assert annotation.automated is False
+
+    def test_save_passes_uri_and_xml_to_api(self):
+        """Test that save() passes the correct URI and XML to the API."""
+        uri = DocumentURIString("test/2023/456")
+        document = DocumentFactory.build(uri=uri)
+        expected_xml = document.body.content_as_xml_tree
+
+        with patch.object(document.api_client, "update_document_xml") as mock_update:
+            document.save(message="Changed document")
+
+            # Verify the correct URI and XML are passed
+            call_args = mock_update.call_args
+            assert call_args[0][0] == uri
+            assert call_args[0][1] is expected_xml
+
+    def test_save_with_message_includes_message_in_annotation(self):
+        """Test that save() includes the message in the annotation."""
+        uri = DocumentURIString("test/2023/789")
+        document = DocumentFactory.build(uri=uri)
+        test_message = "Fixed typo in court name"
+
+        with patch.object(document.api_client, "update_document_xml") as mock_update:
+            document.save(message=test_message)
+
+            call_args = mock_update.call_args
+            annotation = call_args[0][2]
+            assert annotation.message == test_message


### PR DESCRIPTION
This adds the ability to call `Document.save()`, which will write the updated document XML to MarkLogic as a new version.

## Jira

FCLC-1498

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
