### PR TITLE
[FCLC-1919] refactor: standardise how we represent etree._Element type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- **deps**: update boto packages to v1.43.3
+
+### Refactor
+
+- standardise how we represent etree.\_Element type
+
 ## v45.1.0 (2026-05-05)
 
 ### Feat

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -901,7 +901,7 @@ class MarklogicApiClient:
         }
         return self._eval_and_decode(vars, "get_property.xqy")
 
-    def get_property_as_node(self, judgment_uri: DocumentURIString, name: str) -> Optional[etree._Element]:
+    def get_property_as_node(self, judgment_uri: DocumentURIString, name: str) -> Optional[Element]:
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.GetPropertyAsNodeDict = {
             "uri": uri,
@@ -948,7 +948,7 @@ class MarklogicApiClient:
         self,
         judgment_uri: DocumentURIString,
         name: str,
-        value: etree._Element,
+        value: Element,
     ) -> requests.Response:
         """Given a root node, set the value of the MarkLogic property for a document to the _contents_ of that root node. The root node itself is discarded."""
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import pytz
 from ds_caselaw_utils.types import CourtCode
-from lxml import etree
 from saxonche import PySaxonProcessor
 
 from caselawclient.models.utilities.dates import parse_string_date_as_utc
@@ -35,7 +34,7 @@ class DocumentBody:
     def get_xpath_match_strings(self, xpath: str) -> list[str]:
         return self._xml.get_xpath_match_strings(xpath)
 
-    def get_xpath_nodes(self, xpath: str) -> list[etree._Element]:
+    def get_xpath_nodes(self, xpath: str) -> list[Element]:
         return self._xml.get_xpath_nodes(xpath)
 
     @cached_property

--- a/src/caselawclient/models/identifiers/__init__.py
+++ b/src/caselawclient/models/identifiers/__init__.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from lxml import etree
 
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue, SuccessFailureMessageTuple
+from caselawclient.xml_helpers import Element
 
 from .exceptions import IdentifierValidationException
 
@@ -128,7 +129,7 @@ class Identifier(ABC):
         self.deprecated = deprecated
 
     @property
-    def as_xml_tree(self) -> etree._Element:
+    def as_xml_tree(self) -> Element:
         """Convert this Identifier into a packed XML representation for storage."""
         identifier_root = etree.Element("identifier")
 

--- a/src/caselawclient/models/identifiers/collection.py
+++ b/src/caselawclient/models/identifiers/collection.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from lxml import etree
 
 from caselawclient.types import SuccessFailureMessageTuple
+from caselawclient.xml_helpers import Element
 
 from . import Identifier, IdentifierSchema
 from .fclid import FindCaseLawIdentifier
@@ -143,7 +144,7 @@ class IdentifiersCollection(dict[str, Identifier]):
                 del self[uuid]
 
     @property
-    def as_etree(self) -> etree._Element:
+    def as_etree(self) -> Element:
         """Return an etree representation of all the Document's identifiers."""
         identifiers_root = etree.Element("identifiers")
 

--- a/src/caselawclient/models/identifiers/unpacker.py
+++ b/src/caselawclient/models/identifiers/unpacker.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from warnings import warn
 
-from lxml import etree
+from caselawclient.xml_helpers import Element
 
 from . import IDENTIFIER_UNPACKABLE_ATTRIBUTES, Identifier
 from .collection import SUPPORTED_IDENTIFIER_TYPES, IdentifiersCollection
@@ -12,7 +12,7 @@ IDENTIFIER_NAMESPACE_MAP: dict[str, type[Identifier]] = {
 }
 
 
-def unpack_all_identifiers_from_etree(identifiers_etree: Optional[etree._Element]) -> IdentifiersCollection:
+def unpack_all_identifiers_from_etree(identifiers_etree: Optional[Element]) -> IdentifiersCollection:
     """This expects the entire <identifiers> tag, and unpacks all Identifiers inside it"""
     identifiers = IdentifiersCollection()
     if identifiers_etree is None:
@@ -24,7 +24,7 @@ def unpack_all_identifiers_from_etree(identifiers_etree: Optional[etree._Element
     return identifiers
 
 
-def unpack_an_identifier_from_etree(identifier_xml: etree._Element) -> Optional[Identifier]:
+def unpack_an_identifier_from_etree(identifier_xml: Element) -> Optional[Identifier]:
     """Given an etree representation of a single identifier, unpack it into an appropriate instance of an Identifier if the type is known (otherwise return `None`)."""
 
     namespace_element = identifier_xml.find("namespace")

--- a/src/caselawclient/responses/search_response.py
+++ b/src/caselawclient/responses/search_response.py
@@ -1,9 +1,8 @@
 from typing import List
 
-from lxml import etree
-
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.responses.search_result import SearchResult
+from caselawclient.xml_helpers import Element
 
 
 class SearchResponse:
@@ -14,7 +13,7 @@ class SearchResponse:
     NAMESPACES = {"search": "http://marklogic.com/appservices/search"}
     """ Namespaces used in XPath expressions."""
 
-    def __init__(self, node: etree._Element, client: MarklogicApiClient) -> None:
+    def __init__(self, node: Element, client: MarklogicApiClient) -> None:
         """
         Initializes a SearchResponse instance from an xml node.
 

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -17,7 +17,7 @@ from caselawclient.models.identifiers.neutral_citation import NeutralCitationNum
 from caselawclient.models.identifiers.press_summary_ncn import PressSummaryRelatedNCNIdentifier
 from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
 from caselawclient.types import DocumentURIString
-from caselawclient.xml_helpers import get_xpath_match_string
+from caselawclient.xml_helpers import Element, get_xpath_match_string
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class SearchResultMetadata:
     Represents the metadata of a search result.
     """
 
-    def __init__(self, node: etree._Element, last_modified: str):
+    def __init__(self, node: Element, last_modified: str):
         self.node = node
         self.last_modified = last_modified
 
@@ -153,7 +153,7 @@ class SearchResult:
     }
     """ Namespace mappings used in XPath expressions. """
 
-    def __init__(self, node: etree._Element, client: MarklogicApiClient):
+    def __init__(self, node: Element, client: MarklogicApiClient):
         """
         :param node: The XML element representing the search result
         """


### PR DESCRIPTION
This was previously being described as both `caselawclient.xml_helpers.Element` (an alias for `lxml.etree._Element`) and directly as `lxml.etree._Element`. This is now standardised on just `caselawclient.xml_helpers.Element` across the codebase for clarity.

## Jira

<!-- All PRs (except releases) should have a corresponding ticket in Jira. If there isn't, go create one! -->

FCLC-1919

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
