### PR TITLE
Cache aws clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - Adds more logs around document publish
+- Caches AWS clients to prevent spiralling memory costs from creating new ones for each AWS operation
 
 ## v46.0.0 (2026-05-07)
 

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -3,6 +3,7 @@ import json
 import logging
 import uuid
 from collections.abc import Callable
+from functools import cache
 from typing import Any, Literal, Optional, TypedDict, overload
 
 import boto3
@@ -42,14 +43,20 @@ class ParserInstructionsDict(TypedDict):
 
 
 @overload
-def create_aws_client(service: Literal["s3"]) -> S3Client: ...
+def create_aws_client(service: Literal["s3"]) -> S3Client:
+    """Creates a new s3 client on first call, then returns the cached client on subsequent calls"""
+    ...
 
 
 @overload
-def create_aws_client(service: Literal["sns"]) -> SNSClient: ...
+def create_aws_client(service: Literal["sns"]) -> SNSClient:
+    """Creates a new sns client on first call, then returns the cached client on subsequent calls"""
+    ...
 
 
+@cache
 def create_aws_client(service: Literal["s3", "sns"]) -> Any:
+    """Create an AWS client for the given service, caching it for future use."""
     logger.info("Creating AWS client for service %s", service)
     aws = boto3.session.Session()
     return aws.client(
@@ -60,10 +67,12 @@ def create_aws_client(service: Literal["s3", "sns"]) -> Any:
 
 
 def create_s3_client() -> S3Client:
+    """Creates a new s3 client on first call, then returns the cached client on subsequent calls"""
     return create_aws_client("s3")
 
 
 def create_sns_client() -> SNSClient:
+    """Creates a new sns client on first call, then returns the cached client on subsequent calls"""
     return create_aws_client("sns")
 
 

--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -2,7 +2,7 @@ import io
 import json
 import logging
 import os
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 from urllib import parse
 
 import boto3
@@ -26,6 +26,14 @@ from caselawclient.models.utilities.aws import (
     generate_signed_asset_url,
     upload_asset_to_private_bucket,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_aws_client_cache():
+    """Clear the AWS client cache before and after each test to ensure test isolation."""
+    aws_utils.create_aws_client.cache_clear()  # type: ignore[attr-defined]
+    yield
+    aws_utils.create_aws_client.cache_clear()  # type: ignore[attr-defined]
 
 
 @pytest.fixture
@@ -85,6 +93,34 @@ class TestAWSUtils:
         old_key = "failures/TDR-2022-DNWR/image1.jpg"
         new_uri = DocumentURIString("ukpc/2023/120")
         assert build_new_key(old_key, new_uri) == "ukpc/2023/120/image1.jpg"
+
+    @patch("caselawclient.models.utilities.aws.boto3.session.Session")
+    @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET_REGION": "myregion-1"})
+    def test_create_aws_client_caches(self, mock_session, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.INFO)
+        mock_session.return_value.client.side_effect = [MagicMock(), MagicMock()]
+
+        s3Client = aws_utils.create_s3_client()
+        mock_session.return_value.client.assert_called_with("s3", region_name="myregion-1", config=ANY)
+        assert "Creating AWS client for service s3" in caplog.messages
+
+        snsClient = aws_utils.create_sns_client()
+        mock_session.return_value.client.assert_called_with("sns", region_name="myregion-1", config=ANY)
+        assert "Creating AWS client for service sns" in caplog.messages
+
+        assert mock_session.return_value.client.call_count == 2
+        assert s3Client is not snsClient
+
+        mock_session.reset_mock()
+        caplog.clear()
+
+        nextS3Client = aws_utils.create_s3_client()
+        nextSnsClient = aws_utils.create_sns_client()
+
+        assert s3Client is nextS3Client
+        assert snsClient is nextSnsClient
+        mock_session.return_value.client.assert_not_called()
+        assert caplog.text == ""
 
     @patch("caselawclient.models.utilities.aws.create_s3_client")
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})


### PR DESCRIPTION
We are seeing memory leaks occur during bulk ingestion and suspect memory leaks in the EUI and PUI services. One suspect is `boto3` which is [known to be leaky when creating many clients](https://github.com/boto/boto3/issues/1670).

The way that custom API client currently operates is to create a new AWS client each and every time that it wants to trigger an operation in AWS. This PR stops `boto3` creating a brand new AWS client on each call to `create_aws_client` by enabling a cache.

<!-- Replace this with a short summary of changes in this PR -->

## Jira

<!-- All PRs (except releases) should have a corresponding ticket in Jira. If there isn't, go create one! -->

FCLC-1829

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
