### PR TITLE
bump: version 44.5.0 → 45.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v45.0.0 (2026-04-22)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "44.5.0"
+version = "45.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- Remove `XML.xml_as_bytes()`
- `get_xpath_match_string`/`get_xpath_match_strings`/`get_xpath_nodes` on both `Body` and `XML` no longer accept namespaces, and will always use the expected default namespaces for documents.

### Feat

- **XML**: add new get_single_xpath_node method
- Add XML mutation helper methods to XML class

### Fix

- **DocumentBody**: remove cache on content_html
- test now correctly checks for existing value
- fix bad test naming and redundant assertion

### Refactor

- **XML**: remove redundant serialisation method and tests