### PR TITLE
fix: update typing for Element to use TypeAlias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v46.1.1 (2026-05-08)
+
+### Refactor
+
+- Type alias Element for better IDE support
+
 ## v46.1.0 (2026-05-08)
 
 ### Build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "46.1.0"
+version = "46.1.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"

--- a/src/caselawclient/xml_helpers.py
+++ b/src/caselawclient/xml_helpers.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, TypeAlias
 
 from lxml import etree
 
@@ -8,7 +8,7 @@ DEFAULT_NAMESPACES = {
 }
 
 # _Element is the only class lxml exposes, so need to use the private class for typing
-Element = etree._Element  # noqa: SLF001
+Element: TypeAlias = etree._Element  # noqa: SLF001
 
 
 def get_xpath_nodes(


### PR DESCRIPTION
Tiny change to make downstream linters not think this is type `Any`

Also bump version.