### PR TITLE
feat: add more logging around document publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - loosen dependency pin for boto3
 
+### Feat
+
+- Adds more logs around document publish
+
 ## v46.0.0 (2026-05-07)
 
 ### BREAKING CHANGE

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -453,8 +453,10 @@ class Document:
         except CannotEnrichUnenrichableDocument as e:
             if not accept_failures:
                 raise e
+            logger.warning("Enrichment failed for %s but proceeding anyway", self.uri, exc_info=True)
             return False
 
+        logger.info("Enrichment completed for %s", self.uri, exc_info=True)
         return True
 
     @cached_property
@@ -481,11 +483,15 @@ class Document:
     def assign_fclid_if_missing(self) -> Optional[FindCaseLawIdentifier]:
         """If the document does not have an FCLID already, mint a new one and save it."""
         if len(self.identifiers.of_type(FindCaseLawIdentifier)) == 0:
+            logger.info("Document has no FCLID, minting a new one")
             document_fclid = FindCaseLawIdentifierSchema.mint(self.api_client)
+            logger.info("FCLID %s minted", document_fclid)
             self.identifiers.add(document_fclid)
             self.save_identifiers()
+            logger.info("FCLID %s assigned", document_fclid)
             return document_fclid
 
+        logger.info("Document already has an FCLID")
         return None
 
     def save(self, message: str) -> None:
@@ -517,8 +523,10 @@ class Document:
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
         such cannot be published.
         """
+        logger.debug("Assert that document is publishable")
         self.assert_is_publishable()
 
+        logger.info("Start publication process")
         ## Make sure the document has an FCLID
         self.assign_fclid_if_missing()
 
@@ -542,6 +550,8 @@ class Document:
 
         ## Send the document off for enrichment, but accept if we can't for any reason
         self.enrich(accept_failures=True)
+
+        logger.info("Document publication complete")
 
     def unpublish(self) -> None:
         self.api_client.break_checkout(self.uri)

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -50,6 +50,7 @@ def create_aws_client(service: Literal["sns"]) -> SNSClient: ...
 
 
 def create_aws_client(service: Literal["s3", "sns"]) -> Any:
+    logger.info("Creating AWS client for service %s", service)
     aws = boto3.session.Session()
     return aws.client(
         service,
@@ -212,6 +213,7 @@ def announce_document_event(uri: DocumentURIString, status: str, enrich: bool = 
             "StringValue": "1",
         }
 
+    logger.info("Announcing document event for %s with status %s and enrich %s", uri, status, enrich)
     client.publish(
         TopicArn=env("SNS_TOPIC"),  # this is the ANNOUNCE SNS topic
         Message=json.dumps({"uri_reference": uri, "status": status}),

--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -1,4 +1,6 @@
 import io
+import json
+import logging
 import os
 from unittest.mock import MagicMock, Mock, patch
 from urllib import parse
@@ -13,6 +15,7 @@ from caselawclient.models.neutral_citation_mixin import NeutralCitationString
 from caselawclient.models.utilities import aws as aws_utils
 from caselawclient.models.utilities import extract_version, move, render_versions
 from caselawclient.models.utilities.aws import (
+    announce_document_event,
     are_unpublished_assets_clean,
     build_new_key,
     check_docx_exists,
@@ -110,6 +113,43 @@ class TestAWSUtils:
         client.return_value.list_objects.assert_called_with(Bucket="fake_bucket", Prefix="uksc/2023/1/")
         client.return_value.delete_objects.assert_called_with(
             Bucket="fake_bucket", Delete={"Objects": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}]}
+        )
+
+    @patch("caselawclient.models.utilities.aws.create_sns_client")
+    @patch.dict(os.environ, {"SNS_TOPIC": "MY_SNS_TOPIC"})
+    def test_announce_document_event_with_enrich(self, client, caplog):
+        caplog.set_level(logging.INFO)
+
+        announce_document_event(DocumentURIString("uksc/2023/1"), "publish", enrich=True)
+
+        assert "Announcing document event for uksc/2023/1 with status publish and enrich True" in caplog.text
+        client.return_value.publish.assert_called_with(
+            TopicArn="MY_SNS_TOPIC",
+            Message=json.dumps({"uri_reference": "uksc/2023/1", "status": "publish"}),
+            Subject="Updated: uksc/2023/1 publish",
+            MessageAttributes={
+                "update_type": {"DataType": "String", "StringValue": "publish"},
+                "uri_reference": {"DataType": "String", "StringValue": "uksc/2023/1"},
+                "trigger_enrichment": {"DataType": "String", "StringValue": "1"},
+            },
+        )
+
+    @patch("caselawclient.models.utilities.aws.create_sns_client")
+    @patch.dict(os.environ, {"SNS_TOPIC": "MY_SNS_TOPIC"})
+    def test_announce_document_event_no_enrich(self, client, caplog):
+        caplog.set_level(logging.INFO)
+
+        announce_document_event(DocumentURIString("uksc/2023/1"), "publish", enrich=False)
+
+        assert "Announcing document event for uksc/2023/1 with status publish and enrich False" in caplog.text
+        client.return_value.publish.assert_called_with(
+            TopicArn="MY_SNS_TOPIC",
+            Message=json.dumps({"uri_reference": "uksc/2023/1", "status": "publish"}),
+            Subject="Updated: uksc/2023/1 publish",
+            MessageAttributes={
+                "update_type": {"DataType": "String", "StringValue": "publish"},
+                "uri_reference": {"DataType": "String", "StringValue": "uksc/2023/1"},
+            },
         )
 
     @mock_aws


### PR DESCRIPTION
Adds more logs around document publish to track down where things might be falling over in ingestion

## Jira

<!-- All PRs (except releases) should have a corresponding ticket in Jira. If there isn't, go create one! -->

FCL-1829

## Checklist

- [x] I have written tests to cover the new behaviour
- [ ] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
