### PR TITLE
feat: add restore_version method to Document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Added
+
+- **MarklogicApiClient**: add `restore_document` method to restore a previous version of a document
+
 ## v47.0.0
 
 ### Feat

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -40,7 +40,13 @@ from caselawclient.models.utilities.aws import (
 from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple, TDRMetadataDict
 
 from .body import DocumentBody
-from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
+from .exceptions import (
+    CannotEnrichUnenrichableDocument,
+    CannotPublishUnpublishableDocument,
+    CannotRestoreDocumentWithoutConsignmentReference,
+    CannotRestorePublishedDocument,
+    DocumentNotSafeForDeletion,
+)
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
 
 logger = logging.getLogger(__name__)
@@ -348,6 +354,32 @@ class Document:
                 + ", ".join(self.validation_failure_messages),
             )
 
+    def assert_is_restorable(self, version_number: int) -> None:
+        """Assert that the given version can be restored, raising if it cannot.
+
+        Args:
+            version_number: The version number that is to be restored.
+
+        Raises:
+            CannotRestorePublishedDocument: The document is currently published
+                and so cannot have a version restored, as the public version
+                could otherwise diverge from the restored draft content.
+            CannotRestoreDocumentWithoutConsignmentReference: No TDR consignment
+                reference is available to locate the document's S3 assets, so a
+                complete restore cannot be performed.
+        """
+        if self.is_published:
+            raise CannotRestorePublishedDocument(
+                f"{self.document_noun.capitalize()} {self.uri} cannot be restored because it is currently published.",
+            )
+
+        tre_metadata = self._get_restore_tre_metadata(version_number) or {}
+        if not tre_metadata.get("parameters", {}).get("TDR"):
+            raise CannotRestoreDocumentWithoutConsignmentReference(
+                f"{self.document_noun.capitalize()} {self.uri} cannot be restored to version {version_number} "
+                "because no TDR consignment reference is available to locate its assets.",
+            )
+
     @cached_property
     def first_published_datetime(self) -> Optional[datetime.datetime]:
         """
@@ -625,6 +657,24 @@ class Document:
 
         return metadata_source_version
 
+    def _get_restore_tre_metadata(self, version_number: int) -> Optional[dict[str, Any]]:
+        """Get the TRE metadata associated with a previous version.
+
+        Args:
+            version_number: Version number being restored.
+
+        Returns:
+            The `tre_raw_metadata` mapping from the metadata source version, or
+            `None` when there is no metadata source version or it carries no TRE
+            metadata.
+        """
+        metadata_source_version_document = self._get_restore_metadata_source_version(version_number)
+        if metadata_source_version_document is None:
+            return None
+
+        payload = metadata_source_version_document.structured_annotation.get("payload") or {}
+        return payload.get("tre_raw_metadata") or None
+
     def _get_version(self, version_number: int) -> Optional["Document"]:
         """Find a specific version from the document history.
 
@@ -687,10 +737,11 @@ class Document:
         """Restore a previous version of this document.
 
         Create a new version from a historical version while preserving version
-        history. Unpublish the document first, build the restore annotation from
-        the target version's structured annotation, attach action requester's
-        details to payload metadata, restore the corresponding S3 assets, and
-        reload the document body after restore.
+        history. Validate that the document is currently unpublished and the
+        required consignment metadata is available, build the restore annotation
+        from the target version's structured annotation, attach the action
+        requester's details to payload metadata, restore the corresponding S3
+        assets, and finally reload the document body and cached properties.
 
         Args:
             version_number: The version number to restore.
@@ -700,21 +751,34 @@ class Document:
 
         Raises:
             ValueError: If the specified version number is not found.
+            CannotRestorePublishedDocument: If the document is currently
+                published.
+            CannotRestoreDocumentWithoutConsignmentReference: If no TDR
+                consignment reference is available to locate the document's S3
+                assets.
         """
-
         restore_version_document = self._get_version(version_number)
-        metadata_source_version_document = self._get_restore_metadata_source_version(version_number)
 
-        # We need a version to restore from.
         if restore_version_document is None:
             raise ValueError(f"Version {version_number} not found in document history")
 
-        # Take the document out of the published state before restoring, so the
-        # public version cannot diverge from the restored draft content.
-        if self.is_published:
-            self.unpublish()
+        # Perform all necessary validation before updating the document:
+        self.assert_is_restorable(version_number)
+
+        # assert_is_restorable guarantees these are present.
+        tre_metadata = self._get_restore_tre_metadata(version_number) or {}
+        tdr_metadata = tre_metadata["parameters"]["TDR"]
+
+        consignment_reference_for_assets = tdr_metadata["Internal-Sender-Identifier"]
+
+        # Capture the source filename and images so S3 assets can be restored
+        # selectively, mirroring how the ingester stores them.
+        tre_payload = tre_metadata.get("parameters", {}).get("TRE", {}).get("payload", {})
+        source_filename_for_assets = tre_payload.get("filename")
+        image_filenames_for_assets: list[str] = tre_payload.get("images") or []
 
         restore_version_annotation = restore_version_document.structured_annotation
+
         # Cannot rely on .get("payload", {}) because payload may actually exist with a value of None.
         restore_version_annotation_payload = restore_version_annotation.get("payload")
         if restore_version_annotation_payload is None:
@@ -722,31 +786,14 @@ class Document:
         else:
             restore_version_annotation_payload = dict(restore_version_annotation_payload)
 
-        consignment_reference_for_assets = None
-        source_filename_for_assets = None
-        image_filenames_for_assets: list[str] = []
-        if metadata_source_version_document:
-            metadata_source_version_annotation = metadata_source_version_document.structured_annotation
-            metadata_source_version_annotation_payload = metadata_source_version_annotation.get("payload")
-            if metadata_source_version_annotation_payload is None:
-                metadata_source_version_annotation_payload = {}
-
-            if tre_metadata := metadata_source_version_annotation_payload.get("tre_raw_metadata", {}):
-                if tdr_metadata := tre_metadata.get("parameters", {}).get("TDR", {}):
-                    self._set_tdr_metadata(tdr_metadata)
-                    consignment_reference_for_assets = tdr_metadata["Internal-Sender-Identifier"]
-
-                # Capture the source filename and images so S3 assets can be restored
-                # selectively, mirroring how the ingester stores them.
-                tre_payload = tre_metadata.get("parameters", {}).get("TRE", {}).get("payload", {})
-                source_filename_for_assets = tre_payload.get("filename")
-                image_filenames_for_assets = tre_payload.get("images") or []
-
-                # Ensure restoring to a restored version can get required TDR metadata.
-                restore_version_annotation_payload["tre_raw_metadata"] = tre_metadata
+        # Ensure future restores to this new restore version can get required metadata.
+        restore_version_annotation_payload["tre_raw_metadata"] = tre_metadata
 
         if action_requested_by is not None:
             restore_version_annotation_payload["action_requested_by"] = action_requested_by
+
+        # Update document properties:
+        self._set_tdr_metadata(tdr_metadata)
 
         annotation = VersionAnnotation(
             VersionType.RESTORE,
@@ -757,16 +804,16 @@ class Document:
         annotation.set_calling_function("restore_version")
         annotation.set_calling_agent(self.api_client.user_agent)
 
+        # Update document:
         self.api_client.restore_document(self.uri, version_number, annotation)
-        # Without the consignment reference we cannot locate the tarball or know
-        # which assets to restore, so asset restore is skipped in that case.
-        if consignment_reference_for_assets:
-            restore_assets_from_consignment_archive(
-                self.uri,
-                consignment_reference_for_assets,
-                source_filename_for_assets,
-                image_filenames_for_assets,
-            )
+
+        # Update S3 assets:
+        restore_assets_from_consignment_archive(
+            self.uri,
+            consignment_reference_for_assets,
+            source_filename_for_assets,
+            image_filenames_for_assets,
+        )
 
         # These will have changed so remove from cache.
         self.__dict__.pop("versions", None)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -34,6 +34,7 @@ from caselawclient.models.utilities.aws import (
     generate_pdf_url,
     publish_documents,
     request_parse,
+    restore_assets_from_consignment_archive,
     unpublish_documents,
 )
 from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple, TDRMetadataDict
@@ -681,9 +682,10 @@ class Document:
         """Restore a previous version of this document.
 
         Create a new version from a historical version while preserving version
-        history. Build the restore annotation from the target version's
-        structured annotation, remove submitter details from payload metadata,
-        and reload the document body after restore.
+        history. Unpublish the document first, build the restore annotation from
+        the target version's structured annotation, remove submitter details
+        from payload metadata, restore the corresponding S3 assets, and reload
+        the document body after restore.
 
         Args:
             version_number: The version number to restore.
@@ -700,6 +702,11 @@ class Document:
         if restore_version_document is None:
             raise ValueError(f"Version {version_number} not found in document history")
 
+        # Take the document out of the published state before restoring, so the
+        # public version cannot diverge from the restored draft content.
+        if self.is_published:
+            self.unpublish()
+
         restore_version_annotation = restore_version_document.structured_annotation
         # Cannot rely on .get("payload", {}) because payload may actually exist with a value of None.
         restore_version_annotation_payload = restore_version_annotation.get("payload")
@@ -708,6 +715,9 @@ class Document:
         else:
             restore_version_annotation_payload = dict(restore_version_annotation_payload)
 
+        consignment_reference_for_assets = None
+        source_filename_for_assets = None
+        image_filenames_for_assets: list[str] = []
         if metadata_source_version_document:
             metadata_source_version_annotation = metadata_source_version_document.structured_annotation
             metadata_source_version_annotation_payload = metadata_source_version_annotation.get("payload")
@@ -717,6 +727,13 @@ class Document:
             if tre_metadata := metadata_source_version_annotation_payload.get("tre_raw_metadata", {}):
                 if tdr_metadata := tre_metadata.get("parameters", {}).get("TDR", {}):
                     self._set_tdr_metadata(tdr_metadata)
+                    consignment_reference_for_assets = tdr_metadata["Internal-Sender-Identifier"]
+
+                # Capture the source filename and images so S3 assets can be restored
+                # selectively, mirroring how the ingester stores them.
+                tre_payload = tre_metadata.get("parameters", {}).get("TRE", {}).get("payload", {})
+                source_filename_for_assets = tre_payload.get("filename")
+                image_filenames_for_assets = tre_payload.get("images") or []
 
                 # Ensure restoring to a restored version can get required TDR metadata.
                 restore_version_annotation_payload["tre_raw_metadata"] = tre_metadata
@@ -733,6 +750,15 @@ class Document:
         annotation.set_calling_agent(self.api_client.user_agent)
 
         self.api_client.restore_document(self.uri, version_number, annotation)
+        # Without the consignment reference we cannot locate the tarball or know
+        # which assets to restore, so asset restore is skipped in that case.
+        if consignment_reference_for_assets:
+            restore_assets_from_consignment_archive(
+                self.uri,
+                consignment_reference_for_assets,
+                source_filename_for_assets,
+                image_filenames_for_assets,
+            )
 
         # These will have changed so remove from cache.
         self.__dict__.pop("versions", None)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -678,18 +678,25 @@ class Document:
         self.__dict__.pop("source_email", None)
         self.__dict__.pop("consignment_reference", None)
 
-    def restore_version(self, version_number: int, automated: bool = True) -> None:
+    def restore_version(
+        self,
+        version_number: int,
+        automated: bool = True,
+        action_requested_by: Optional[str] = None,
+    ) -> None:
         """Restore a previous version of this document.
 
         Create a new version from a historical version while preserving version
         history. Unpublish the document first, build the restore annotation from
-        the target version's structured annotation, remove submitter details
-        from payload metadata, restore the corresponding S3 assets, and reload
-        the document body after restore.
+        the target version's structured annotation, attach action requester's
+        details to payload metadata, restore the corresponding S3 assets, and
+        reload the document body after restore.
 
         Args:
             version_number: The version number to restore.
             automated: Whether to mark the restore as automated.
+            action_requested_by: Optional identifier of who requested the
+                restore.
 
         Raises:
             ValueError: If the specified version number is not found.
@@ -738,8 +745,9 @@ class Document:
                 # Ensure restoring to a restored version can get required TDR metadata.
                 restore_version_annotation_payload["tre_raw_metadata"] = tre_metadata
 
-        # Remove submitter as this could be misleading (they may not be the one who restored the version).
-        restore_version_annotation_payload.pop("submitter", None)
+        if action_requested_by is not None:
+            restore_version_annotation_payload["action_requested_by"] = action_requested_by
+
         annotation = VersionAnnotation(
             VersionType.RESTORE,
             automated=automated,

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -36,7 +36,7 @@ from caselawclient.models.utilities.aws import (
     request_parse,
     unpublish_documents,
 )
-from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple
+from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple, TDRMetadataDict
 
 from .body import DocumentBody
 from .exceptions import CannotEnrichUnenrichableDocument, CannotPublishUnpublishableDocument, DocumentNotSafeForDeletion
@@ -141,15 +141,7 @@ class Document:
         if not self.document_exists():
             raise DocumentNotFoundError(f"Document {self.uri} does not exist")
 
-        self.body: DocumentBody = DocumentBody(
-            xml_bytestring=self.api_client.get_judgment_xml_bytestring(
-                self.uri,
-                show_unpublished=True,
-                search_query=search_query,
-            ),
-        )
-        """ `Document.body` represents the body of the document itself, without any information such as version tracking or properties. """
-
+        self._initialise_document_body(search_query=search_query)
         self._initialise_identifiers()
 
     def __repr__(self) -> str:
@@ -165,6 +157,25 @@ class Document:
     def docx_exists(self) -> bool:
         """There is a docx in S3 private bucket for this Document"""
         return check_docx_exists(self.uri)
+
+    def _initialise_document_body(self, search_query: str | None = None) -> None:
+        """Load this document's body from MarkLogic.
+
+        Fetches the document body XML from MarkLogic and initializes the
+        `Document.body` property. The body represents the document itself,
+        without version tracking or property information.
+
+        Args:
+            search_query: Optional search query to pass to MarkLogic when
+                fetching the document body.
+        """
+        self.body: DocumentBody = DocumentBody(
+            xml_bytestring=self.api_client.get_judgment_xml_bytestring(
+                self.uri,
+                show_unpublished=True,
+                search_query=search_query,
+            ),
+        )
 
     def _initialise_identifiers(self) -> None:
         """Load this document's identifiers from MarkLogic."""
@@ -588,6 +599,145 @@ class Document:
             delete_documents_from_private_bucket(self.uri)
         else:
             raise DocumentNotSafeForDeletion
+
+    def _get_restore_metadata_source_version(self, version_number: int) -> Optional["Document"]:
+        """Find the latest version that should source metadata during restore.
+
+        Args:
+            version_number: Version number to search back from.
+
+        Returns:
+            The latest submission/restore version at or before `version_number`,
+            or `None` when no matching version exists.
+        """
+        metadata_source_version = None
+        prior_submission_types = {VersionType.SUBMISSION.value, VersionType.RESTORE.value}
+
+        # self.versions_as_documents is pre-sorted with newest first.
+        for document in self.versions_as_documents:
+            if document.version_number > version_number:
+                continue
+
+            if document.structured_annotation and document.structured_annotation.get("type") in prior_submission_types:
+                metadata_source_version = document
+                break
+
+        return metadata_source_version
+
+    def _get_version(self, version_number: int) -> Optional["Document"]:
+        """Find a specific version from the document history.
+
+        Args:
+            version_number: Version number to retrieve.
+
+        Returns:
+            The version document matching `version_number`, or `None` if it does
+            not exist.
+        """
+        version_document = None
+
+        for document in self.versions_as_documents:
+            if document.version_number == version_number:
+                version_document = document
+                break
+
+        return version_document
+
+    def _set_tdr_metadata(self, tdr_metadata: TDRMetadataDict) -> None:
+        """Store TDR metadata values on document properties.
+
+        Args:
+            tdr_metadata: TDR metadata mapping extracted from TRE payload data.
+
+        Raises:
+            KeyError: A required TDR metadata key is missing.
+        """
+        self.api_client.set_property(
+            self.uri,
+            name="source-organisation",
+            value=tdr_metadata["Source-Organization"],
+        )
+        self.api_client.set_property(self.uri, name="source-name", value=tdr_metadata["Contact-Name"])
+        self.api_client.set_property(self.uri, name="source-email", value=tdr_metadata["Contact-Email"])
+
+        # Store TDR data
+        self.api_client.set_property(
+            self.uri,
+            name="transfer-consignment-reference",
+            value=tdr_metadata["Internal-Sender-Identifier"],
+        )
+        self.api_client.set_property(
+            self.uri,
+            name="transfer-received-at",
+            value=tdr_metadata["Consignment-Completed-Datetime"],
+        )
+
+        # These have potentially been updated so remove from cache.
+        self.__dict__.pop("source_name", None)
+        self.__dict__.pop("source_email", None)
+        self.__dict__.pop("consignment_reference", None)
+
+    def restore_version(self, version_number: int, automated: bool = True) -> None:
+        """Restore a previous version of this document.
+
+        Create a new version from a historical version while preserving version
+        history. Build the restore annotation from the target version's
+        structured annotation, remove submitter details from payload metadata,
+        and reload the document body after restore.
+
+        Args:
+            version_number: The version number to restore.
+            automated: Whether to mark the restore as automated.
+
+        Raises:
+            ValueError: If the specified version number is not found.
+        """
+
+        restore_version_document = self._get_version(version_number)
+        metadata_source_version_document = self._get_restore_metadata_source_version(version_number)
+
+        # We need a version to restore from.
+        if restore_version_document is None:
+            raise ValueError(f"Version {version_number} not found in document history")
+
+        restore_version_annotation = restore_version_document.structured_annotation
+        # Cannot rely on .get("payload", {}) because payload may actually exist with a value of None.
+        restore_version_annotation_payload = restore_version_annotation.get("payload")
+        if restore_version_annotation_payload is None:
+            restore_version_annotation_payload = {}
+        else:
+            restore_version_annotation_payload = dict(restore_version_annotation_payload)
+
+        if metadata_source_version_document:
+            metadata_source_version_annotation = metadata_source_version_document.structured_annotation
+            metadata_source_version_annotation_payload = metadata_source_version_annotation.get("payload")
+            if metadata_source_version_annotation_payload is None:
+                metadata_source_version_annotation_payload = {}
+
+            if tre_metadata := metadata_source_version_annotation_payload.get("tre_raw_metadata", {}):
+                if tdr_metadata := tre_metadata.get("parameters", {}).get("TDR", {}):
+                    self._set_tdr_metadata(tdr_metadata)
+
+                # Ensure restoring to a restored version can get required TDR metadata.
+                restore_version_annotation_payload["tre_raw_metadata"] = tre_metadata
+
+        # Remove submitter as this could be misleading (they may not be the one who restored the version).
+        restore_version_annotation_payload.pop("submitter", None)
+        annotation = VersionAnnotation(
+            VersionType.RESTORE,
+            automated=automated,
+            message=f"Restored from version {version_number}",
+            payload=restore_version_annotation_payload,
+        )
+        annotation.set_calling_function("restore_version")
+        annotation.set_calling_agent(self.api_client.user_agent)
+
+        self.api_client.restore_document(self.uri, version_number, annotation)
+
+        # These will have changed so remove from cache.
+        self.__dict__.pop("versions", None)
+        self.__dict__.pop("versions_as_documents", None)
+        self._initialise_document_body()
 
     def move(self, new_citation: NeutralCitationString) -> None:
         self.api_client.update_document_uri(self.uri, new_citation)

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -2,6 +2,18 @@ class CannotPublishUnpublishableDocument(Exception):
     """A document which has failed publication safety checks in `Document.is_publishable` cannot be published."""
 
 
+class CannotRestoreDocument(Exception):
+    """Base class for reasons why a previous version of a document cannot be restored."""
+
+
+class CannotRestorePublishedDocument(CannotRestoreDocument):
+    """A document which is currently published cannot have a previous version restored."""
+
+
+class CannotRestoreDocumentWithoutConsignmentReference(CannotRestoreDocument):
+    """A document cannot be restored when no TDR consignment reference is available, as its S3 assets cannot be located."""
+
+
 class CannotEnrichUnenrichableDocument(Exception):
     """A document which cannot be enriched (see `Document.can_enrich`) tried to be sent to enrichment"""
 

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -1,6 +1,8 @@
 import datetime
+import io
 import json
 import logging
+import tarfile
 import uuid
 from collections.abc import Callable
 from functools import cache
@@ -152,6 +154,8 @@ def delete_some_from_bucket(
             {"Key": obj["Key"]} for obj in response.get("Contents", [])
         ]
         objects_to_delete = [obj for obj in objects_to_maybe_delete if filter(obj)]
+        if not objects_to_delete:
+            return
         client.delete_objects(
             Bucket=bucket,
             Delete={
@@ -162,6 +166,127 @@ def delete_some_from_bucket(
 
 def delete_non_targz_from_bucket(uri: DocumentURIString, bucket: str) -> None:
     delete_some_from_bucket(uri=uri, bucket=bucket, filter=lambda x: not x["Key"].endswith(".tar.gz"))
+
+
+def _get_consignment_archive_key(keys: list[str], consignment_reference: str) -> str | None:
+    """Find the S3 key for a consignment's tarball.
+
+    Args:
+        keys: Candidate S3 object keys under the document prefix.
+        consignment_reference: The consignment reference whose
+            `{reference}.tar.gz` archive we want.
+
+    Returns:
+        The matching S3 key, or `None` if no exact match exists.
+    """
+    target_filename = f"{consignment_reference}.tar.gz"
+    for key in keys:
+        if key.rsplit("/", 1)[-1] == target_filename:
+            return key
+
+    return None
+
+
+def _restore_archive_file_to_bucket(
+    archive: tarfile.TarFile,
+    archive_entry_name: str,
+    bucket: str,
+    destination_key: str,
+    client: S3Client,
+) -> bool:
+    """Copy a single named file from an open tar archive into S3.
+
+    Args:
+        archive: The open tar archive to read from.
+        archive_entry_name: The full path of the file within the archive.
+        bucket: The destination S3 bucket.
+        destination_key: The destination S3 key.
+        client: The S3 client to use.
+
+    Returns:
+        `True` if the file was found and copied, `False` if it was not present.
+    """
+    try:
+        file_object = archive.extractfile(archive_entry_name)
+    except KeyError:
+        return False
+
+    if file_object is None:
+        return False
+
+    client.put_object(Bucket=bucket, Key=destination_key, Body=file_object.read())
+    return True
+
+
+def restore_assets_from_consignment_archive(
+    uri: DocumentURIString,
+    consignment_reference: str,
+    source_filename: Optional[str],
+    image_filenames: list[str],
+) -> None:
+    """Restore a document's S3 assets from its consignment tarball.
+
+    Deletes the document's current (non-tarball) assets in the
+    private/unpublished bucket and repopulates them from the
+    `{consignment_reference}.tar.gz` archive. Only the private bucket is
+    touched, as consignment tarballs only exist there.
+
+    Mirrors the ingester's `save_files_to_s3`: only the source document,
+    `parser.log`, and the metadata-declared images are restored. Other files in
+    the archive (e.g. the parsed XML and consignment metadata JSON) are
+    deliberately not stored as assets. Archive entries are read from the
+    `{consignment_reference}/` directory inside the tarball.
+
+    Args:
+        uri: The document URI whose assets should be restored.
+        consignment_reference: The consignment reference identifying which
+            submission's tarball to restore from.
+        source_filename: The original source document filename (docx/pdf) as
+            recorded in the consignment metadata, or `None` (e.g. for reparses)
+            in which case no source document is restored.
+        image_filenames: The image filenames declared in the consignment
+            metadata to restore.
+
+    Raises:
+        FileNotFoundError: No matching consignment archive exists for the
+            document.
+    """
+    bucket = env("PRIVATE_ASSET_BUCKET")
+    client = create_s3_client()
+    response = client.list_objects(Bucket=bucket, Prefix=uri_for_s3(uri))
+    object_keys = [str(obj["Key"]) for obj in response.get("Contents", [])]
+
+    archive_key = _get_consignment_archive_key(object_keys, consignment_reference)
+    if archive_key is None:
+        raise FileNotFoundError(
+            f"No matching consignment archive found in {bucket} for {uri} and consignment {consignment_reference}"
+        )
+
+    delete_non_targz_from_bucket(uri=uri, bucket=bucket)
+    archive_object = client.get_object(Bucket=bucket, Key=archive_key)
+    archive_bytes = archive_object["Body"].read()
+
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+        # Restore the source document under its canonical key (e.g. uksc_2023_1.docx).
+        if source_filename:
+            source_extension = source_filename.rsplit(".", 1)[-1].lower()
+            source_destination_key = f"{uri}/{uri.replace('/', '_')}.{source_extension}"
+            if not _restore_archive_file_to_bucket(
+                archive, f"{consignment_reference}/{source_filename}", bucket, source_destination_key, client
+            ):
+                logger.warning("Source file %s not found in archive %s", source_filename, archive_key)
+
+        # Restore the parser log.
+        _restore_archive_file_to_bucket(
+            archive, f"{consignment_reference}/parser.log", bucket, f"{uri}/parser.log", client
+        )
+
+        # Restore each declared image under its original filename.
+        for image_filename in image_filenames:
+            if not _restore_archive_file_to_bucket(
+                archive, f"{consignment_reference}/{image_filename}", bucket, f"{uri}/{image_filename}", client
+            ):
+                logger.warning("Image %s not found in archive %s", image_filename, archive_key)
 
 
 def publish_documents(uri: DocumentURIString) -> None:

--- a/src/caselawclient/models/utilities/aws.py
+++ b/src/caselawclient/models/utilities/aws.py
@@ -277,9 +277,10 @@ def restore_assets_from_consignment_archive(
                 logger.warning("Source file %s not found in archive %s", source_filename, archive_key)
 
         # Restore the parser log.
-        _restore_archive_file_to_bucket(
+        if not _restore_archive_file_to_bucket(
             archive, f"{consignment_reference}/parser.log", bucket, f"{uri}/parser.log", client
-        )
+        ):
+            logger.warning("Parser log not found in archive %s", archive_key)
 
         # Restore each declared image under its original filename.
         for image_filename in image_filenames:

--- a/src/caselawclient/types.py
+++ b/src/caselawclient/types.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import TypedDict
 
 from lxml import etree
 
@@ -70,6 +71,18 @@ class DocumentIdentifierSlug(str):
 
 class DocumentIdentifierValue(str):
     pass
+
+
+TDRMetadataDict = TypedDict(
+    "TDRMetadataDict",
+    {
+        "Source-Organization": str,
+        "Contact-Name": str,
+        "Contact-Email": str,
+        "Internal-Sender-Identifier": str,
+        "Consignment-Completed-Datetime": str,
+    },
+)
 
 
 class SuccessFailureMessageTuple(tuple[bool, list[str]]):

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -648,6 +648,54 @@ def _standard_tdr_payload(**extra: object) -> dict:
     return payload
 
 
+class TestAssertIsRestorable:
+    @pytest.fixture(autouse=True)
+    def unpublished_document(self, mock_api_client):
+        mock_api_client.get_published.return_value = False
+
+    def test_raises_if_published(self, mock_api_client):
+        mock_api_client.get_published.return_value = True
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with pytest.raises(CannotRestorePublishedDocument):
+            document.assert_is_restorable(3)
+
+    def test_raises_without_consignment_reference_when_no_metadata_source_version(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(Document, "versions_as_documents", new_callable=PropertyMock, return_value=[]),
+            pytest.raises(CannotRestoreDocumentWithoutConsignmentReference),
+        ):
+            document.assert_is_restorable(3)
+
+    @pytest.mark.parametrize("payload", [{}, {"tre_raw_metadata": None}, {"tre_raw_metadata": {}}])
+    def test_raises_without_consignment_reference_when_metadata_lacks_tdr(self, mock_api_client, payload):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload=payload)],
+            ),
+            pytest.raises(CannotRestoreDocumentWithoutConsignmentReference),
+        ):
+            document.assert_is_restorable(3)
+
+    def test_passes_for_unpublished_document_with_consignment_reference(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(
+            Document,
+            "versions_as_documents",
+            new_callable=PropertyMock,
+            return_value=[_make_version_document(3, payload=_standard_tdr_payload())],
+        ):
+            assert document.assert_is_restorable(3) is None
+
+
 class TestDocumentRestoreVersion:
     @pytest.fixture(autouse=True)
     def mock_restore_assets(self):
@@ -1152,33 +1200,6 @@ class TestDocumentRestoreVersion:
         else:
             assert result is not None
             assert result.version_number == expected_version_number
-
-    def test_get_restore_tre_metadata_returns_tre_raw_metadata_from_source(self, mock_api_client):
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-        source_version = _make_version_document(3, payload=_standard_tdr_payload())
-
-        with patch.object(Document, "_get_restore_metadata_source_version", return_value=source_version):
-            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
-
-        assert result == _STANDARD_TRE_RAW_METADATA
-
-    def test_get_restore_tre_metadata_returns_none_when_no_source_version(self, mock_api_client):
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-
-        with patch.object(Document, "_get_restore_metadata_source_version", return_value=None):
-            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
-
-        assert result is None
-
-    @pytest.mark.parametrize("payload", [{}, {"tre_raw_metadata": None}, {"tre_raw_metadata": {}}])
-    def test_get_restore_tre_metadata_returns_none_when_payload_has_no_tre_metadata(self, mock_api_client, payload):
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-        source_version = _make_version_document(3, payload=payload)
-
-        with patch.object(Document, "_get_restore_metadata_source_version", return_value=source_version):
-            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
-
-        assert result is None
 
     def test_set_tdr_metadata_sets_properties_and_invalidates_cached_values(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -1,11 +1,12 @@
 import datetime
 import json
 import os
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import ANY, Mock, PropertyMock, call, patch
 
 import pytest
 import time_machine
 
+from caselawclient.errors import MarklogicResourceVersionInvalidError
 from caselawclient.factories import JudgmentFactory
 from caselawclient.models.documents import (
     CannotEnrichUnenrichableDocument,
@@ -14,6 +15,7 @@ from caselawclient.models.documents import (
     DocumentNotSafeForDeletion,
     DocumentURIString,
 )
+from caselawclient.models.documents.versions import VersionAnnotation, VersionType
 from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier
@@ -549,3 +551,468 @@ class TestReparse:
             "last_sent_to_parser",
             "2015-10-21T16:29:00+00:00",
         )
+
+
+_MISSING_PAYLOAD = object()
+
+
+def _make_tdr_payload(
+    organisation: str,
+    contact_name: str,
+    contact_email: str,
+    sender_identifier: str,
+    completed_at: str,
+    extra_tre_raw_metadata: dict | None = None,
+):
+    payload = {
+        "tre_raw_metadata": {
+            "parameters": {
+                "TDR": {
+                    "Source-Organization": organisation,
+                    "Contact-Name": contact_name,
+                    "Contact-Email": contact_email,
+                    "Internal-Sender-Identifier": sender_identifier,
+                    "Consignment-Completed-Datetime": completed_at,
+                }
+            }
+        }
+    }
+    if extra_tre_raw_metadata:
+        payload["tre_raw_metadata"].update(extra_tre_raw_metadata)
+    return payload
+
+
+def _make_version_document(
+    version_number: int,
+    annotation_type: str = "submission",
+    payload: dict | None | object = _MISSING_PAYLOAD,
+):
+    version_document = Mock(spec=Document)
+    version_document.version_number = version_number
+    structured_annotation: dict[str, object] = {"type": annotation_type}
+    if payload is not _MISSING_PAYLOAD:
+        structured_annotation["payload"] = payload
+    version_document.structured_annotation = structured_annotation
+    return version_document
+
+
+def _assert_tdr_metadata_set(
+    mock_api_client, organisation: str, contact_name: str, contact_email: str, sender_id: str, completed_at: str
+):
+    mock_api_client.set_property.assert_has_calls(
+        [
+            call("test/1234", name="source-organisation", value=organisation),
+            call("test/1234", name="source-name", value=contact_name),
+            call("test/1234", name="source-email", value=contact_email),
+            call("test/1234", name="transfer-consignment-reference", value=sender_id),
+            call("test/1234", name="transfer-received-at", value=completed_at),
+        ]
+    )
+    assert mock_api_client.set_property.call_count == 5
+
+
+class TestDocumentRestoreVersion:
+    def test_restore_version_calls_api_client(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(
+            Document,
+            "versions_as_documents",
+            new_callable=PropertyMock,
+            return_value=[
+                _make_version_document(
+                    3,
+                    payload={"submitter": "should-be-removed@example.com", "other": "should-not-be-removed"},
+                )
+            ],
+        ):
+            document.restore_version(3, automated=False)
+
+        restore_call_args = mock_api_client.restore_document.call_args.args
+        assert restore_call_args[0] == "test/1234"
+        assert restore_call_args[1] == 3
+
+        annotation = restore_call_args[2]
+        assert isinstance(annotation, VersionAnnotation)
+        assert annotation.version_type == VersionType.RESTORE
+        assert annotation.automated is False
+        assert annotation.message == "Restored from version 3"
+        assert annotation.payload == {"other": "should-not-be-removed"}
+        assert annotation.calling_function == "restore_version"
+        assert annotation.calling_agent == "marklogic-api-client-test"
+
+    def test_restore_version_propagates_api_client_errors(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        mock_api_client.restore_document.side_effect = MarklogicResourceVersionInvalidError
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload={"test-key": "test-value"})],
+            ),
+            pytest.raises(MarklogicResourceVersionInvalidError),
+        ):
+            document.restore_version(3, automated=False)
+
+    @pytest.mark.parametrize(
+        "versions,target_version",
+        [
+            ([_make_version_document(1, payload={"test-key": "test-value"})], 99),
+            ([], 1),
+        ],
+    )
+    def test_restore_version_raises_if_version_number_not_found(self, mock_api_client, versions, target_version):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(Document, "versions_as_documents", new_callable=PropertyMock, return_value=versions),
+            pytest.raises(ValueError, match=f"Version {target_version} not found"),
+        ):
+            document.restore_version(target_version, automated=False)
+
+    @pytest.mark.parametrize(
+        "payload,expected_payload",
+        [
+            (_MISSING_PAYLOAD, {}),
+            (None, {}),
+            (
+                {
+                    "submitter": "should-be-removed@example.com",
+                    "other-key-1": "other-value-1",
+                    "other-key-2": "other-value-2",
+                },
+                {"other-key-1": "other-value-1", "other-key-2": "other-value-2"},
+            ),
+        ],
+    )
+    def test_restore_version_uses_previous_version_payload(self, mock_api_client, payload, expected_payload):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        version_document = (
+            _make_version_document(7) if payload is _MISSING_PAYLOAD else _make_version_document(7, payload=payload)
+        )
+        with patch.object(
+            Document, "versions_as_documents", new_callable=PropertyMock, return_value=[version_document]
+        ):
+            document.restore_version(7, automated=False)
+
+        annotation = mock_api_client.restore_document.call_args.args[2]
+        assert isinstance(annotation, VersionAnnotation)
+        assert annotation.payload == expected_payload
+
+    @pytest.mark.parametrize(
+        "versions,target_version,expected_tdr",
+        [
+            (
+                [
+                    _make_version_document(
+                        7,
+                        payload=_make_tdr_payload(
+                            "Example Organisation",
+                            "Example Contact",
+                            "contact@example.com",
+                            "TDR-12345",
+                            "2026-01-01T12:00:00Z",
+                        ),
+                    )
+                ],
+                7,
+                ("Example Organisation", "Example Contact", "contact@example.com", "TDR-12345", "2026-01-01T12:00:00Z"),
+            ),
+            (
+                [
+                    _make_version_document(
+                        7,
+                        "not-a-submission",
+                        _make_tdr_payload(
+                            "Wrong Organisation",
+                            "Wrong Contact",
+                            "wrong@example.com",
+                            "WRONG-12345",
+                            "2025-01-01T12:00:00Z",
+                        ),
+                    ),
+                    _make_version_document(
+                        6,
+                        payload=_make_tdr_payload(
+                            "Correct Organisation",
+                            "Correct Contact",
+                            "correct@example.com",
+                            "TDR-12345",
+                            "2026-01-01T12:00:00Z",
+                        ),
+                    ),
+                ],
+                7,
+                ("Correct Organisation", "Correct Contact", "correct@example.com", "TDR-12345", "2026-01-01T12:00:00Z"),
+            ),
+            (
+                [
+                    _make_version_document(4, "edit", payload={}),
+                    _make_version_document(
+                        3,
+                        "restore",
+                        _make_tdr_payload(
+                            "Submission A Organisation",
+                            "Submission A Contact",
+                            "a@example.com",
+                            "TDR-A",
+                            "2026-01-01T12:00:00Z",
+                        ),
+                    ),
+                    _make_version_document(
+                        2,
+                        payload=_make_tdr_payload(
+                            "Submission B Organisation",
+                            "Submission B Contact",
+                            "b@example.com",
+                            "TDR-B",
+                            "2026-02-01T12:00:00Z",
+                        ),
+                    ),
+                    _make_version_document(
+                        1,
+                        payload=_make_tdr_payload(
+                            "Submission A Organisation",
+                            "Submission A Contact",
+                            "a@example.com",
+                            "TDR-A",
+                            "2026-01-01T12:00:00Z",
+                        ),
+                    ),
+                ],
+                3,
+                ("Submission A Organisation", "Submission A Contact", "a@example.com", "TDR-A", "2026-01-01T12:00:00Z"),
+            ),
+        ],
+    )
+    def test_restore_version_sets_tdr_metadata_from_expected_source(
+        self, mock_api_client, versions, target_version, expected_tdr
+    ):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(Document, "versions_as_documents", new_callable=PropertyMock, return_value=versions),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(target_version, automated=False)
+
+        _assert_tdr_metadata_set(mock_api_client, *expected_tdr)
+
+    def test_restore_version_reloads_document_body_after_restore(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(4, payload={})],
+            ),
+            patch.object(document, "_initialise_document_body") as initialise_document_body_mock,
+        ):
+            document.restore_version(4, automated=True)
+
+        initialise_document_body_mock.assert_called_once_with()
+
+    def test_restore_version_invalidates_cached_properties_when_tdr_metadata_is_set(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        mock_api_client.get_property.side_effect = ["old-contact", "new-contact"]
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.source_name == "old-contact"
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[
+                    _make_version_document(
+                        6,
+                        payload=_make_tdr_payload(
+                            "Example Organisation",
+                            "Example Contact",
+                            "contact@example.com",
+                            "TDR-12345",
+                            "2026-01-01T12:00:00Z",
+                        ),
+                    )
+                ],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(6, automated=False)
+
+        assert document.source_name == "new-contact"
+        assert mock_api_client.get_property.call_args_list == [
+            call("test/1234", "source-name"),
+            call("test/1234", "source-name"),
+        ]
+
+    def test_restore_version_preserves_full_tre_raw_metadata_from_metadata_source(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[
+                    _make_version_document(4, "edit", payload={}),
+                    _make_version_document(
+                        3,
+                        annotation_type="restore",
+                        payload=_make_tdr_payload(
+                            "Example Organisation",
+                            "Example Contact",
+                            "contact@example.com",
+                            "TDR-12345",
+                            "2026-01-01T12:00:00Z",
+                            extra_tre_raw_metadata={
+                                "extra-tre-key-1": "extra-tre-value-1",
+                                "extra-tre-key-2": {"example": True},
+                            },
+                        ),
+                    ),
+                ],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(4, automated=False)
+
+        mock_api_client.assert_has_calls(
+            [
+                call.set_property("test/1234", name="source-organisation", value="Example Organisation"),
+                call.set_property("test/1234", name="source-name", value="Example Contact"),
+                call.set_property("test/1234", name="source-email", value="contact@example.com"),
+                call.set_property("test/1234", name="transfer-consignment-reference", value="TDR-12345"),
+                call.set_property("test/1234", name="transfer-received-at", value="2026-01-01T12:00:00Z"),
+                call.restore_document("test/1234", 4, ANY),
+            ]
+        )
+
+        annotation = mock_api_client.restore_document.call_args.args[2]
+        assert annotation.payload == {
+            "tre_raw_metadata": {
+                "parameters": {
+                    "TDR": {
+                        "Source-Organization": "Example Organisation",
+                        "Contact-Name": "Example Contact",
+                        "Contact-Email": "contact@example.com",
+                        "Internal-Sender-Identifier": "TDR-12345",
+                        "Consignment-Completed-Datetime": "2026-01-01T12:00:00Z",
+                    }
+                },
+                "extra-tre-key-1": "extra-tre-value-1",
+                "extra-tre-key-2": {"example": True},
+            }
+        }
+
+
+class TestDocumentVersionHelpers:
+    def test_get_version_returns_matching_version(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        version_4 = _make_version_document(4)
+        version_3 = _make_version_document(3)
+
+        with patch.object(
+            Document, "versions_as_documents", new_callable=PropertyMock, return_value=[version_4, version_3]
+        ):
+            assert document._get_version(3) is version_3  # noqa: SLF001
+            assert document._get_version(99) is None  # noqa: SLF001
+
+    @pytest.mark.parametrize(
+        "versions,target_version,expected_version_number",
+        [
+            (
+                [
+                    _make_version_document(7, "not-submission"),
+                    _make_version_document(6, "not-submission"),
+                    _make_version_document(5, "submission"),
+                    _make_version_document(4, "submission"),
+                ],
+                6,
+                5,
+            ),
+            (
+                [
+                    _make_version_document(4, "edit"),
+                    _make_version_document(3, "restore"),
+                    _make_version_document(2, "submission"),
+                    _make_version_document(1, "submission"),
+                ],
+                3,
+                3,
+            ),
+            (
+                [
+                    _make_version_document(3, "not-submission"),
+                    _make_version_document(2, "not-submission"),
+                ],
+                3,
+                None,
+            ),
+        ],
+    )
+    def test_get_restore_metadata_source_version(
+        self, mock_api_client, versions, target_version, expected_version_number
+    ):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(Document, "versions_as_documents", new_callable=PropertyMock, return_value=versions):
+            result = document._get_restore_metadata_source_version(target_version)  # noqa: SLF001
+
+        if expected_version_number is None:
+            assert result is None
+        else:
+            assert result is not None
+            assert result.version_number == expected_version_number
+
+    def test_set_tdr_metadata_sets_properties_and_invalidates_cached_values(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        mock_api_client.get_property.side_effect = [
+            "old-source-name",
+            "old-source-email",
+            "old-consignment-reference",
+            "new-source-name",
+            "new-source-email",
+            "new-consignment-reference",
+        ]
+
+        assert document.source_name == "old-source-name"
+        assert document.source_email == "old-source-email"
+        assert document.consignment_reference == "old-consignment-reference"
+
+        document._set_tdr_metadata(  # noqa: SLF001
+            {
+                "Source-Organization": "Example Organisation",
+                "Contact-Name": "Example Contact",
+                "Contact-Email": "contact@example.com",
+                "Internal-Sender-Identifier": "TDR-12345",
+                "Consignment-Completed-Datetime": "2026-01-01T12:00:00Z",
+            }
+        )
+
+        _assert_tdr_metadata_set(
+            mock_api_client,
+            "Example Organisation",
+            "Example Contact",
+            "contact@example.com",
+            "TDR-12345",
+            "2026-01-01T12:00:00Z",
+        )
+
+        assert document.source_name == "new-source-name"
+        assert document.source_email == "new-source-email"
+        assert document.consignment_reference == "new-consignment-reference"

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -642,7 +642,7 @@ class TestDocumentRestoreVersion:
             return_value=[
                 _make_version_document(
                     3,
-                    payload={"submitter": "should-be-removed@example.com", "other": "should-not-be-removed"},
+                    payload={"submitter": "user@example.com", "other": "should-not-be-removed"},
                 )
             ],
         ):
@@ -657,7 +657,7 @@ class TestDocumentRestoreVersion:
         assert annotation.version_type == VersionType.RESTORE
         assert annotation.automated is False
         assert annotation.message == "Restored from version 3"
-        assert annotation.payload == {"other": "should-not-be-removed"}
+        assert annotation.payload == {"submitter": "user@example.com", "other": "should-not-be-removed"}
         assert annotation.calling_function == "restore_version"
         assert annotation.calling_agent == "marklogic-api-client-test"
 
@@ -701,11 +701,11 @@ class TestDocumentRestoreVersion:
             (None, {}),
             (
                 {
-                    "submitter": "should-be-removed@example.com",
+                    "submitter": "user@example.com",
                     "other-key-1": "other-value-1",
                     "other-key-2": "other-value-2",
                 },
-                {"other-key-1": "other-value-1", "other-key-2": "other-value-2"},
+                {"submitter": "user@example.com", "other-key-1": "other-value-1", "other-key-2": "other-value-2"},
             ),
         ],
     )
@@ -724,6 +724,42 @@ class TestDocumentRestoreVersion:
         annotation = mock_api_client.restore_document.call_args.args[2]
         assert isinstance(annotation, VersionAnnotation)
         assert annotation.payload == expected_payload
+
+    def test_restore_version_embeds_action_requested_by_in_payload(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(
+            Document,
+            "versions_as_documents",
+            new_callable=PropertyMock,
+            return_value=[_make_version_document(3, payload={"other": "should-not-be-removed"})],
+        ):
+            document.restore_version(3, automated=False, action_requested_by="user@example.com")
+
+        annotation = mock_api_client.restore_document.call_args.args[2]
+        assert isinstance(annotation, VersionAnnotation)
+        assert annotation.payload == {
+            "other": "should-not-be-removed",
+            "action_requested_by": "user@example.com",
+        }
+
+    def test_restore_version_omits_action_requested_by_when_not_provided(self, mock_api_client):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(
+            Document,
+            "versions_as_documents",
+            new_callable=PropertyMock,
+            return_value=[_make_version_document(3, payload={"other": "value"})],
+        ):
+            document.restore_version(3, automated=False)
+
+        annotation = mock_api_client.restore_document.call_args.args[2]
+        assert isinstance(annotation, VersionAnnotation)
+        assert annotation.payload is not None
+        assert "action_requested_by" not in annotation.payload
 
     @pytest.mark.parametrize(
         "versions,target_version,expected_tdr",

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -693,7 +693,8 @@ class TestAssertIsRestorable:
             new_callable=PropertyMock,
             return_value=[_make_version_document(3, payload=_standard_tdr_payload())],
         ):
-            assert document.assert_is_restorable(3) is None
+            # Should not raise:
+            document.assert_is_restorable(3)
 
 
 class TestDocumentRestoreVersion:

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -11,6 +11,8 @@ from caselawclient.factories import JudgmentFactory
 from caselawclient.models.documents import (
     CannotEnrichUnenrichableDocument,
     CannotPublishUnpublishableDocument,
+    CannotRestoreDocumentWithoutConsignmentReference,
+    CannotRestorePublishedDocument,
     Document,
     DocumentNotSafeForDeletion,
     DocumentURIString,
@@ -620,6 +622,32 @@ def _assert_tdr_metadata_set(
     assert mock_api_client.set_property.call_count == 5
 
 
+# Reusable consignment metadata so restores have the consignment reference now required to proceed.
+_STANDARD_TRE_RAW_METADATA = {
+    "parameters": {
+        "TDR": {
+            "Source-Organization": "Example Organisation",
+            "Contact-Name": "Example Contact",
+            "Contact-Email": "contact@example.com",
+            "Internal-Sender-Identifier": "TDR-12345",
+            "Consignment-Completed-Datetime": "2026-01-01T12:00:00Z",
+        }
+    }
+}
+
+
+def _standard_tdr_payload(**extra: object) -> dict:
+    payload = _make_tdr_payload(
+        "Example Organisation",
+        "Example Contact",
+        "contact@example.com",
+        "TDR-12345",
+        "2026-01-01T12:00:00Z",
+    )
+    payload.update(extra)
+    return payload
+
+
 class TestDocumentRestoreVersion:
     @pytest.fixture(autouse=True)
     def mock_restore_assets(self):
@@ -627,9 +655,9 @@ class TestDocumentRestoreVersion:
             yield restore_assets
 
     @pytest.fixture(autouse=True)
-    def mock_unpublish(self):
-        with patch.object(Document, "unpublish") as unpublish:
-            yield unpublish
+    def unpublished_document(self, mock_api_client):
+        # A document can only be restored when it is not currently published.
+        mock_api_client.get_published.return_value = False
 
     def test_restore_version_calls_api_client(self, mock_api_client):
         mock_api_client.user_agent = "marklogic-api-client-test"
@@ -642,7 +670,7 @@ class TestDocumentRestoreVersion:
             return_value=[
                 _make_version_document(
                     3,
-                    payload={"submitter": "user@example.com", "other": "should-not-be-removed"},
+                    payload=_standard_tdr_payload(submitter="user@example.com", other="should-not-be-removed"),
                 )
             ],
         ):
@@ -657,7 +685,11 @@ class TestDocumentRestoreVersion:
         assert annotation.version_type == VersionType.RESTORE
         assert annotation.automated is False
         assert annotation.message == "Restored from version 3"
-        assert annotation.payload == {"submitter": "user@example.com", "other": "should-not-be-removed"}
+        assert annotation.payload == {
+            "submitter": "user@example.com",
+            "other": "should-not-be-removed",
+            "tre_raw_metadata": _STANDARD_TRE_RAW_METADATA,
+        }
         assert annotation.calling_function == "restore_version"
         assert annotation.calling_agent == "marklogic-api-client-test"
 
@@ -671,7 +703,7 @@ class TestDocumentRestoreVersion:
                 Document,
                 "versions_as_documents",
                 new_callable=PropertyMock,
-                return_value=[_make_version_document(3, payload={"test-key": "test-value"})],
+                return_value=[_make_version_document(3, payload=_standard_tdr_payload())],
             ),
             pytest.raises(MarklogicResourceVersionInvalidError),
         ):
@@ -694,36 +726,32 @@ class TestDocumentRestoreVersion:
         ):
             document.restore_version(target_version, automated=False)
 
-    @pytest.mark.parametrize(
-        "payload,expected_payload",
-        [
-            (_MISSING_PAYLOAD, {}),
-            (None, {}),
-            (
-                {
-                    "submitter": "user@example.com",
-                    "other-key-1": "other-value-1",
-                    "other-key-2": "other-value-2",
-                },
-                {"submitter": "user@example.com", "other-key-1": "other-value-1", "other-key-2": "other-value-2"},
-            ),
-        ],
-    )
-    def test_restore_version_uses_previous_version_payload(self, mock_api_client, payload, expected_payload):
+        mock_api_client.restore_document.assert_not_called()
+
+    def test_restore_version_uses_previous_version_payload(self, mock_api_client):
         mock_api_client.user_agent = "marklogic-api-client-test"
         document = Document(DocumentURIString("test/1234"), mock_api_client)
 
-        version_document = (
-            _make_version_document(7) if payload is _MISSING_PAYLOAD else _make_version_document(7, payload=payload)
+        payload = _standard_tdr_payload(
+            submitter="user@example.com",
+            **{"other-key-1": "other-value-1", "other-key-2": "other-value-2"},
         )
         with patch.object(
-            Document, "versions_as_documents", new_callable=PropertyMock, return_value=[version_document]
+            Document,
+            "versions_as_documents",
+            new_callable=PropertyMock,
+            return_value=[_make_version_document(7, payload=payload)],
         ):
             document.restore_version(7, automated=False)
 
         annotation = mock_api_client.restore_document.call_args.args[2]
         assert isinstance(annotation, VersionAnnotation)
-        assert annotation.payload == expected_payload
+        assert annotation.payload == {
+            "submitter": "user@example.com",
+            "other-key-1": "other-value-1",
+            "other-key-2": "other-value-2",
+            "tre_raw_metadata": _STANDARD_TRE_RAW_METADATA,
+        }
 
     def test_restore_version_embeds_action_requested_by_in_payload(self, mock_api_client):
         mock_api_client.user_agent = "marklogic-api-client-test"
@@ -733,14 +761,15 @@ class TestDocumentRestoreVersion:
             Document,
             "versions_as_documents",
             new_callable=PropertyMock,
-            return_value=[_make_version_document(3, payload={"other": "should-not-be-removed"})],
+            return_value=[_make_version_document(3, payload=_standard_tdr_payload(other="value"))],
         ):
             document.restore_version(3, automated=False, action_requested_by="user@example.com")
 
         annotation = mock_api_client.restore_document.call_args.args[2]
         assert isinstance(annotation, VersionAnnotation)
         assert annotation.payload == {
-            "other": "should-not-be-removed",
+            "other": "value",
+            "tre_raw_metadata": _STANDARD_TRE_RAW_METADATA,
             "action_requested_by": "user@example.com",
         }
 
@@ -752,7 +781,7 @@ class TestDocumentRestoreVersion:
             Document,
             "versions_as_documents",
             new_callable=PropertyMock,
-            return_value=[_make_version_document(3, payload={"other": "value"})],
+            return_value=[_make_version_document(3, payload=_standard_tdr_payload(other="value"))],
         ):
             document.restore_version(3, automated=False)
 
@@ -870,7 +899,7 @@ class TestDocumentRestoreVersion:
                 Document,
                 "versions_as_documents",
                 new_callable=PropertyMock,
-                return_value=[_make_version_document(4, payload={})],
+                return_value=[_make_version_document(4, payload=_standard_tdr_payload())],
             ),
             patch.object(document, "_initialise_document_body") as initialise_document_body_mock,
         ):
@@ -1005,7 +1034,7 @@ class TestDocumentRestoreVersion:
 
         mock_restore_assets.assert_called_once_with("test/1234", "TDR-12345", "source.docx", ["image1.png"])
 
-    def test_restore_version_skips_asset_restore_without_tre_metadata(self, mock_api_client, mock_restore_assets):
+    def test_restore_version_aborts_without_consignment_reference(self, mock_api_client, mock_restore_assets):
         mock_api_client.user_agent = "marklogic-api-client-test"
         document = Document(DocumentURIString("test/1234"), mock_api_client)
 
@@ -1017,12 +1046,16 @@ class TestDocumentRestoreVersion:
                 return_value=[_make_version_document(3, payload={"other": "value"})],
             ),
             patch.object(document, "_initialise_document_body"),
+            pytest.raises(CannotRestoreDocumentWithoutConsignmentReference),
         ):
             document.restore_version(3, automated=False)
 
+        # Nothing should have been updated.
+        mock_api_client.restore_document.assert_not_called()
+        mock_api_client.set_property.assert_not_called()
         mock_restore_assets.assert_not_called()
 
-    def test_restore_version_unpublishes_before_restoring(self, mock_api_client, mock_unpublish):
+    def test_restore_version_aborts_if_published(self, mock_api_client, mock_restore_assets):
         mock_api_client.user_agent = "marklogic-api-client-test"
         mock_api_client.get_published.return_value = True
         document = Document(DocumentURIString("test/1234"), mock_api_client)
@@ -1032,33 +1065,19 @@ class TestDocumentRestoreVersion:
                 Document,
                 "versions_as_documents",
                 new_callable=PropertyMock,
-                return_value=[_make_version_document(3, payload={"other": "value"})],
+                return_value=[_make_version_document(3, payload=_standard_tdr_payload())],
             ),
             patch.object(document, "_initialise_document_body"),
+            pytest.raises(CannotRestorePublishedDocument),
         ):
             document.restore_version(3, automated=False)
 
-        mock_unpublish.assert_called_once_with()
+        # Nothing should have been updated.
+        mock_api_client.restore_document.assert_not_called()
+        mock_api_client.set_property.assert_not_called()
+        mock_restore_assets.assert_not_called()
 
-    def test_restore_version_does_not_unpublish_if_already_unpublished(self, mock_api_client, mock_unpublish):
-        mock_api_client.user_agent = "marklogic-api-client-test"
-        mock_api_client.get_published.return_value = False
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-
-        with (
-            patch.object(
-                Document,
-                "versions_as_documents",
-                new_callable=PropertyMock,
-                return_value=[_make_version_document(3, payload={"other": "value"})],
-            ),
-            patch.object(document, "_initialise_document_body"),
-        ):
-            document.restore_version(3, automated=False)
-
-        mock_unpublish.assert_not_called()
-
-    def test_restore_version_does_not_unpublish_for_invalid_version(self, mock_api_client, mock_unpublish):
+    def test_restore_version_does_not_restore_for_invalid_version(self, mock_api_client, mock_restore_assets):
         mock_api_client.user_agent = "marklogic-api-client-test"
         document = Document(DocumentURIString("test/1234"), mock_api_client)
 
@@ -1067,13 +1086,14 @@ class TestDocumentRestoreVersion:
                 Document,
                 "versions_as_documents",
                 new_callable=PropertyMock,
-                return_value=[_make_version_document(3, payload={"other": "value"})],
+                return_value=[_make_version_document(3, payload=_standard_tdr_payload())],
             ),
             pytest.raises(ValueError, match="Version 99 not found"),
         ):
             document.restore_version(99, automated=False)
 
-        mock_unpublish.assert_not_called()
+        mock_api_client.restore_document.assert_not_called()
+        mock_restore_assets.assert_not_called()
 
     def test_get_version_returns_matching_version(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
@@ -1132,6 +1152,33 @@ class TestDocumentRestoreVersion:
         else:
             assert result is not None
             assert result.version_number == expected_version_number
+
+    def test_get_restore_tre_metadata_returns_tre_raw_metadata_from_source(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        source_version = _make_version_document(3, payload=_standard_tdr_payload())
+
+        with patch.object(Document, "_get_restore_metadata_source_version", return_value=source_version):
+            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
+
+        assert result == _STANDARD_TRE_RAW_METADATA
+
+    def test_get_restore_tre_metadata_returns_none_when_no_source_version(self, mock_api_client):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with patch.object(Document, "_get_restore_metadata_source_version", return_value=None):
+            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
+
+        assert result is None
+
+    @pytest.mark.parametrize("payload", [{}, {"tre_raw_metadata": None}, {"tre_raw_metadata": {}}])
+    def test_get_restore_tre_metadata_returns_none_when_payload_has_no_tre_metadata(self, mock_api_client, payload):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        source_version = _make_version_document(3, payload=payload)
+
+        with patch.object(Document, "_get_restore_metadata_source_version", return_value=source_version):
+            result = document._get_restore_tre_metadata(3)  # noqa: SLF001
+
+        assert result is None
 
     def test_set_tdr_metadata_sets_properties_and_invalidates_cached_values(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -1143,17 +1143,6 @@ class TestDocumentRestoreVersion:
         mock_api_client.restore_document.assert_not_called()
         mock_restore_assets.assert_not_called()
 
-    def test_get_version_returns_matching_version(self, mock_api_client):
-        document = Document(DocumentURIString("test/1234"), mock_api_client)
-        version_4 = _make_version_document(4)
-        version_3 = _make_version_document(3)
-
-        with patch.object(
-            Document, "versions_as_documents", new_callable=PropertyMock, return_value=[version_4, version_3]
-        ):
-            assert document._get_version(3) is version_3  # noqa: SLF001
-            assert document._get_version(99) is None  # noqa: SLF001
-
     @pytest.mark.parametrize(
         "versions,target_version,expected_version_number",
         [

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -563,8 +563,10 @@ def _make_tdr_payload(
     sender_identifier: str,
     completed_at: str,
     extra_tre_raw_metadata: dict | None = None,
+    source_filename: str | None = None,
+    images: list[str] | None = None,
 ):
-    payload = {
+    payload: dict = {
         "tre_raw_metadata": {
             "parameters": {
                 "TDR": {
@@ -573,10 +575,17 @@ def _make_tdr_payload(
                     "Contact-Email": contact_email,
                     "Internal-Sender-Identifier": sender_identifier,
                     "Consignment-Completed-Datetime": completed_at,
-                }
+                },
             }
         }
     }
+    if source_filename is not None or images is not None:
+        payload["tre_raw_metadata"]["parameters"]["TRE"] = {
+            "payload": {
+                "filename": source_filename,
+                "images": images or [],
+            }
+        }
     if extra_tre_raw_metadata:
         payload["tre_raw_metadata"].update(extra_tre_raw_metadata)
     return payload
@@ -612,6 +621,16 @@ def _assert_tdr_metadata_set(
 
 
 class TestDocumentRestoreVersion:
+    @pytest.fixture(autouse=True)
+    def mock_restore_assets(self):
+        with patch("caselawclient.models.documents.restore_assets_from_consignment_archive") as restore_assets:
+            yield restore_assets
+
+    @pytest.fixture(autouse=True)
+    def mock_unpublish(self):
+        with patch.object(Document, "unpublish") as unpublish:
+            yield unpublish
+
     def test_restore_version_calls_api_client(self, mock_api_client):
         mock_api_client.user_agent = "marklogic-api-client-test"
         document = Document(DocumentURIString("test/1234"), mock_api_client)
@@ -918,8 +937,108 @@ class TestDocumentRestoreVersion:
             }
         }
 
+    def test_restore_version_restores_s3_assets_using_tdr_consignment_reference(
+        self, mock_api_client, mock_restore_assets
+    ):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
 
-class TestDocumentVersionHelpers:
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[
+                    _make_version_document(
+                        3,
+                        payload=_make_tdr_payload(
+                            "Example Organisation",
+                            "Example Contact",
+                            "contact@example.com",
+                            "TDR-12345",
+                            "2026-01-01T12:00:00Z",
+                            source_filename="source.docx",
+                            images=["image1.png"],
+                        ),
+                    ),
+                ],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(3, automated=False)
+
+        mock_restore_assets.assert_called_once_with("test/1234", "TDR-12345", "source.docx", ["image1.png"])
+
+    def test_restore_version_skips_asset_restore_without_tre_metadata(self, mock_api_client, mock_restore_assets):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload={"other": "value"})],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(3, automated=False)
+
+        mock_restore_assets.assert_not_called()
+
+    def test_restore_version_unpublishes_before_restoring(self, mock_api_client, mock_unpublish):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        mock_api_client.get_published.return_value = True
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload={"other": "value"})],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(3, automated=False)
+
+        mock_unpublish.assert_called_once_with()
+
+    def test_restore_version_does_not_unpublish_if_already_unpublished(self, mock_api_client, mock_unpublish):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        mock_api_client.get_published.return_value = False
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload={"other": "value"})],
+            ),
+            patch.object(document, "_initialise_document_body"),
+        ):
+            document.restore_version(3, automated=False)
+
+        mock_unpublish.assert_not_called()
+
+    def test_restore_version_does_not_unpublish_for_invalid_version(self, mock_api_client, mock_unpublish):
+        mock_api_client.user_agent = "marklogic-api-client-test"
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        with (
+            patch.object(
+                Document,
+                "versions_as_documents",
+                new_callable=PropertyMock,
+                return_value=[_make_version_document(3, payload={"other": "value"})],
+            ),
+            pytest.raises(ValueError, match="Version 99 not found"),
+        ):
+            document.restore_version(99, automated=False)
+
+        mock_unpublish.assert_not_called()
+
     def test_get_version_returns_matching_version(self, mock_api_client):
         document = Document(DocumentURIString("test/1234"), mock_api_client)
         version_4 = _make_version_document(4)

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -26,6 +26,7 @@ from caselawclient.models.documents import (
     Document,
     DocumentURIString,
 )
+from caselawclient.models.documents.body import DocumentBody
 from caselawclient.models.judgments import Judgment
 from caselawclient.types import InvalidDocumentURIException
 from caselawclient.xml_helpers import DEFAULT_NAMESPACES
@@ -291,6 +292,21 @@ class TestDocument:
         mock_api_client.get_judgment_xml_bytestring.assert_called_with(
             document.uri, show_unpublished=True, search_query="test search query"
         )
+
+    def test_initialise_document_body(self, mock_api_client):
+        test_uri = DocumentURIString("test/1234")
+        test_xml = b"<test>mock xml content</test>"
+        mock_api_client.get_judgment_xml_bytestring.return_value = test_xml
+        document = Document(test_uri, mock_api_client)
+        search_query = "test query"
+
+        document._initialise_document_body(search_query=search_query)  # noqa: SLF001
+
+        mock_api_client.get_judgment_xml_bytestring.assert_called_with(
+            test_uri, show_unpublished=True, search_query=search_query
+        )
+        assert isinstance(document.body, DocumentBody)
+        assert test_xml.decode() in document.body._xml.xml_as_string  # noqa: SLF001
 
 
 class TestDocumentEnrichedRecently:

--- a/tests/models/utilities/test_utilities.py
+++ b/tests/models/utilities/test_utilities.py
@@ -2,6 +2,7 @@ import io
 import json
 import logging
 import os
+import tarfile
 from unittest.mock import ANY, MagicMock, Mock, patch
 from urllib import parse
 
@@ -24,6 +25,7 @@ from caselawclient.models.utilities.aws import (
     generate_docx_url,
     generate_pdf_url,
     generate_signed_asset_url,
+    restore_assets_from_consignment_archive,
     upload_asset_to_private_bucket,
 )
 
@@ -150,6 +152,114 @@ class TestAWSUtils:
         client.return_value.delete_objects.assert_called_with(
             Bucket="fake_bucket", Delete={"Objects": [{"Key": "uksc/2023/1/uksc_2023_1.docx"}]}
         )
+
+    @staticmethod
+    def _build_consignment_archive(consignment_reference: str, files: dict[str, bytes]) -> bytes:
+        archive_buffer = io.BytesIO()
+        with tarfile.open(fileobj=archive_buffer, mode="w:gz") as archive:
+            for filename, data in files.items():
+                info = tarfile.TarInfo(name=f"{consignment_reference}/{filename}")
+                info.size = len(data)
+                archive.addfile(info, io.BytesIO(data))
+        return archive_buffer.getvalue()
+
+    def test_restore_assets_from_consignment_archive(self, fake_bucket):
+        archive_bytes = self._build_consignment_archive(
+            "TDR-12345",
+            {
+                "source.docx": b"docx-bytes",
+                "parser.log": b"log-bytes",
+                "image1.png": b"image-bytes",
+                # Non-asset files that must NOT be restored to the document prefix.
+                "TDR-12345.xml": b"xml-bytes",
+                "TRE-TDR-12345-metadata.json": b"json-bytes",
+            },
+        )
+        fake_bucket.put_object(Key="uksc/2023/1/TDR-12345.tar.gz", Body=archive_bytes)
+        fake_bucket.put_object(Key="uksc/2023/1/old-asset.png", Body=b"stale-bytes")
+
+        restore_assets_from_consignment_archive(
+            DocumentURIString("uksc/2023/1"),
+            "TDR-12345",
+            source_filename="source.docx",
+            image_filenames=["image1.png"],
+        )
+
+        keys = sorted(obj.key for obj in fake_bucket.objects.filter(Prefix="uksc/2023/1/"))
+        assert keys == [
+            "uksc/2023/1/TDR-12345.tar.gz",
+            "uksc/2023/1/image1.png",
+            "uksc/2023/1/parser.log",
+            "uksc/2023/1/uksc_2023_1.docx",
+        ]
+        assert fake_bucket.Object("uksc/2023/1/uksc_2023_1.docx").get()["Body"].read() == b"docx-bytes"
+        assert fake_bucket.Object("uksc/2023/1/parser.log").get()["Body"].read() == b"log-bytes"
+        assert fake_bucket.Object("uksc/2023/1/image1.png").get()["Body"].read() == b"image-bytes"
+
+    def test_restore_assets_from_consignment_archive_restores_pdf_source(self, fake_bucket):
+        archive_bytes = self._build_consignment_archive("TDR-12345", {"source.pdf": b"pdf-bytes"})
+        fake_bucket.put_object(Key="uksc/2023/1/TDR-12345.tar.gz", Body=archive_bytes)
+
+        restore_assets_from_consignment_archive(
+            DocumentURIString("uksc/2023/1"),
+            "TDR-12345",
+            source_filename="source.pdf",
+            image_filenames=[],
+        )
+
+        assert fake_bucket.Object("uksc/2023/1/uksc_2023_1.pdf").get()["Body"].read() == b"pdf-bytes"
+
+    def test_restore_assets_from_consignment_archive_without_source_filename(self, fake_bucket):
+        archive_bytes = self._build_consignment_archive(
+            "TDR-12345",
+            {"parser.log": b"log-bytes", "image1.png": b"image-bytes"},
+        )
+        fake_bucket.put_object(Key="uksc/2023/1/TDR-12345.tar.gz", Body=archive_bytes)
+        fake_bucket.put_object(Key="uksc/2023/1/old-asset.png", Body=b"stale-bytes")
+
+        restore_assets_from_consignment_archive(
+            DocumentURIString("uksc/2023/1"),
+            "TDR-12345",
+            source_filename=None,
+            image_filenames=["image1.png"],
+        )
+
+        keys = sorted(obj.key for obj in fake_bucket.objects.filter(Prefix="uksc/2023/1/"))
+        assert keys == [
+            "uksc/2023/1/TDR-12345.tar.gz",
+            "uksc/2023/1/image1.png",
+            "uksc/2023/1/parser.log",
+        ]
+
+    def test_restore_assets_from_consignment_archive_selects_exact_archive(self, fake_bucket):
+        fake_bucket.put_object(
+            Key="uksc/2023/1/TDR-2026-CBBR3.tar.gz",
+            Body=self._build_consignment_archive("TDR-2026-CBBR3", {"source.docx": b"wrong"}),
+        )
+        fake_bucket.put_object(
+            Key="uksc/2023/1/TDR-2026-CBBR5.tar.gz",
+            Body=self._build_consignment_archive("TDR-2026-CBBR5", {"source.docx": b"right"}),
+        )
+
+        restore_assets_from_consignment_archive(
+            DocumentURIString("uksc/2023/1"),
+            "TDR-2026-CBBR5",
+            source_filename="source.docx",
+            image_filenames=[],
+        )
+
+        assert fake_bucket.Object("uksc/2023/1/uksc_2023_1.docx").get()["Body"].read() == b"right"
+
+    def test_restore_assets_from_consignment_archive_raises_if_no_archive_found(self, fake_bucket):
+        fake_bucket.put_object(Key="uksc/2023/1/TDR-99999.tar.gz", Body=b"irrelevant")
+
+        with pytest.raises(FileNotFoundError, match="No matching consignment archive found"):
+            restore_assets_from_consignment_archive(
+                DocumentURIString("uksc/2023/1"),
+                "TDR-12345",
+                source_filename="source.docx",
+                image_filenames=[],
+            )
 
     @patch("caselawclient.models.utilities.aws.create_sns_client")
     @patch.dict(os.environ, {"SNS_TOPIC": "MY_SNS_TOPIC"})


### PR DESCRIPTION
## Changes

- Added a new `restore_version` method to `Document` so document versions can be restored via the client API. Makes use of the lower-level method added in [1821](https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1821).
- Included restore logic that re-applies metadata from the selected previous version, so restored documents keep consistent version/context metadata.
- Restores the S3 assets associated with the TDR submission of the version that is being restored to.
- Added tests for document verbs and document behavior around version restoration.

~~**Note:** Restoring assets in S3 will be done in a follow-up PR.~~

## Jira

<!-- All PRs (except releases) should have a corresponding ticket in Jira. If there isn't, go create one! -->

FCLC-1991, FCLC-1992

## Checklist

- [X] I have written tests to cover the new behaviour - tests added
- [X] I have created/updated method docstrings (if necessary) - docstrings added
- [X] I have considered if this is a breaking change - adds rather than changes behaviour
