### PR TITLE
bump: version 45.0.1 → 45.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v45.1.0 (2026-05-05)
 
 ### Feat
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "45.0.1"
+version = "45.1.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Feat

- **Client**: MarkLogic client uses HTTP(S) adapter pool
- **Document**: add method to save document to MarkLogic

### Fix

- **deps**: update boto packages to v1.43.2
- **deps**: update boto packages to v1.43.1
- **deps**: update boto packages to v1.43.0
- **deps**: update dependency boto3 to v1.42.97

### Refactor

- swap from defusedxml to lxml for serialisation