### PR TITLE
FCLC-1990 | add version restore method to MarklogicApiClient 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
-## Fix
+### Added
+
+- **MarklogicApiClient**: add `restore_document` method to restore a previous version of a document
+
+### Fix
 
 - Permit enriching bulk data if there's content
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -27,7 +27,7 @@ from caselawclient.models.documents import (
     DOCUMENT_COLLECTION_URI_PRESS_SUMMARY,
     Document,
 )
-from caselawclient.models.documents.versions import VersionAnnotation
+from caselawclient.models.documents.versions import VersionAnnotation, VersionType
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities import move
@@ -54,6 +54,7 @@ from .errors import (
     MarklogicResourceNotCheckedOutError,
     MarklogicResourceNotFoundError,
     MarklogicResourceUnmanagedError,
+    MarklogicResourceVersionInvalidError,
     MarklogicUnauthorizedError,
     MarklogicValidationFailedError,
 )
@@ -183,6 +184,7 @@ class MarklogicApiClient:
         "XDMP-DOCNOTFOUND": MarklogicResourceNotFoundError,
         "XDMP-LOCKCONFLICT": MarklogicResourceLockedError,
         "XDMP-LOCKED": MarklogicResourceLockedError,
+        "DLS-INVALIDVERSION": MarklogicResourceVersionInvalidError,
         "DLS-UNMANAGED": MarklogicResourceUnmanagedError,
         "DLS-NOTCHECKEDOUT": MarklogicResourceNotCheckedOutError,
         "DLS-CHECKOUTCONFLICT": MarklogicCheckoutConflictError,
@@ -1040,6 +1042,57 @@ class MarklogicApiClient:
 
         content = str(decoder.MultipartDecoder.from_response(response).parts[0].text)
         return content
+
+    def restore_document(
+        self, document_uri: DocumentURIString, version_number: int, annotation: VersionAnnotation | None = None
+    ) -> requests.Response:
+        """Restore a previous document version in MarkLogic.
+
+        This creates a new version while preserving the existing version
+        history. If no annotation is supplied, a restore annotation is created
+        that records the source version and the client user agent. The
+        annotation payload always includes `restored_from_version`, even when
+        a custom annotation is provided. This uses MarkLogic's
+        document-checkout-update-checkin flow to handle the checkout and
+        checkin.
+
+        Args:
+            document_uri: The URI of the document to restore.
+            version_number: The version number to restore.
+            annotation: An optional version annotation to store on the
+                restored version. Its payload is updated to include
+                `restored_from_version`.
+
+        Returns:
+            The MarkLogic response from restoring the document.
+        """
+        # This may not restore all of the properties of the previous document,
+        # as MarkLogic only versions properties if a change to the content is
+        # also made: https://docs.marklogic.com/9.0/dls.documentAddProperties
+
+        uri = self._format_uri_for_marklogic(document_uri)
+        if annotation is None:
+            annotation = VersionAnnotation(
+                VersionType.RESTORE,
+                automated=True,
+                message=f"Restored from version {version_number}",
+            )
+
+            annotation.set_calling_function("restore_document")
+            annotation.set_calling_agent(self.user_agent)
+
+        if annotation.payload is None:
+            annotation.payload = {}
+
+        annotation.payload.update({"restored_from_version": version_number})
+
+        vars: query_dicts.RestoreVersionDict = {
+            "uri": uri,
+            "version_number": version_number,
+            "annotation": annotation.as_json,
+        }
+
+        return self._send_to_eval(vars, "restore_version.xqy")
 
     def delete_judgment(self, judgment_uri: DocumentURIString) -> requests.Response:
         uri = self._format_uri_for_marklogic(judgment_uri)

--- a/src/caselawclient/errors.py
+++ b/src/caselawclient/errors.py
@@ -26,6 +26,11 @@ class MarklogicResourceNotFoundError(MarklogicAPIError):
     default_message = "No resource with that name could be found."
 
 
+class MarklogicResourceVersionInvalidError(MarklogicAPIError):
+    status_code = 404
+    default_message = "No resource with that version could be found."
+
+
 class MarklogicResourceLockedError(MarklogicAPIError):
     status_code = 409
     default_message = "The resource is locked by another user, so you cannot change it."

--- a/src/caselawclient/models/documents/versions.py
+++ b/src/caselawclient/models/documents/versions.py
@@ -26,6 +26,9 @@ class VersionType(Enum):
     EDIT = "edit"
     """ This version has been created as the result of a manual edit. """
 
+    RESTORE = "restore"
+    """ This version has been created as the result of a restore of a previous document. """
+
 
 class VersionAnnotation:
     """A class holding structured data about the reason for a version."""

--- a/src/caselawclient/xquery/restore_version.xqy
+++ b/src/caselawclient/xquery/restore_version.xqy
@@ -1,0 +1,16 @@
+xquery version "1.0-ml";
+
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare variable $uri as xs:string external;
+declare variable $version_number as xs:int external;
+declare variable $annotation as xs:string external;
+
+let $version_content := dls:document-version($uri, $version_number)
+
+return dls:document-checkout-update-checkin(
+  $uri,
+  $version_content,
+  $annotation, 
+  fn:true()
+)

--- a/src/caselawclient/xquery_type_dicts.py
+++ b/src/caselawclient/xquery_type_dicts.py
@@ -170,6 +170,13 @@ class ResolveFromIdentifierValueDict(MarkLogicAPIDict):
     published_only: Optional[int]
 
 
+# restore_version.xqy
+class RestoreVersionDict(MarkLogicAPIDict):
+    annotation: str
+    uri: MarkLogicDocumentURIString
+    version_number: int
+
+
 # set_boolean_property.xqy
 class SetBooleanPropertyDict(MarkLogicAPIDict):
     name: str

--- a/tests/client/test_restore_document.py
+++ b/tests/client/test_restore_document.py
@@ -1,0 +1,134 @@
+import json
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from caselawclient.Client import MarklogicApiClient
+from caselawclient.errors import MarklogicResourceUnmanagedError, MarklogicResourceVersionInvalidError
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.versions import VersionAnnotation, VersionType
+
+
+class TestRestoreDocument(unittest.TestCase):
+    def setUp(self):
+        self.client = MarklogicApiClient(
+            host="",
+            username="",
+            password="",
+            use_https=False,
+            user_agent="marklogic-api-client-test",
+        )
+
+    def test_restore_document_calls_correct_xquery(self):
+        """
+        Given a document URI and a version number,
+        When `Client.restore_document` is called,
+        Then the xquery in `restore_version.xqy` is called on the MarkLogic db.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            uri = DocumentURIString("test/1234")
+            self.client.restore_document(uri, 3)
+
+            assert mock_send_to_eval.call_args.args[1] == "restore_version.xqy"
+
+    def test_restore_document_sends_correct_vars_default_annotation(self):
+        """
+        Given a document URI and a version number,
+        When `Client.restore_document` is called with no annotation,
+        Then the correct vars are passed to the xquery, with a default restore annotation.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            uri = DocumentURIString("test/1234")
+            version_number = 3
+            expected_vars = {
+                "uri": "/test/1234.xml",
+                "version_number": version_number,
+                "annotation": json.dumps(
+                    {
+                        "type": "restore",
+                        "calling_function": "restore_document",
+                        "calling_agent": "marklogic-api-client-test",
+                        "automated": True,
+                        "message": "Restored from version 3",
+                        "payload": {"restored_from_version": 3},
+                    }
+                ),
+            }
+            self.client.restore_document(uri, version_number)
+
+            assert mock_send_to_eval.call_args.args[0] == expected_vars
+
+    def test_restore_document_sends_correct_vars_with_provided_annotation(self):
+        """
+        Given a document URI, version number, and custom annotation,
+        When `Client.restore_document` is called,
+        Then the provided annotation is sent with restored_from_version attached.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            uri = DocumentURIString("test/1234")
+            version_number = 5
+            annotation = VersionAnnotation(
+                VersionType.RESTORE,
+                automated=False,
+                message="Restored from version 3",
+                payload={"test-key": "test-value"},
+            )
+            annotation.set_calling_function("test-caller")
+            annotation.set_calling_agent("test-agent")
+            expected_vars = {
+                "uri": "/test/1234.xml",
+                "version_number": version_number,
+                "annotation": json.dumps(
+                    {
+                        "type": "restore",
+                        "calling_function": "test-caller",
+                        "calling_agent": "test-agent",
+                        "automated": False,
+                        "message": "Restored from version 3",
+                        "payload": {
+                            "test-key": "test-value",
+                            "restored_from_version": version_number,
+                        },
+                    }
+                ),
+            }
+            self.client.restore_document(uri, version_number, annotation=annotation)
+
+            assert mock_send_to_eval.call_args.args[0] == expected_vars
+
+    def test_restore_document_returns_eval_response(self):
+        """
+        Given a successful call to `_send_to_eval`,
+        When `Client.restore_document` is called,
+        Then the response from `_send_to_eval` is returned.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            uri = DocumentURIString("test/1234")
+            result = self.client.restore_document(uri, 2)
+
+            assert result == mock_send_to_eval.return_value
+
+    def test_restore_document_raises_if_version_does_not_exist(self):
+        """
+        Given a version number that does not exist (MarkLogic: DLS-INVALIDVERSION),
+        When `Client.restore_document` is called,
+        Then a MarklogicResourceVersionInvalidError is raised.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            mock_send_to_eval.side_effect = MarklogicResourceVersionInvalidError
+            uri = DocumentURIString("test/1234")
+            with pytest.raises(MarklogicResourceVersionInvalidError):
+                self.client.restore_document(uri, 99)
+
+    def test_restore_document_raises_if_document_is_unmanaged(self):
+        """
+        Given a document URI that is not DLS-managed (MarkLogic: DLS-UNMANAGED),
+        When `Client.restore_document` is called,
+        Then a MarklogicResourceUnmanagedError is raised.
+        """
+        with patch.object(self.client, "_send_to_eval") as mock_send_to_eval:
+            mock_send_to_eval.side_effect = MarklogicResourceUnmanagedError
+            uri = DocumentURIString("test/1234")
+            with pytest.raises(MarklogicResourceUnmanagedError):
+                self.client.restore_document(uri, 3)


### PR DESCRIPTION
<!-- Replace this with a short summary of changes in this PR -->

Given a MarkLogic document with multiple versions
When the method is called to restore to a previous version
Then the method calls the MarkLogic xquery document-checkout-update-checkin

## Jira

<!-- All PRs (except releases) should have a corresponding ticket in Jira. If there isn't, go create one! -->

Subtask `FCLC-1990` of `FCLC-1975`

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
