### PR TITLE
feat(Client): MarkLogic client uses HTTP(S) adapter pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- **Client**: MarkLogic client uses HTTP(S) adapter pool
 - **Document**: add method to save document to MarkLogic
+
+### Fix
+
+- **deps**: update boto packages to v1.43.2
+- **deps**: update boto packages to v1.43.1
+- **deps**: update boto packages to v1.43.0
+- **deps**: update dependency boto3 to v1.42.97
 
 ### Refactor
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -15,6 +15,7 @@ from defusedxml import ElementTree
 from defusedxml.ElementTree import ParseError, fromstring
 from ds_caselaw_utils.types import NeutralCitationString
 from lxml import etree
+from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from requests.structures import CaseInsensitiveDict
 from requests_toolbelt.multipart import decoder
@@ -62,6 +63,8 @@ env = environ.Env()
 # Requests timeouts: https://requests.readthedocs.io/en/latest/user/advanced/
 CONNECT_TIMEOUT = float(os.environ.get("CONNECT_TIMEOUT", "3.05"))
 READ_TIMEOUT = float(os.environ.get("READ_TIMEOUT", "10.0"))
+HTTP_POOL_CONNECTIONS = int(os.environ.get("MARKLOGIC_HTTP_POOL_CONNECTIONS", "10"))
+HTTP_POOL_MAXSIZE = int(os.environ.get("MARKLOGIC_HTTP_POOL_MAXSIZE", "20"))
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 DEFAULT_XSL_TRANSFORM = "accessible-html.xsl"
@@ -206,6 +209,12 @@ class MarklogicApiClient:
         self.session = requests.Session()
         self.session.auth = HTTPBasicAuth(username, password)
         self.session.headers.update({"User-Agent": user_agent})
+        adapter = HTTPAdapter(
+            pool_connections=HTTP_POOL_CONNECTIONS,
+            pool_maxsize=HTTP_POOL_MAXSIZE,
+        )
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
         self.user_agent = user_agent
 
     def get_press_summaries_for_document_uri(
@@ -380,7 +389,7 @@ class MarklogicApiClient:
         data: Optional[dict[str, Any]] = None,
     ) -> requests.Response:
         kwargs = self.prepare_request_kwargs(method, path, body, data)
-        self.session.headers = headers
+        kwargs["headers"] = headers
         response = self.session.request(method, **kwargs)
         # Raise relevant exception for an erroneous response
         self._raise_for_status(response)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -7,9 +7,12 @@ import pytest
 import requests
 import responses
 from requests import Request
+from requests.structures import CaseInsensitiveDict
 
 from caselawclient.Client import (
     CONNECT_TIMEOUT,
+    HTTP_POOL_CONNECTIONS,
+    HTTP_POOL_MAXSIZE,
     READ_TIMEOUT,
     MarklogicApiClient,
     MultipartResponseLongerThanExpected,
@@ -18,6 +21,44 @@ from caselawclient.Client import (
 )
 from caselawclient.errors import GatewayTimeoutError
 from caselawclient.models.documents import DocumentURIString
+
+
+class TestMarklogicApiClientConnectionPool(unittest.TestCase):
+    @patch("caselawclient.Client.HTTPAdapter")
+    def test_session_mounts_configured_http_adapter(self, mock_http_adapter):
+        adapter_instance = MagicMock()
+        mock_http_adapter.return_value = adapter_instance
+
+        client = MarklogicApiClient("", "", "", False)
+
+        mock_http_adapter.assert_called_once_with(
+            pool_connections=HTTP_POOL_CONNECTIONS,
+            pool_maxsize=HTTP_POOL_MAXSIZE,
+        )
+        assert client.session.adapters["https://"] is adapter_instance
+        assert client.session.adapters["http://"] is adapter_instance
+
+
+class TestMakeRequest(unittest.TestCase):
+    def test_make_request_merges_headers_without_clobbering_session_user_agent(self):
+        client = MarklogicApiClient("", "", "", False)
+        with patch.object(client.session, "request") as mock_request:
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock(return_value=None)
+            mock_request.return_value = mock_response
+
+            client.make_request(
+                "GET",
+                "some/path",
+                CaseInsensitiveDict({"X-Custom-Header": "1"}),
+            )
+
+            mock_request.assert_called_once()
+            _args, call_kwargs = mock_request.call_args
+            assert call_kwargs["headers"]["X-Custom-Header"] == "1"
+
+        prepared = client.session.prepare_request(Request("GET", "http://example.invalid"))
+        assert re.match(r"^ds-caselaw-marklogic-api-client/\d+", prepared.headers["user-agent"])
 
 
 class TestErrors(unittest.TestCase):


### PR DESCRIPTION
Replace the default session adapters with sized pools so threaded workloads can reuse connections without urllib3 spinning up ephemeral pools. Pool sizes are tunable via `MARKLOGIC_HTTP_POOL_CONNECTIONS` and `MARKLOGIC_HTTP_POOL_MAXSIZE`.

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
