### PR TITLE
bump: version 45.0.0 → 46.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v46.0.0 (2026-05-07)
+
+### BREAKING CHANGE
+
+- This version correctly marks the change of `insert_document_xml` and `update_document_xml` signatures to require `lxml.etree._Element` as breaking.
 
 ### Fix
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "45.1.0"
+version = "46.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- This version correctly marks the change of `insert_document_xml` and `update_document_xml` signatures to require `lxml.etree._Element` as breaking.

### Fix

- **deps**: update boto packages to v1.43.3

### Refactor

- standardise how we represent `etree._Element` type