### PR TITLE
[FCLC-2101] Clean up and standardise how we get metadata from XML body through to the new class-based metadata layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- read document comparison fields from metadata
 - move document body metadata extraction into metadata layer
 - embed document metadata defaults in factory XML fixtures
 - populate Document.metadata from registered metadata types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- embed document metadata defaults in factory XML fixtures
 - populate Document.metadata from registered metadata types
 - add CategoriesMetadata delegating to document body categories
 - add CaseNumberMetadata delegating to document body case number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- move document body metadata extraction into metadata layer
 - embed document metadata defaults in factory XML fixtures
 - populate Document.metadata from registered metadata types
 - add CategoriesMetadata delegating to document body categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - read document comparison fields from metadata
 - move document body metadata extraction into metadata layer
 - embed document metadata defaults in factory XML fixtures
-- populate Document.metadata from registered metadata types
+- populate Document.metadata from DocumentMetadataRegistry
 - add CategoriesMetadata delegating to document body categories
 - add CaseNumberMetadata delegating to document body case number
 - add DateMetadata delegating to document body date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- read force_reparse metadata from document metadata layer
 - read document comparison fields from metadata
 - move document body metadata extraction into metadata layer
 - embed document metadata defaults in factory XML fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Feat
 
+- read document validation helpers from metadata layer
 - read force_reparse metadata from document metadata layer
 - read document comparison fields from metadata
 - move document body metadata extraction into metadata layer

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -18,9 +18,33 @@ from caselawclient.types import DocumentURIString
 
 T = TypeVar("T")
 
-DEFAULT_DOCUMENT_BODY_XML = """<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+
+def build_document_body_xml(
+    *,
+    name: str = "Judgment v Judgement",
+    court: str = "Court of Testing",
+    jurisdiction: str = "",
+    document_date_as_string: str | None = "2023-02-03",
+    case_number: str = "",
+) -> str:
+    frbr_date_line = (
+        f'                            <FRBRdate date="{document_date_as_string}"/>\n' if document_date_as_string else ""
+    )
+    return f"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
             <judgment name="decision">
-                <meta/><header><p>Header contains text</p></header>
+                <meta>
+                    <identification>
+                        <FRBRWork>
+                            <FRBRname value="{name}"/>
+{frbr_date_line}                        </FRBRWork>
+                    </identification>
+                    <proprietary>
+                        <uk:court>{court}</uk:court>
+                        <uk:jurisdiction>{jurisdiction}</uk:jurisdiction>
+                        <uk:caseNumber>{case_number}</uk:caseNumber>
+                    </proprietary>
+                </meta>
+                <header><p>Header contains text</p></header>
                 <judgmentBody>
                 <decision>
                 <p>This is a document.</p>
@@ -31,24 +55,20 @@ DEFAULT_DOCUMENT_BODY_XML = """<akomaNtoso xmlns="http://docs.oasis-open.org/leg
 
 
 class DocumentBodyFactory:
-    # "name_of_attribute": "default value"
-    PARAMS_MAP: dict[str, Any] = {
-        "name": "Judgment v Judgement",
-        "court": "Court of Testing",
-        "document_date_as_string": "2023-02-03",
-    }
-
     @classmethod
-    def build(cls, xml_string: str = DEFAULT_DOCUMENT_BODY_XML, **kwargs: Any) -> DocumentBody:
-        document_body = DocumentBody(
+    def build(cls, xml_string: str | None = None, **kwargs: Any) -> DocumentBody:
+        if xml_string is None:
+            xml_string = build_document_body_xml(
+                name=kwargs.get("name", "Judgment v Judgement"),
+                court=kwargs.get("court", "Court of Testing"),
+                jurisdiction=kwargs.get("jurisdiction", ""),
+                document_date_as_string=kwargs.get("document_date_as_string", "2023-02-03"),
+                case_number=kwargs.get("case_number", ""),
+            )
+
+        return DocumentBody(
             xml_bytestring=xml_string.encode(encoding="utf-8"),
         )
-
-        for param_name, default_value in cls.PARAMS_MAP.items():
-            value = kwargs.get(param_name, default_value)
-            setattr(document_body, param_name, value)
-
-        return document_body
 
 
 class DocumentFactory:
@@ -82,7 +102,7 @@ class DocumentFactory:
 
         if not api_client:
             api_client = Mock(spec=MarklogicApiClient)
-            api_client.get_judgment_xml_bytestring.return_value = DEFAULT_DOCUMENT_BODY_XML.encode(encoding="utf-8")
+            api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml().encode(encoding="utf-8")
             api_client.get_property_as_node.return_value = None
 
         document = cls.target_class(uri, api_client=api_client)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from ds_caselaw_utils import courts
 from ds_caselaw_utils.courts import CourtNotFoundException
-from ds_caselaw_utils.types import NeutralCitationString
+from ds_caselaw_utils.types import CourtCode, NeutralCitationString
 from pydantic import TypeAdapter
 from requests_toolbelt.multipart import decoder
 
@@ -169,7 +169,7 @@ class Document:
         self._initialise_metadata()
 
     def __repr__(self) -> str:
-        name = self.body.name or "un-named"
+        name = self.metadata["name"].value or "un-named"  # type: ignore[attr-defined]
         return f"<{self.document_noun} {self.uri}: {name}>"
 
     def document_exists(self) -> bool:
@@ -352,14 +352,15 @@ class Document:
 
     @cached_property
     def has_name(self) -> bool:
-        return bool(self.body.name)
+        return bool(self.metadata["name"].value)  # type: ignore[attr-defined]
 
     @cached_property
     def has_valid_court(self) -> bool:
+        court = self.metadata["court"].value  # type: ignore[attr-defined]
+        jurisdiction = self.metadata["jurisdiction"].value  # type: ignore[attr-defined]
+        court_code = CourtCode("/".join((court, jurisdiction))) if jurisdiction != "" else CourtCode(court)
         try:
-            return bool(
-                courts.get_by_code(self.body.court_and_jurisdiction_identifier_string),
-            )
+            return bool(courts.get_by_code(court_code))
         except CourtNotFoundException:
             return False
 
@@ -928,7 +929,25 @@ class Document:
                 "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
             )
 
+    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
+        "name": ("name", "value"),
+        "court": ("court", "value"),
+        "jurisdiction": ("jurisdiction", "value"),
+        "document_date_as_date": ("date", "value"),
+        "document_date_as_string": ("date", "as_string"),
+        "case_number": ("case_number", "value"),
+        "categories": ("categories", "values"),
+    }
+
     def __getattr__(self, name: str) -> Any:
+        if name in self._METADATA_DEPRECATED_ATTRS:
+            metadata_key, attribute = self._METADATA_DEPRECATED_ATTRS[name]
+            warnings.warn(
+                f"{name} no longer exists on Document, using Document.metadata instead",
+                DeprecationWarning,
+            )
+            return getattr(self.metadata[metadata_key], attribute)
+
         warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
         try:
             return getattr(self.body, name)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -18,7 +18,7 @@ from caselawclient.errors import (
     OnlySupportedOnVersion,
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
-from caselawclient.models.documents.metadata.base import Metadata
+from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry, MetadataAttributeKey
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -142,14 +142,7 @@ class Document:
     Individual document classes should extend this list where necessary to validate document type-specific attributes.
     """
 
-    metadata_types: ClassVar[tuple[type[Metadata], ...]] = (
-        NameMetadata,
-        CourtMetadata,
-        JurisdictionMetadata,
-        DateMetadata,
-        CaseNumberMetadata,
-        CategoriesMetadata,
-    )
+    metadata: DocumentMetadataRegistry
 
     def __init__(self, uri: DocumentURIString, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
         """
@@ -169,7 +162,7 @@ class Document:
         self._initialise_metadata()
 
     def __repr__(self) -> str:
-        name = self.metadata["name"].value or "un-named"  # type: ignore[attr-defined]
+        name = self.metadata["name"].value or "un-named"
         return f"<{self.document_noun} {self.uri}: {name}>"
 
     def document_exists(self) -> bool:
@@ -210,13 +203,14 @@ class Document:
     def _initialise_metadata(self) -> None:
         """Initialise all this document's metadata values."""
 
-        metadata: dict[str, Metadata] = {}
-        for metadata_cls in type(self).metadata_types:
-            if metadata_cls.key in metadata:
-                msg = f"Duplicate metadata key {metadata_cls.key!r} registered on {type(self).__name__}"
-                raise ValueError(msg)
-            metadata[metadata_cls.key] = metadata_cls(self)
-        self.metadata = metadata
+        self.metadata = DocumentMetadataRegistry(
+            name=NameMetadata(self),
+            court=CourtMetadata(self),
+            jurisdiction=JurisdictionMetadata(self),
+            date=DateMetadata(self),
+            case_number=CaseNumberMetadata(self),
+            categories=CategoriesMetadata(self),
+        )
 
     @property
     def best_human_identifier(self) -> Optional[Identifier]:
@@ -352,12 +346,12 @@ class Document:
 
     @cached_property
     def has_name(self) -> bool:
-        return bool(self.metadata["name"].value)  # type: ignore[attr-defined]
+        return bool(self.metadata["name"].value)
 
     @cached_property
     def has_valid_court(self) -> bool:
-        court = self.metadata["court"].value  # type: ignore[attr-defined]
-        jurisdiction = self.metadata["jurisdiction"].value  # type: ignore[attr-defined]
+        court = self.metadata["court"].value
+        jurisdiction = self.metadata["jurisdiction"].value
         court_code = CourtCode("/".join((court, jurisdiction))) if jurisdiction != "" else CourtCode(court)
         try:
             return bool(courts.get_by_code(court_code))
@@ -859,9 +853,8 @@ class Document:
         self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
 
         checked_date: Optional[str] = (
-            self.metadata["date"].value.isoformat()  # type: ignore[attr-defined]
-            if self.metadata["date"].value  # type: ignore[attr-defined]
-            and self.metadata["date"].value > datetime.date(1001, 1, 1)  # type: ignore[attr-defined]
+            self.metadata["date"].value.isoformat()
+            if self.metadata["date"].value and self.metadata["date"].value > datetime.date(1001, 1, 1)
             else None
         )
 
@@ -871,9 +864,9 @@ class Document:
 
         parser_instructions: ParserInstructionsDict = {
             "metadata": {
-                "name": self.metadata["name"].value or None,  # type: ignore[attr-defined]
+                "name": self.metadata["name"].value or None,
                 "cite": None,
-                "court": self.metadata["court"].value or None,  # type: ignore[attr-defined]
+                "court": self.metadata["court"].value or None,
                 "date": checked_date,
                 "uri": self.uri,
             }
@@ -929,7 +922,7 @@ class Document:
                 "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
             )
 
-    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
+    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[MetadataAttributeKey, str]]] = {
         "name": ("name", "value"),
         "court": ("court", "value"),
         "jurisdiction": ("jurisdiction", "value"),
@@ -951,7 +944,7 @@ class Document:
         warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
         try:
             return getattr(self.body, name)
-        except Exception:
+        except AttributeError:
             raise AttributeError(f"Neither 'Document' nor 'DocumentBody' objects have an attribute '{name}'")
 
     def linked_document_resolutions(self, namespaces: list[str], only_published: bool = True) -> IdentifierResolutions:

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -858,8 +858,9 @@ class Document:
         self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
 
         checked_date: Optional[str] = (
-            self.body.document_date_as_date.isoformat()
-            if self.body.document_date_as_date and self.body.document_date_as_date > datetime.date(1001, 1, 1)
+            self.metadata["date"].value.isoformat()  # type: ignore[attr-defined]
+            if self.metadata["date"].value  # type: ignore[attr-defined]
+            and self.metadata["date"].value > datetime.date(1001, 1, 1)  # type: ignore[attr-defined]
             else None
         )
 
@@ -869,9 +870,9 @@ class Document:
 
         parser_instructions: ParserInstructionsDict = {
             "metadata": {
-                "name": self.body.name or None,
+                "name": self.metadata["name"].value or None,  # type: ignore[attr-defined]
                 "cite": None,
-                "court": self.body.court or None,
+                "court": self.metadata["court"].value or None,  # type: ignore[attr-defined]
                 "date": checked_date,
                 "uri": self.uri,
             }

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -7,7 +7,9 @@ from typing import Optional
 import pytz
 from ds_caselaw_utils.types import CourtCode
 from saxonche import PySaxonProcessor
+from typing_extensions import deprecated
 
+from caselawclient.models.documents.metadata.types.date import date_as_string_from_value
 from caselawclient.models.utilities.dates import parse_string_date_as_utc
 from caselawclient.types import DocumentCategory
 from caselawclient.xml_helpers import DEFAULT_NAMESPACES, Element
@@ -105,12 +107,8 @@ class DocumentBody:
         return CourtCode(self.court)
 
     @cached_property
-    def document_date_as_string(self) -> str:
-        return self.get_xpath_match_string(DATE_XPATH)
-
-    @cached_property
     def document_date_as_date(self) -> Optional[datetime.date]:
-        date_as_string = self.document_date_as_string
+        date_as_string = self.get_xpath_match_string(DATE_XPATH)
         if not date_as_string:
             return None
         try:
@@ -124,6 +122,11 @@ class DocumentBody:
                 UnparsableDate,
             )
             return None
+
+    @cached_property
+    @deprecated("Use Document.metadata['date'].as_string instead")
+    def document_date_as_string(self) -> str:
+        return date_as_string_from_value(self.document_date_as_date)
 
     def get_manifestation_datetimes(
         self,

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -30,6 +30,12 @@ DATE_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn
 
 
 def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
+    """Build a tree of document categories from Akoma Ntoso category XML nodes.
+
+    Top-level categories (nodes without a ``parent`` attribute) are returned in
+    document order. Child categories are attached to their parent's
+    ``subcategories`` list.
+    """
     categories: dict[str, DocumentCategory] = {}
     children_map: dict[str, list[DocumentCategory]] = {}
 

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -19,6 +19,40 @@ class UnparsableDate(Warning):
     pass
 
 
+NAME_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname/@value"
+COURT_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:court/text()"
+JURISDICTION_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdiction/text()"
+CATEGORIES_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
+CASE_NUMBER_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()"
+DATE_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date"
+
+
+def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
+    categories: dict[str, DocumentCategory] = {}
+    children_map: dict[str, list[DocumentCategory]] = {}
+
+    for node in nodes:
+        name = node.text
+        if name is None or not name.strip():
+            continue
+
+        category = DocumentCategory(name=name)
+        categories[name] = category
+
+        parent = node.get("parent")
+
+        if parent:
+            children_map.setdefault(parent, []).append(category)
+
+    for parent, subcategories in children_map.items():
+        if parent in categories:
+            categories[parent].subcategories.extend(subcategories)
+
+    return [
+        categories[name] for node in nodes if node.get("parent") is None if (name := node.text) and name in categories
+    ]
+
+
 class DocumentBody:
     """
     A class for abstracting out interactions with the body of a document.
@@ -39,51 +73,19 @@ class DocumentBody:
 
     @cached_property
     def name(self) -> str:
-        return self.get_xpath_match_string(
-            "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRname/@value"
-        )
+        return self.get_xpath_match_string(NAME_XPATH)
 
     @cached_property
     def court(self) -> str:
-        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:court/text()")
+        return self.get_xpath_match_string(COURT_XPATH)
 
     @cached_property
     def jurisdiction(self) -> str:
-        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdiction/text()")
+        return self.get_xpath_match_string(JURISDICTION_XPATH)
 
     @cached_property
     def categories(self) -> list[DocumentCategory]:
-        xpath = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
-        nodes = self.get_xpath_nodes(xpath)
-
-        categories: dict[str, DocumentCategory] = {}
-        children_map: dict[str, list[DocumentCategory]] = {}
-
-        for node in nodes:
-            name = node.text
-            if name is None or not name.strip():
-                continue
-
-            category = DocumentCategory(name=name)
-            categories[name] = category
-
-            parent = node.get("parent")
-
-            if parent:
-                children_map.setdefault(parent, []).append(category)
-
-        for parent, subcategories in children_map.items():
-            if parent in categories:
-                categories[parent].subcategories.extend(subcategories)
-
-        top_level_categories = [
-            categories[name]
-            for node in nodes
-            if node.get("parent") is None
-            if (name := node.text) and name in categories
-        ]
-
-        return top_level_categories
+        return categories_from_nodes(self.get_xpath_nodes(CATEGORIES_XPATH))
 
     # NOTE: Deprecated - use categories function
     @cached_property
@@ -94,7 +96,7 @@ class DocumentBody:
 
     @cached_property
     def case_number(self) -> Optional[str]:
-        return self.get_xpath_match_string("/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()")
+        return self.get_xpath_match_string(CASE_NUMBER_XPATH)
 
     @property
     def court_and_jurisdiction_identifier_string(self) -> CourtCode:
@@ -104,22 +106,21 @@ class DocumentBody:
 
     @cached_property
     def document_date_as_string(self) -> str:
-        return self.get_xpath_match_string(
-            "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date",
-        )
+        return self.get_xpath_match_string(DATE_XPATH)
 
     @cached_property
     def document_date_as_date(self) -> Optional[datetime.date]:
-        if not self.document_date_as_string:
+        date_as_string = self.document_date_as_string
+        if not date_as_string:
             return None
         try:
             return datetime.datetime.strptime(
-                self.document_date_as_string,
+                date_as_string,
                 "%Y-%m-%d",
             ).date()
         except ValueError:
             warnings.warn(
-                f"Unparsable date encountered: {self.document_date_as_string}",
+                f"Unparsable date encountered: {date_as_string}",
                 UnparsableDate,
             )
             return None

--- a/src/caselawclient/models/documents/comparison.py
+++ b/src/caselawclient/models/documents/comparison.py
@@ -19,22 +19,22 @@ class Comparison(dict[str, AttributeComparison]):
         # court, date, title
         self["court"] = AttributeComparison(
             label="court",
-            this_value=this_doc.metadata["court"].value,  # type: ignore[attr-defined]
-            that_value=that_doc.metadata["court"].value,  # type: ignore[attr-defined]
-            match=this_doc.metadata["court"].value == that_doc.metadata["court"].value,  # type: ignore[attr-defined]
+            this_value=this_doc.metadata["court"].value,
+            that_value=that_doc.metadata["court"].value,
+            match=this_doc.metadata["court"].value == that_doc.metadata["court"].value,
         )
 
         self["date"] = AttributeComparison(
             label="date",
-            this_value=this_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
-            that_value=that_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
-            match=this_doc.metadata["date"].as_string == that_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
+            this_value=this_doc.metadata["date"].as_string,
+            that_value=that_doc.metadata["date"].as_string,
+            match=this_doc.metadata["date"].as_string == that_doc.metadata["date"].as_string,
         )
         self["name"] = AttributeComparison(
             label="name",
-            this_value=this_doc.metadata["name"].value,  # type: ignore[attr-defined]
-            that_value=that_doc.metadata["name"].value,  # type: ignore[attr-defined]
-            match=this_doc.metadata["name"].value == that_doc.metadata["name"].value,  # type: ignore[attr-defined]
+            this_value=this_doc.metadata["name"].value,
+            that_value=that_doc.metadata["name"].value,
+            match=this_doc.metadata["name"].value == that_doc.metadata["name"].value,
         )
 
     def match(self) -> bool:

--- a/src/caselawclient/models/documents/comparison.py
+++ b/src/caselawclient/models/documents/comparison.py
@@ -19,22 +19,22 @@ class Comparison(dict[str, AttributeComparison]):
         # court, date, title
         self["court"] = AttributeComparison(
             label="court",
-            this_value=this_doc.court,
-            that_value=that_doc.court,
-            match=this_doc.court == that_doc.court,
+            this_value=this_doc.metadata["court"].value,  # type: ignore[attr-defined]
+            that_value=that_doc.metadata["court"].value,  # type: ignore[attr-defined]
+            match=this_doc.metadata["court"].value == that_doc.metadata["court"].value,  # type: ignore[attr-defined]
         )
 
         self["date"] = AttributeComparison(
             label="date",
-            this_value=this_doc.body.document_date_as_string,
-            that_value=that_doc.body.document_date_as_string,
-            match=this_doc.body.document_date_as_string == that_doc.body.document_date_as_string,
+            this_value=this_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
+            that_value=that_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
+            match=this_doc.metadata["date"].as_string == that_doc.metadata["date"].as_string,  # type: ignore[attr-defined]
         )
         self["name"] = AttributeComparison(
             label="name",
-            this_value=this_doc.name,
-            that_value=that_doc.name,
-            match=this_doc.name == that_doc.name,
+            this_value=this_doc.metadata["name"].value,  # type: ignore[attr-defined]
+            that_value=that_doc.metadata["name"].value,  # type: ignore[attr-defined]
+            match=this_doc.metadata["name"].value == that_doc.metadata["name"].value,  # type: ignore[attr-defined]
         )
 
     def match(self) -> bool:

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,0 +1,19 @@
+from typing import Literal, TypedDict
+
+from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
+from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
+from caselawclient.models.documents.metadata.types.court import CourtMetadata
+from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
+from caselawclient.models.documents.metadata.types.name import NameMetadata
+
+MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_number", "categories"]
+
+
+class DocumentMetadataRegistry(TypedDict):
+    name: NameMetadata
+    court: CourtMetadata
+    jurisdiction: JurisdictionMetadata
+    date: DateMetadata
+    case_number: CaseNumberMetadata
+    categories: CategoriesMetadata

--- a/src/caselawclient/models/documents/metadata/types/case_number.py
+++ b/src/caselawclient/models/documents/metadata/types/case_number.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
@@ -8,6 +6,6 @@ class CaseNumberMetadata(SingleMetadata[str | None]):
     title = "Case Number"
     description = "The case number of the document."
 
-    @cached_property
+    @property
     def value(self) -> str | None:
         return self.document.body.case_number

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from caselawclient.models.documents.metadata.base import MultipleMetadata
 from caselawclient.types import DocumentCategory
 
@@ -9,6 +7,6 @@ class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
     title = "Categories"
     description = "The categories assigned to the document."
 
-    @cached_property
+    @property
     def values(self) -> list[DocumentCategory]:
         return self.document.body.categories

--- a/src/caselawclient/models/documents/metadata/types/court.py
+++ b/src/caselawclient/models/documents/metadata/types/court.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
@@ -8,6 +6,6 @@ class CourtMetadata(SingleMetadata[str]):
     title = "Court"
     description = "The court that issued the document."
 
-    @cached_property
+    @property
     def value(self) -> str:
         return self.document.body.court

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -3,15 +3,24 @@ import datetime
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
+def date_as_string_from_value(value: datetime.date | None) -> str:
+    if value is None:
+        return ""
+    return value.strftime("%Y-%m-%d")
+
+
 class DateMetadata(SingleMetadata[datetime.date | None]):
     key = "date"
     title = "Date"
     description = "The date of the document."
 
     @property
-    def as_string(self) -> str:
-        return self.document.body.document_date_as_string
-
-    @property
     def value(self) -> datetime.date | None:
         return self.document.body.document_date_as_date
+
+    @property
+    def as_string(self) -> str:
+        return date_as_string_from_value(self.value)
+
+    def __str__(self) -> str:
+        return self.as_string

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -1,5 +1,4 @@
 import datetime
-from functools import cached_property
 
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
@@ -9,6 +8,10 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
     title = "Date"
     description = "The date of the document."
 
-    @cached_property
+    @property
+    def as_string(self) -> str:
+        return self.document.body.document_date_as_string
+
+    @property
     def value(self) -> datetime.date | None:
         return self.document.body.document_date_as_date

--- a/src/caselawclient/models/documents/metadata/types/jurisdiction.py
+++ b/src/caselawclient/models/documents/metadata/types/jurisdiction.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
@@ -8,6 +6,6 @@ class JurisdictionMetadata(SingleMetadata[str]):
     title = "Jurisdiction"
     description = "The jurisdiction of the document."
 
-    @cached_property
+    @property
     def value(self) -> str:
         return self.document.body.jurisdiction

--- a/src/caselawclient/models/documents/metadata/types/name.py
+++ b/src/caselawclient/models/documents/metadata/types/name.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
@@ -8,6 +6,6 @@ class NameMetadata(SingleMetadata[str]):
     title = "Name"
     description = "The name of the document."
 
-    @cached_property
+    @property
     def value(self) -> str:
         return self.document.body.name

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -301,9 +301,10 @@ class TestDocumentBody:
         """.encode()
         )
 
-        assert body.document_date_as_string == "kitten"
         with pytest.warns(UnparsableDate):
             assert body.document_date_as_date is None
+        with pytest.warns(DeprecationWarning):
+            assert body.document_date_as_string == ""
 
     def test_absent_date_as_string(self):
         body = DocumentBody(b"""

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -58,6 +58,22 @@ class TestNameMetadata:
         assert issubclass(NameMetadata, SingleMetadata)
         assert NameMetadata.key == "name"
 
+    def test_name_metadata_value_reads_from_xml(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+        from caselawclient.models.documents.metadata.types.name import NameMetadata
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Custom Case Name"),
+        )
+        metadata = NameMetadata(document)
+
+        assert metadata.value == "Custom Case Name"
+        assert document.body.name == metadata.value
+        name_from_registry = document.metadata["name"]
+        assert isinstance(name_from_registry, NameMetadata)
+        assert name_from_registry.value == metadata.value
+
     def test_name_metadata_value_matches_document_body_name(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.name import NameMetadata
@@ -97,6 +113,35 @@ class TestJurisdictionMetadata:
 
 
 class TestDateMetadata:
+    def test_date_metadata_value_reads_from_xml(self, mock_api_client):
+        import datetime
+
+        from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+        from caselawclient.models.documents.metadata.types.date import DateMetadata
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(document_date_as_string="2023-02-03"),
+        )
+        metadata = DateMetadata(document)
+
+        assert metadata.value == datetime.date(2023, 2, 3)
+        assert metadata.as_string == "2023-02-03"
+        assert document.body.document_date_as_date == metadata.value
+
+    def test_date_metadata_warns_on_unparsable_date(self):
+        from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+        from caselawclient.models.documents.body import UnparsableDate
+        from caselawclient.models.documents.metadata.types.date import DateMetadata
+
+        document = DocumentFactory.build(
+            body=DocumentBodyFactory.build(document_date_as_string="kitten"),
+        )
+        metadata = DateMetadata(document)
+
+        with pytest.warns(UnparsableDate):
+            assert metadata.value is None
+
     def test_date_metadata_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.date import DateMetadata

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -127,6 +127,7 @@ class TestDateMetadata:
 
         assert metadata.value == datetime.date(2023, 2, 3)
         assert metadata.as_string == "2023-02-03"
+        assert str(metadata) == "2023-02-03"
         assert document.body.document_date_as_date == metadata.value
 
     def test_date_metadata_warns_on_unparsable_date(self):
@@ -141,6 +142,8 @@ class TestDateMetadata:
 
         with pytest.warns(UnparsableDate):
             assert metadata.value is None
+        assert metadata.as_string == ""
+        assert str(metadata) == ""
 
     def test_date_metadata_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -124,6 +124,20 @@ class TestCategoriesMetadata:
 
 
 class TestDocumentMetadata:
+    def test_factory_built_document_metadata_reads_from_xml(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.types.court import CourtMetadata
+        from caselawclient.models.documents.metadata.types.name import NameMetadata
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        name_metadata = document.metadata["name"]
+        court_metadata = document.metadata["court"]
+        assert isinstance(name_metadata, NameMetadata)
+        assert isinstance(court_metadata, CourtMetadata)
+        assert name_metadata.value == "Judgment v Judgement"
+        assert court_metadata.value == "Court of Testing"
+
     def test_metadata_is_dict_keyed_by_metadata_type(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 

--- a/tests/models/documents/test_document_validation.py
+++ b/tests/models/documents/test_document_validation.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from caselawclient.factories import build_document_body_xml
 from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.models.documents.exceptions import CannotPublishUnpublishableDocument
 
@@ -25,25 +26,29 @@ class TestDocumentValidation:
         assert parked_document.is_parked is True
 
     def test_has_name(self, mock_api_client):
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(
+            name="Judgment v Judgement",
+        ).encode()
         document_with_name = Document(DocumentURIString("test/1234"), mock_api_client)
-        document_with_name.body.name = "Judgment v Judgement"
 
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(name="").encode()
         document_without_name = Document(DocumentURIString("test/1234"), mock_api_client)
-        document_without_name.body.name = ""
 
         assert document_with_name.has_name is True
         assert document_without_name.has_name is False
 
     def test_has_court_is_covered_by_has_valid_court(self, mock_api_client):
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(court="UKSC").encode()
         document_with_court = Document(DocumentURIString("test/1234"), mock_api_client)
-        document_with_court.body.court = "UKSC"
 
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(court="").encode()
         document_without_court = Document(DocumentURIString("test/1234"), mock_api_client)
-        document_without_court.body.court = ""
 
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(
+            court="UKFTT-GRC",
+            jurisdiction="InformationRights",
+        ).encode()
         document_with_court_and_jurisdiction = Document(DocumentURIString("test/1234"), mock_api_client)
-        document_with_court_and_jurisdiction.body.court = "UKFTT-GRC"
-        document_with_court_and_jurisdiction.body.jurisdiction = "InformationRights"
 
         assert document_with_court.has_valid_court is True
         assert document_with_court_and_jurisdiction.has_valid_court is True

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -377,11 +377,16 @@ class TestReparse:
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
     def test_force_reparse_empty(self, sns, mock_api_client):
+        from caselawclient.factories import build_document_body_xml
+
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(
+            name="",
+            court="",
+            document_date_as_string="1001-01-01",
+        ).encode()
         document = Judgment(DocumentURIString("test/2023/123"), mock_api_client)
 
         document.consignment_reference = "TDR-12345"
-
-        document.body.document_date_as_date = datetime.date(1001, 1, 1)
 
         document.force_reparse()
 
@@ -429,14 +434,17 @@ class TestReparse:
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
     def test_force_reparse_full(self, sns, mock_api_client):
+        from caselawclient.factories import build_document_body_xml
+
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(
+            name="Judgment v Judgement",
+            court="Court of Testing",
+            document_date_as_string="2023-02-03",
+        ).encode()
         document = Judgment(DocumentURIString("test/2023/123"), mock_api_client)
 
         document.neutral_citation = NeutralCitationString("[2023] Test 123")
         document.consignment_reference = "TDR-12345"
-
-        document.body.name = "Judgment v Judgement"
-        document.body.court = "Court of Testing"
-        document.body.document_date_as_date = datetime.date(2023, 2, 3)
 
         document.force_reparse()
 

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -68,8 +68,12 @@ class TestDocument:
         assert any("There is another document with identical content" in msg for msg in messages)
 
     def test_has_sensible_repr_with_name_and_judgment(self, mock_api_client):
+        from caselawclient.factories import build_document_body_xml
+
+        mock_api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml(
+            name="Document Name",
+        ).encode()
         document = Judgment(DocumentURIString("test/1234"), mock_api_client)
-        document.body.name = "Document Name"
         assert str(document) == "<judgment test/1234: Document Name>"
 
     def test_has_sensible_repr_without_name_or_subclass(self, mock_api_client):

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -363,6 +363,21 @@ class TestDocumentEnrichedRecently:
             ):
                 doc.x
 
+        def test_body_property_error_is_not_masked_as_attribute_error(self, mock_api_client):
+            doc = DocumentFactory.build(
+                uri=DocumentURIString("test/1234"), body=DocumentBodyFactory.build(name="docname")
+            )
+
+            def boom(_self: object) -> None:
+                raise ValueError("boom")
+
+            type(doc.body).boom = property(boom)  # type: ignore[attr-defined]
+            try:
+                with pytest.raises(ValueError, match="boom"):
+                    doc.boom
+            finally:
+                del type(doc.body).boom  # type: ignore[attr-defined]
+
 
 class TestDocumentURIString:
     def test_accepts_two_element_uri(self):


### PR DESCRIPTION
Now that we have a new metadata object framework, we can move the behaviour of actually moving behaviour to the new subclasses.

For most of these, they rely (for the moment) on the contents of `document.body`. We move the XPath to a nice clean list in the `Body`, which still handles actually reading the XML. This is a candidate for better cleanup in future, but isn't really on the critical path here.

This is all a stepping stone to the metadata layer being able to handle multiple sources of facts.

## Jira

FCLC-2101

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
