### PR TITLE
[FCLC-1824] fix(DocumentBody): remove cache on content_html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- **DocumentBody**: remove cache on content_html
 - test now correctly checks for existing value
 - fix bad test naming and redundant assertion
 

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import warnings
-from functools import cache, cached_property
+from functools import cached_property
 from typing import Optional
 
 import pytz
@@ -186,7 +186,6 @@ class DocumentBody:
         "is there a uk:party tag" is intended as a stopgap whilst we're not importing that data."""
         return bool(self._xml.xml_as_tree.xpath("//uk:party", namespaces=DEFAULT_NAMESPACES))
 
-    @cache
     def content_html(self, image_prefix: str) -> Optional[str]:
         """Convert the XML representation of the Document into HTML for rendering."""
         """This used to be called content_as_html but we have changed the parameter passed to it from the

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import warnings
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from lxml import etree
@@ -394,13 +394,13 @@ class TestLinkedDocumentResolutions:
 
     @patch.dict(os.environ, {"XSLT_IMAGE_LOCATION": "imagepath"}, clear=True)
     class TestDocumentContentAsHtml:
-        def test_document_content_as_html_calls_with_uri(self):
+        @patch("caselawclient.models.documents.DocumentBody.content_html", return_value="html")
+        def test_document_content_as_html_calls_with_uri(self, mock_content_html):
             doc = DocumentFactory.build(
                 uri=DocumentURIString("test/1234"), body=DocumentBodyFactory.build(name="docname")
             )
-            doc.body.content_html = Mock()
             doc.content_as_html()
-            doc.body.content_html.assert_called_with("imagepath/test/1234")
+            mock_content_html.assert_called_with("imagepath/test/1234")
 
 
 class TestDocumentXMLWithCorrectFRBR:


### PR DESCRIPTION
This is our chief suspect in some leaky memory behaviour; cache maintains a function-level cache of rendered HTML, but thanks to the inclusion of `self` is also effectively preventing every `DocumentBody` instance - potentially multiple per document (one per request, even for the same document) - from being garbage collected whilst not actually offering any cache benefits.

All user-facing rendered HTML should be cached at another layer already, so this is actually just wasting cycles and more crucially just chewing up memory until instances fall over.
