### PR TITLE
Renovate will preserve semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>nationalarchives/ds-find-caselaw-docs"],
+  "extends": [
+    "github>nationalarchives/ds-find-caselaw-docs",
+    ":preserveSemverRanges"
+  ],
   "addLabels": ["no-changelog"]
 }


### PR DESCRIPTION
Whilst our stance for application code is to precisely pin dependencies, for our libraries it helps to keep the pins range-based to allow for variation downstream.