### PR TITLE
refactor: replace print debug statements with tiered logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Refactor
+
+- replace print debug statements with tiered logging
+
 ## v45.0.0 (2026-04-22)
 
 ### BREAKING CHANGE

--- a/assertions/assert.py
+++ b/assertions/assert.py
@@ -1,9 +1,12 @@
 import glob
+import logging
 
 import environ
 from dotenv import load_dotenv
 
 from caselawclient import Client
+
+logger = logging.getLogger(__name__)
 
 load_dotenv()
 env = environ.Env()
@@ -19,6 +22,6 @@ files = glob.glob("*.xqy")
 
 for file in files:
     path = f"../../../assertions/{file}"
-    print(path)
+    logger.info("Evaluating: %s", path)
     response = api_client._send_to_eval({}, path)  ## noqa: SLF001
-    print(Client.get_multipart_strings_from_marklogic_response(response))
+    logger.info("Response: %s", Client.get_multipart_strings_from_marklogic_response(response))

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -74,6 +74,8 @@ DEFAULT_USER_AGENT = f"ds-caselaw-marklogic-api-client/{VERSION}"
 
 DEBUG: bool = bool(os.getenv("DEBUG", default=False))
 
+logger = logging.getLogger(__name__)
+
 
 class NoResponse(Exception):
     """A requests HTTPError has no response. We expect this will never happen."""
@@ -251,7 +253,7 @@ class MarklogicApiClient:
         for regex, error in self.error_code_classes.items():
             if re.fullmatch(regex, error_code):
                 return error
-        print(f"No error code match found for {error_code}")
+        logger.warning("No error code match found for %s", error_code)
         return self.default_http_error_class
 
     def _path_to_request_url(self, path: str) -> str:
@@ -259,7 +261,7 @@ class MarklogicApiClient:
 
     @classmethod
     def _get_error_code(cls, content_as_xml: Optional[str]) -> str:
-        logging.warning(
+        logger.warning(
             "XMLTools is deprecated and will be removed in later versions. "
             "Use methods from MarklogicApiClient.Client instead.",
         )
@@ -384,7 +386,7 @@ class MarklogicApiClient:
         return response
 
     def GET(self, path: str, headers: dict[str, Any], **data: Any) -> requests.Response:
-        logging.warning("GET() is deprecated, use eval() or invoke()")
+        logger.warning("GET() is deprecated, use eval() or invoke()")
         return self.make_request("GET", path, headers, data)  # type: ignore
 
     def POST(
@@ -393,7 +395,7 @@ class MarklogicApiClient:
         headers: dict[str, Any],
         **data: Any,
     ) -> requests.Response:
-        logging.warning("POST() is deprecated, use eval() or invoke()")
+        logger.warning("POST() is deprecated, use eval() or invoke()")
         return self.make_request("POST", path, headers, data)  # type: ignore
 
     def document_exists(self, document_uri: DocumentURIString) -> bool:
@@ -744,6 +746,9 @@ class MarklogicApiClient:
         accept_header: str = "multipart/mixed",
         timeout: tuple[float, float] = (CONNECT_TIMEOUT, READ_TIMEOUT),
     ) -> requests.Response:
+
+        logger.debug("Evaluating XQuery at %s with variables %s", xquery_path, vars)
+
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
             "Accept": accept_header,
@@ -753,9 +758,6 @@ class MarklogicApiClient:
             "vars": vars,
         }
         path = "LATEST/eval"
-
-        if DEBUG:
-            print(f"Sending {vars} to {xquery_path}")
 
         response = self.session.request(
             "POST",

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 import warnings
 from functools import cached_property
@@ -40,6 +41,8 @@ from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple
 from .body import DocumentBody
 from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
+
+logger = logging.getLogger(__name__)
 
 MINIMUM_ENRICHMENT_TIME = datetime.timedelta(minutes=20)
 
@@ -440,10 +443,10 @@ class Document:
         Request enrichment of a document, if it's sensible to do so.
         """
         if not (even_if_recent) and self.enriched_recently:
-            print("Enrichment not requested as document was enriched recently")
+            logger.info("Enrichment not requested as document was enriched recently")
             return False
 
-        print("Enrichment requested")
+        logger.info("Enrichment requested for %s", self.uri)
 
         try:
             self.force_enrich()

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -18,6 +18,8 @@ from caselawclient.types import DocumentURIString
 
 env = environ.Env()
 
+logger = logging.getLogger(__name__)
+
 
 class S3PrefixString(str):
     def __new__(cls, content: str) -> "S3PrefixString":
@@ -166,18 +168,21 @@ def publish_documents(uri: DocumentURIString) -> None:
     response = client.list_objects(Bucket=private_bucket, Prefix=uri_for_s3(uri))
 
     for result in response.get("Contents", []):
-        print(f"Contemplating copying {result!r}")
+        logger.debug("Contemplating copying %r", result)
         key = str(result["Key"])
 
         if not key.endswith("parser.log") and not key.endswith(".tar.gz"):
             source: CopySourceTypeDef = {"Bucket": private_bucket, "Key": key}
             extra_args: dict[str, str] = {}
             try:
-                print(f"Copying {key!r} from {private_bucket!r} to {public_bucket!r}")
+                logger.debug("Copying %s from %s to %s", key, private_bucket, public_bucket)
                 client.copy(source, public_bucket, key, extra_args)
             except botocore.client.ClientError as e:
-                logging.warning(
-                    f"Unable to copy file {key} to new location {public_bucket}, error: {e}",
+                logger.warning(
+                    "Unable to copy file %s to new location %s, error: %s",
+                    key,
+                    public_bucket,
+                    e,
                 )
 
 
@@ -240,8 +245,11 @@ def copy_assets(old_uri: DocumentURIString, new_uri: DocumentURIString) -> None:
             source: CopySourceTypeDef = {"Bucket": bucket, "Key": old_key}
             client.copy(source, bucket, new_key)
         except botocore.client.ClientError as e:
-            logging.warning(
-                f"Unable to copy file {old_key} to new location {new_key}, error: {e}",
+            logger.warning(
+                "Unable to copy file %s to new location %s, error: %s",
+                old_key,
+                new_key,
+                e,
             )
 
 

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -19,6 +19,8 @@ from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_fro
 from caselawclient.types import DocumentURIString
 from caselawclient.xml_helpers import get_xpath_match_string
 
+logger = logging.getLogger(__name__)
+
 
 class EditorStatus(Enum):
     """
@@ -182,7 +184,7 @@ class SearchResult:
         identifiers_etrees = self._get_xpath(".//identifiers")
         count = len(identifiers_etrees)
         if count != 1:
-            logging.warning(f"{count} //identifiers nodes found in search result, expected 1.")
+            logger.warning("%s //identifiers nodes found in search result, expected 1.", count)
         identifiers_etree = None if not identifiers_etrees else identifiers_etrees[0]
         return unpack_all_identifiers_from_etree(identifiers_etree)
 
@@ -233,17 +235,20 @@ class SearchResult:
                     CourtCode(court_code), JurisdictionCode(jurisdiction_code)
                 )
             except CourtNotFoundException:
-                logging.warning(
-                    "Court not found with court code %s and jurisdiction code %s for judgment with NCN %s, falling back to court."
-                    % (court_code, jurisdiction_code, self.neutral_citation),
+                logger.warning(
+                    "Court not found with court code %s and jurisdiction code %s for judgment with NCN %s, falling back to court.",
+                    court_code,
+                    jurisdiction_code,
+                    self.neutral_citation,
                 )
         if court is None:
             try:
                 court = courts.get_by_code(CourtCode(court_code))
             except CourtNotFoundException:
-                logging.warning(
-                    "Court not found with court code %s for judgment with NCN %s, returning None."
-                    % (court_code, self.neutral_citation),
+                logger.warning(
+                    "Court not found with court code %s for judgment with NCN %s, returning None.",
+                    court_code,
+                    self.neutral_citation,
                 )
                 court = None
         return court
@@ -260,8 +265,10 @@ class SearchResult:
         try:
             date = dateparser.parse(date_string)
         except ParserError as e:
-            logging.warning(
-                f'Unable to parse document date "{date_string}". Full error: {e}',
+            logger.warning(
+                'Unable to parse document date "%s". Full error: %s',
+                date_string,
+                e,
             )
             date = None
         return date

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -225,7 +225,7 @@ class TestSearchResultIdentifierHandling:
             search_result.slug
         assert str(search_result) == "<SearchResult a/c/2015/20 **NO SLUG** **NO NAME** None>"
 
-    @patch("logging.warning")
+    @patch("caselawclient.responses.search_result.logger.warning")
     def test_has_many_identifiers(self, logging_warning):
         """
         GIVEN an XML node with multiple identifiers
@@ -265,7 +265,7 @@ class TestSearchResultIdentifierHandling:
         (identifier_1,) = identifiers.values()
         assert identifier_1.value == "[1901] UKSC 1"
         assert search_result.slug == "uksc/1901/1"
-        logging_warning.assert_called_with("2 //identifiers nodes found in search result, expected 1.")
+        logging_warning.assert_called_with("%s //identifiers nodes found in search result, expected 1.", 2)
 
 
 class TestSearchResultMeta:


### PR DESCRIPTION
This gives us more flexibility in understanding what is going on whilst the code is running by dynamically adjusting log levels, rather than just blindly printing things to stdio.