### PR TITLE
FCLC-2014 | add metadata attribute to document

### DIFF
--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -18,10 +18,12 @@ from caselawclient.errors import (
     OnlySupportedOnVersion,
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
+from caselawclient.models.documents.metadata import DocumentMetadata
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier, FindCaseLawIdentifierSchema
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
 from caselawclient.models.utilities import VersionsDict, extract_version, render_versions
 from caselawclient.models.utilities.aws import (
@@ -186,6 +188,28 @@ class Document:
         :return: The absolute, public URI at which a copy of this document can be found
         """
         return f"https://caselaw.nationalarchives.gov.uk/{self.slug}"
+
+    @cached_property
+    def metadata(self) -> DocumentMetadata:
+        ncn = self.identifiers.preferred(NeutralCitationNumber)
+
+        return DocumentMetadata(
+            name=self.body.name,
+            ncn=str(ncn) if ncn else None,
+            court=self.body.court,
+            jurisdiction=self.body.jurisdiction,
+            categories=self.body.categories,
+            case_number=self.body.case_number,
+            date=self.body.document_date_as_string,
+            parties=self.body.parties,
+            judges=self.body.judges,
+            uri=self.uri,
+            source_name=self.source_name,
+            source_email=self.source_email,
+            consignment_reference=self.consignment_reference,
+            identifiers=self.identifiers,
+            version_annotation=self.annotation,
+        )
 
     @cached_property
     def slug(self) -> str:

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -48,6 +48,14 @@ class DocumentBody:
         return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:court/text()")
 
     @cached_property
+    def parties(self) -> list[str]:
+        return self.get_xpath_match_strings("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:party/text()")
+
+    @cached_property
+    def judges(self) -> list[str]:
+        return self.get_xpath_match_strings("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:judge/text()")
+
+    @cached_property
     def jurisdiction(self) -> str:
         return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdiction/text()")
 

--- a/src/caselawclient/models/documents/metadata.py
+++ b/src/caselawclient/models/documents/metadata.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from caselawclient.models.identifiers.collection import IdentifiersCollection
+
+
+@dataclass(frozen=True)
+class DocumentMetadata:
+    name: Optional[str] = None
+    ncn: Optional[str] = None
+    court: Optional[str] = None
+    jurisdiction: Optional[str] = None
+    categories: Optional[list[Any]] = None
+    case_number: Optional[str] = None
+    date: Optional[str] = None
+    parties: Optional[list[str]] = None
+    judges: Optional[list[str]] = None
+    uri: Optional[str] = None
+    source_name: Optional[str] = None
+    source_email: Optional[str] = None
+    consignment_reference: Optional[str] = None
+    identifiers: Optional[IdentifiersCollection] = None
+    version_annotation: Optional[str] = None
+
+    def as_dict(self, exclude_empty: bool = False) -> dict[str, Any]:
+        data = {
+            "name": self.name,
+            "ncn": self.ncn,
+            "court": self.court,
+            "jurisdiction": self.jurisdiction,
+            "categories": self.categories,
+            "case_number": self.case_number,
+            "date": self.date,
+            "parties": self.parties,
+            "judges": self.judges,
+            "uri": self.uri,
+            "source_name": self.source_name,
+            "source_email": self.source_email,
+            "consignment_reference": self.consignment_reference,
+            "identifiers": self.identifiers,
+            "version_annotation": self.version_annotation,
+        }
+
+        if exclude_empty:
+            return {key: value for key, value in data.items() if value not in (None, "", [], {}, ())}
+
+        return data

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -81,6 +81,76 @@ class TestDocumentBody:
 
         assert body.court == "Court of Testing"
 
+    def test_parties(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+            >
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:party>Test Claimant</uk:party>
+                            <uk:party>Test Defendant</uk:party>
+                        </proprietary>
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """)
+
+        assert body.parties == ["Test Claimant", "Test Defendant"]
+
+    def test_no_parties(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+            >
+                <judgment>
+                    <meta>
+                        <proprietary />
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """)
+
+        assert body.parties == []
+
+    def test_judges(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+            >
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:judge>Lord Test</uk:judge>
+                            <uk:judge>Lady Example</uk:judge>
+                        </proprietary>
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """)
+
+        assert body.judges == ["Lord Test", "Lady Example"]
+
+    def test_no_judges(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+            >
+                <judgment>
+                    <meta>
+                        <proprietary />
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """)
+
+        assert body.judges == []
+
     @pytest.mark.parametrize(
         "opening_tag, closing_tag",
         [

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -1,0 +1,116 @@
+from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+from caselawclient.models.documents.metadata import DocumentMetadata
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
+from caselawclient.types import DocumentCategory
+
+
+class TestDocumentMetadata:
+    def test_metadata(self):
+        categories = [
+            DocumentCategory(
+                name="Breach of code of standards",
+                subcategories=[
+                    DocumentCategory(name="Standards not met"),
+                ],
+            ),
+        ]
+
+        body = DocumentBodyFactory.build()
+        body.name = "Test Claimant v Test Defendant"
+        body.court = "Court of Testing"
+        body.jurisdiction = "SoftwareTesting"
+        body.categories = categories
+        body.case_number = "2010/1/dis"
+        body.document_date_as_string = "2023-02-03"
+        body.parties = ["Test Claimant", "Test Defendant"]
+        body.judges = ["Lord Test", "Lady Example"]
+
+        document = DocumentFactory.build(
+            body=body,
+            identifiers=[
+                NeutralCitationNumber("[2023] UKSC 123"),
+            ],
+            source_name="Example Uploader",
+            source_email="uploader@example.com",
+            consignment_reference="TDR-12345",
+        )
+        document.annotation = "Test version annotation"
+
+        assert isinstance(document.metadata, DocumentMetadata)
+        assert document.metadata.name == "Test Claimant v Test Defendant"
+        assert document.metadata.ncn == "[2023] UKSC 123"
+        assert document.metadata.court == "Court of Testing"
+        assert document.metadata.jurisdiction == "SoftwareTesting"
+        assert document.metadata.categories == categories
+        assert document.metadata.case_number == "2010/1/dis"
+        assert document.metadata.date == "2023-02-03"
+        assert document.metadata.parties == ["Test Claimant", "Test Defendant"]
+        assert document.metadata.judges == ["Lord Test", "Lady Example"]
+        assert document.metadata.uri == "test/2023/123"
+        assert document.metadata.source_name == "Example Uploader"
+        assert document.metadata.source_email == "uploader@example.com"
+        assert document.metadata.consignment_reference == "TDR-12345"
+        assert document.metadata.identifiers == document.identifiers
+        assert document.metadata.version_annotation == "Test version annotation"
+
+    def test_metadata_without_neutral_citation_number(self):
+        document = DocumentFactory.build()
+
+        assert document.metadata.ncn is None
+
+    def test_metadata_as_dict(self):
+        body = DocumentBodyFactory.build()
+        body.name = "Test Claimant v Test Defendant"
+        body.court = "Court of Testing"
+        body.jurisdiction = ""
+        body.categories = []
+        body.case_number = ""
+        body.document_date_as_string = "2023-02-03"
+        body.parties = []
+        body.judges = []
+
+        document = DocumentFactory.build(body=body)
+        document.annotation = ""
+
+        assert document.metadata.as_dict() == {
+            "name": "Test Claimant v Test Defendant",
+            "ncn": None,
+            "court": "Court of Testing",
+            "jurisdiction": "",
+            "categories": [],
+            "case_number": "",
+            "date": "2023-02-03",
+            "parties": [],
+            "judges": [],
+            "uri": "test/2023/123",
+            "source_name": "Example Uploader",
+            "source_email": "uploader@example.com",
+            "consignment_reference": "TDR-12345",
+            "identifiers": document.identifiers,
+            "version_annotation": "",
+        }
+
+    def test_metadata_as_dict_excluding_empty_values(self):
+        body = DocumentBodyFactory.build()
+        body.name = "Test Claimant v Test Defendant"
+        body.court = "Court of Testing"
+        body.jurisdiction = ""
+        body.categories = []
+        body.case_number = ""
+        body.document_date_as_string = "2023-02-03"
+        body.parties = []
+        body.judges = []
+
+        document = DocumentFactory.build(body=body)
+        document.annotation = ""
+
+        assert document.metadata.as_dict(exclude_empty=True) == {
+            "name": "Test Claimant v Test Defendant",
+            "court": "Court of Testing",
+            "date": "2023-02-03",
+            "uri": "test/2023/123",
+            "source_name": "Example Uploader",
+            "source_email": "uploader@example.com",
+            "consignment_reference": "TDR-12345",
+            "identifiers": document.identifiers,
+        }


### PR DESCRIPTION
Adds a metadata attribute to the document with the fields documented here: https://github.com/nationalarchives/ds-find-caselaw-docs/pull/509

## Jira

https://national-archives.atlassian.net/browse/FCLC-2014

FCL-

## Checklist

- [x] I have written tests to cover the new behaviour
- [ ] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
