### PR TITLE
Relax 'can_enrich' so we can enrich bulk data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+## Fix
+
+- Permit enriching bulk data if there's content
+
 ## v46.1.1 (2026-05-08)
 
 ### Refactor

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -653,7 +653,7 @@ class Document:
         """
         Is it possible to enrich this document?
         """
-        return self.body.has_content and not self.body.has_external_data
+        return self.body.has_content
 
     def validate_identifiers(self) -> SuccessFailureMessageTuple:
         return self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -216,7 +216,6 @@ class TestDocumentForceEnrich:
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
     def test_force_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
-        document.can_enrich = False
         with pytest.raises(CannotEnrichUnenrichableDocument):
             document.force_enrich()
 
@@ -235,7 +234,6 @@ class TestDocumentEnrich:
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
     def test_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
-        document.can_enrich = False
         with pytest.raises(CannotEnrichUnenrichableDocument):
             document.enrich()
 
@@ -254,7 +252,6 @@ class TestDocumentEnrich:
         self, mock_can_enrich, mock_announce_document_event, mock_api_client
     ):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
-        document.can_enrich = False
         document.enrich(accept_failures=True)
 
         mock_api_client.set_property.assert_called_once_with(

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -228,6 +228,20 @@ class TestDocumentForceEnrich:
         mock_announce_document_event.assert_not_called()
 
 
+class TestDocumentCanEnrich:
+    @patch("caselawclient.models.documents.DocumentBody.has_content", new_callable=PropertyMock, return_value=True)
+    def test_can_enrich_true_when_has_content(self, mock_has_content, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.can_enrich is True
+
+    @patch("caselawclient.models.documents.DocumentBody.has_content", new_callable=PropertyMock, return_value=False)
+    def test_can_enrich_false_when_no_content(self, mock_has_content, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.can_enrich is False
+
+
 class TestDocumentEnrich:
     @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")


### PR DESCRIPTION
Previously we blocked enrichment for bulk documents on the assumption that they were PDF-only and hence had no content: we think we can and should enrich bulk uploads which have content.

In future we should reparse them as well even if they have external data but that requires the external data to be roundtrippable to the Parser (and there's still a risk of data loss if that goes wrong)

<!-- Replace this with a short summary of changes in this PR -->

## Jira

https://national-archives.atlassian.net/browse/FCLC-1968

## Checklist

- [ ] I have written tests to cover the new behaviour
- [X] I have created/updated method docstrings (if necessary)
- [X] I have considered if this is a breaking change

This is a change of behaviour but the current behaviour is no longer correct.
