### PR TITLE
[FCLC-2101] Convert Document.metadata to a more proper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
-- `Document.metadata` is now an instance of `DocumentMetadataRegistry`, not a dict. Metadata items must be accessed with dot notation.
+- `Document.metadata` is now an instance of `DocumentMetadataRegistry`, not a dict. Metadata items must be accessed with dot notation (`document.metadata.name`), with no mapping-style API.
 
 ### Feat
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- `Document.metadata` is now an instance of `DocumentMetadataRegistry`, not a dict. Metadata items must be accessed with dot notation.
+
+### Feat
+
+- **Document**: convert document.metadata to a richer class
+- derive DateMetadata string representation from parsed value
+- read document validation helpers from metadata layer
+- read force_reparse metadata from document metadata layer
+- read document comparison fields from metadata
+- move document body metadata extraction into metadata layer
+- embed document metadata defaults in factory XML fixtures
+
+### Fix
+
+- address PR review feedback on metadata typing
+
 ## v47.1.0
 
 ### Feat

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -18,7 +18,7 @@ from caselawclient.errors import (
     OnlySupportedOnVersion,
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
-from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry, MetadataAttributeKey
+from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
@@ -909,7 +909,7 @@ class Document:
                 "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
             )
 
-    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[MetadataAttributeKey, str]]] = {
+    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
         "name": ("name", "value"),
         "court": ("court", "value"),
         "jurisdiction": ("jurisdiction", "value"),

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -19,12 +19,6 @@ from caselawclient.errors import (
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
 from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry, MetadataAttributeKey
-from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
-from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
-from caselawclient.models.documents.metadata.types.court import CourtMetadata
-from caselawclient.models.documents.metadata.types.date import DateMetadata
-from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
-from caselawclient.models.documents.metadata.types.name import NameMetadata
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
@@ -162,7 +156,7 @@ class Document:
         self._initialise_metadata()
 
     def __repr__(self) -> str:
-        name = self.metadata["name"].value or "un-named"
+        name = self.metadata.name.value or "un-named"
         return f"<{self.document_noun} {self.uri}: {name}>"
 
     def document_exists(self) -> bool:
@@ -203,14 +197,7 @@ class Document:
     def _initialise_metadata(self) -> None:
         """Initialise all this document's metadata values."""
 
-        self.metadata = DocumentMetadataRegistry(
-            name=NameMetadata(self),
-            court=CourtMetadata(self),
-            jurisdiction=JurisdictionMetadata(self),
-            date=DateMetadata(self),
-            case_number=CaseNumberMetadata(self),
-            categories=CategoriesMetadata(self),
-        )
+        self.metadata = DocumentMetadataRegistry(self)
 
     @property
     def best_human_identifier(self) -> Optional[Identifier]:
@@ -346,12 +333,12 @@ class Document:
 
     @cached_property
     def has_name(self) -> bool:
-        return bool(self.metadata["name"].value)
+        return bool(self.metadata.name.value)
 
     @cached_property
     def has_valid_court(self) -> bool:
-        court = self.metadata["court"].value
-        jurisdiction = self.metadata["jurisdiction"].value
+        court = self.metadata.court.value
+        jurisdiction = self.metadata.jurisdiction.value
         court_code = CourtCode("/".join((court, jurisdiction))) if jurisdiction != "" else CourtCode(court)
         try:
             return bool(courts.get_by_code(court_code))
@@ -853,8 +840,8 @@ class Document:
         self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
 
         checked_date: Optional[str] = (
-            self.metadata["date"].value.isoformat()
-            if self.metadata["date"].value and self.metadata["date"].value > datetime.date(1001, 1, 1)
+            self.metadata.date.value.isoformat()
+            if self.metadata.date.value and self.metadata.date.value > datetime.date(1001, 1, 1)
             else None
         )
 
@@ -864,9 +851,9 @@ class Document:
 
         parser_instructions: ParserInstructionsDict = {
             "metadata": {
-                "name": self.metadata["name"].value or None,
+                "name": self.metadata.name.value or None,
                 "cite": None,
-                "court": self.metadata["court"].value or None,
+                "court": self.metadata.court.value or None,
                 "date": checked_date,
                 "uri": self.uri,
             }
@@ -939,7 +926,7 @@ class Document:
                 f"{name} no longer exists on Document, using Document.metadata instead",
                 DeprecationWarning,
             )
-            return getattr(self.metadata[metadata_key], attribute)
+            return getattr(getattr(self.metadata, metadata_key), attribute)
 
         warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
         try:

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -130,7 +130,7 @@ class DocumentBody:
             return None
 
     @cached_property
-    @deprecated("Use Document.metadata['date'].as_string instead")
+    @deprecated("Use Document.metadata.date.as_string instead")
     def document_date_as_string(self) -> str:
         return date_as_string_from_value(self.document_date_as_date)
 

--- a/src/caselawclient/models/documents/comparison.py
+++ b/src/caselawclient/models/documents/comparison.py
@@ -19,22 +19,22 @@ class Comparison(dict[str, AttributeComparison]):
         # court, date, title
         self["court"] = AttributeComparison(
             label="court",
-            this_value=this_doc.metadata["court"].value,
-            that_value=that_doc.metadata["court"].value,
-            match=this_doc.metadata["court"].value == that_doc.metadata["court"].value,
+            this_value=this_doc.metadata.court.value,
+            that_value=that_doc.metadata.court.value,
+            match=this_doc.metadata.court.value == that_doc.metadata.court.value,
         )
 
         self["date"] = AttributeComparison(
             label="date",
-            this_value=this_doc.metadata["date"].as_string,
-            that_value=that_doc.metadata["date"].as_string,
-            match=this_doc.metadata["date"].as_string == that_doc.metadata["date"].as_string,
+            this_value=this_doc.metadata.date.as_string,
+            that_value=that_doc.metadata.date.as_string,
+            match=this_doc.metadata.date.as_string == that_doc.metadata.date.as_string,
         )
         self["name"] = AttributeComparison(
             label="name",
-            this_value=this_doc.metadata["name"].value,
-            that_value=that_doc.metadata["name"].value,
-            match=this_doc.metadata["name"].value == that_doc.metadata["name"].value,
+            this_value=this_doc.metadata.name.value,
+            that_value=that_doc.metadata.name.value,
+            match=this_doc.metadata.name.value == that_doc.metadata.name.value,
         )
 
     def match(self) -> bool:

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Iterator, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
@@ -34,36 +34,11 @@ class DocumentMetadataRegistry:
     categories: CategoriesMetadata
 
     def __init__(self, document: "Document") -> None:
-        self._by_key: dict[str, Metadata] = {}
+        seen_keys: set[str] = set()
         for metadata_cls in type(self).METADATA_TYPES:
             key = metadata_cls.key
-            if key in self._by_key:
+            if key in seen_keys:
                 msg = f"Duplicate metadata key {key!r} registered on {type(self).__name__}"
                 raise ValueError(msg)
-            metadata = metadata_cls(document)
-            self._by_key[key] = metadata
-            setattr(self, key, metadata)
-
-    def __getitem__(self, key: str) -> Metadata:
-        return self._by_key[key]
-
-    def get(self, key: str, default: Metadata | None = None) -> Metadata | None:
-        return self._by_key.get(key, default)
-
-    def keys(self) -> set[str]:
-        return set(self._by_key.keys())
-
-    def values(self) -> list[Metadata]:
-        return list(self._by_key.values())
-
-    def items(self) -> list[tuple[str, Metadata]]:
-        return list(self._by_key.items())
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._by_key)
-
-    def __len__(self) -> int:
-        return len(self._by_key)
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._by_key
+            seen_keys.add(key)
+            setattr(self, key, metadata_cls(document))

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
@@ -9,8 +9,6 @@ from caselawclient.models.documents.metadata.types.name import NameMetadata
 
 if TYPE_CHECKING:
     from caselawclient.models.documents import Document
-
-MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_number", "categories"]
 
 
 class DocumentMetadataRegistry:

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,6 +1,5 @@
-from typing import TYPE_CHECKING, Literal, get_type_hints
+from typing import TYPE_CHECKING, Literal
 
-from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -15,11 +14,7 @@ MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_nu
 
 
 class DocumentMetadataRegistry:
-    """Typed registry of metadata objects for a document.
-
-    Annotated attributes are the single source of registered metadata types;
-    instances are built by iterating those annotations.
-    """
+    """Typed registry of metadata objects for a document."""
 
     name: NameMetadata
     court: CourtMetadata
@@ -29,14 +24,9 @@ class DocumentMetadataRegistry:
     categories: CategoriesMetadata
 
     def __init__(self, document: "Document") -> None:
-        for key, metadata_cls in type(self).metadata_types().items():
-            setattr(self, key, metadata_cls(document))
-
-    @classmethod
-    def metadata_types(cls) -> dict[str, type[Metadata]]:
-        """Return attribute name → metadata class for registered fields."""
-        return {
-            key: metadata_cls
-            for key, metadata_cls in get_type_hints(cls).items()
-            if isinstance(metadata_cls, type) and issubclass(metadata_cls, Metadata)
-        }
+        self.name = NameMetadata(document)
+        self.court = CourtMetadata(document)
+        self.jurisdiction = JurisdictionMetadata(document)
+        self.date = DateMetadata(document)
+        self.case_number = CaseNumberMetadata(document)
+        self.categories = CategoriesMetadata(document)

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, Literal, get_type_hints
 
 from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
@@ -15,16 +15,11 @@ MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_nu
 
 
 class DocumentMetadataRegistry:
-    """Typed registry of metadata objects for a document."""
+    """Typed registry of metadata objects for a document.
 
-    METADATA_TYPES: ClassVar[tuple[type[Metadata], ...]] = (
-        NameMetadata,
-        CourtMetadata,
-        JurisdictionMetadata,
-        DateMetadata,
-        CaseNumberMetadata,
-        CategoriesMetadata,
-    )
+    Annotated attributes are the single source of registered metadata types;
+    instances are built by iterating those annotations.
+    """
 
     name: NameMetadata
     court: CourtMetadata
@@ -34,11 +29,14 @@ class DocumentMetadataRegistry:
     categories: CategoriesMetadata
 
     def __init__(self, document: "Document") -> None:
-        seen_keys: set[str] = set()
-        for metadata_cls in type(self).METADATA_TYPES:
-            key = metadata_cls.key
-            if key in seen_keys:
-                msg = f"Duplicate metadata key {key!r} registered on {type(self).__name__}"
-                raise ValueError(msg)
-            seen_keys.add(key)
+        for key, metadata_cls in type(self).metadata_types().items():
             setattr(self, key, metadata_cls(document))
+
+    @classmethod
+    def metadata_types(cls) -> dict[str, type[Metadata]]:
+        """Return attribute name → metadata class for registered fields."""
+        return {
+            key: metadata_cls
+            for key, metadata_cls in get_type_hints(cls).items()
+            if isinstance(metadata_cls, type) and issubclass(metadata_cls, Metadata)
+        }

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,5 +1,6 @@
-from typing import Literal, TypedDict
+from typing import TYPE_CHECKING, ClassVar, Iterator, Literal
 
+from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -7,13 +8,62 @@ from caselawclient.models.documents.metadata.types.date import DateMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 
+if TYPE_CHECKING:
+    from caselawclient.models.documents import Document
+
 MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_number", "categories"]
 
 
-class DocumentMetadataRegistry(TypedDict):
+class DocumentMetadataRegistry:
+    """Typed registry of metadata objects for a document."""
+
+    METADATA_TYPES: ClassVar[tuple[type[Metadata], ...]] = (
+        NameMetadata,
+        CourtMetadata,
+        JurisdictionMetadata,
+        DateMetadata,
+        CaseNumberMetadata,
+        CategoriesMetadata,
+    )
+
     name: NameMetadata
     court: CourtMetadata
     jurisdiction: JurisdictionMetadata
     date: DateMetadata
     case_number: CaseNumberMetadata
     categories: CategoriesMetadata
+
+    def __init__(self, document: "Document") -> None:
+        self._by_key: dict[str, Metadata] = {}
+        for metadata_cls in type(self).METADATA_TYPES:
+            key = metadata_cls.key
+            if key in self._by_key:
+                msg = f"Duplicate metadata key {key!r} registered on {type(self).__name__}"
+                raise ValueError(msg)
+            metadata = metadata_cls(document)
+            self._by_key[key] = metadata
+            setattr(self, key, metadata)
+
+    def __getitem__(self, key: str) -> Metadata:
+        return self._by_key[key]
+
+    def get(self, key: str, default: Metadata | None = None) -> Metadata | None:
+        return self._by_key.get(key, default)
+
+    def keys(self) -> set[str]:
+        return set(self._by_key.keys())
+
+    def values(self) -> list[Metadata]:
+        return list(self._by_key.values())
+
+    def items(self) -> list[tuple[str, Metadata]]:
+        return list(self._by_key.items())
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._by_key)
+
+    def __len__(self) -> int:
+        return len(self._by_key)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._by_key

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -70,7 +70,7 @@ class TestNameMetadata:
 
         assert metadata.value == "Custom Case Name"
         assert document.body.name == metadata.value
-        name_from_registry = document.metadata["name"]
+        name_from_registry = document.metadata.name
         assert isinstance(name_from_registry, NameMetadata)
         assert name_from_registry.value == metadata.value
 
@@ -179,27 +179,27 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        name_metadata = document.metadata["name"]
-        court_metadata = document.metadata["court"]
+        name_metadata = document.metadata.name
+        court_metadata = document.metadata.court
         assert isinstance(name_metadata, NameMetadata)
         assert isinstance(court_metadata, CourtMetadata)
         assert name_metadata.value == "Judgment v Judgement"
         assert court_metadata.value == "Court of Testing"
 
-    def test_metadata_is_dict_keyed_by_metadata_type(self, mock_api_client):
+    def test_metadata_is_document_metadata_registry(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata, dict)
-        assert document.metadata
+        assert isinstance(document.metadata, DocumentMetadataRegistry)
 
     def test_metadata_keys_match_registered_types(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert set(document.metadata.keys()) == {
+        assert document.metadata.keys() == {
             "name",
             "court",
             "jurisdiction",
@@ -219,19 +219,19 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata["name"], NameMetadata)
-        assert isinstance(document.metadata["court"], CourtMetadata)
-        assert isinstance(document.metadata["jurisdiction"], JurisdictionMetadata)
-        assert isinstance(document.metadata["date"], DateMetadata)
-        assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
-        assert isinstance(document.metadata["categories"], CategoriesMetadata)
+        assert isinstance(document.metadata.name, NameMetadata)
+        assert isinstance(document.metadata.court, CourtMetadata)
+        assert isinstance(document.metadata.jurisdiction, JurisdictionMetadata)
+        assert isinstance(document.metadata.date, DateMetadata)
+        assert isinstance(document.metadata.case_number, CaseNumberMetadata)
+        assert isinstance(document.metadata.categories, CategoriesMetadata)
 
     def test_metadata_name_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.name import NameMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
-        name_metadata = document.metadata["name"]
+        name_metadata = document.metadata.name
         assert isinstance(name_metadata, NameMetadata)
         assert name_metadata.value == document.body.name
 
@@ -240,7 +240,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
-        categories_metadata = document.metadata["categories"]
+        categories_metadata = document.metadata.categories
         assert isinstance(categories_metadata, CategoriesMetadata)
         assert categories_metadata.values == document.body.categories
 
@@ -256,4 +256,14 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert len(list(document.metadata.values())) == 6
+        assert len(document.metadata.values()) == 6
+
+    def test_metadata_registry_is_built_from_metadata_types_tuple(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert len(DocumentMetadataRegistry.METADATA_TYPES) == 6
+        for metadata_cls in DocumentMetadataRegistry.METADATA_TYPES:
+            assert isinstance(getattr(document.metadata, metadata_cls.key), metadata_cls)

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -230,13 +230,20 @@ class TestDocumentMetadata:
         assert isinstance(categories_metadata, CategoriesMetadata)
         assert categories_metadata.values == document.body.categories
 
-    def test_metadata_registry_is_built_from_annotated_fields(self, mock_api_client):
+    def test_metadata_registry_exposes_all_registered_fields(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry
+        from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
+        from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
+        from caselawclient.models.documents.metadata.types.court import CourtMetadata
+        from caselawclient.models.documents.metadata.types.date import DateMetadata
+        from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
+        from caselawclient.models.documents.metadata.types.name import NameMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        metadata_types = DocumentMetadataRegistry.metadata_types()
-        assert len(metadata_types) == 6
-        for key, metadata_cls in metadata_types.items():
-            assert isinstance(getattr(document.metadata, key), metadata_cls)
+        assert isinstance(document.metadata.name, NameMetadata)
+        assert isinstance(document.metadata.court, CourtMetadata)
+        assert isinstance(document.metadata.jurisdiction, JurisdictionMetadata)
+        assert isinstance(document.metadata.date, DateMetadata)
+        assert isinstance(document.metadata.case_number, CaseNumberMetadata)
+        assert isinstance(document.metadata.categories, CategoriesMetadata)

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -230,12 +230,13 @@ class TestDocumentMetadata:
         assert isinstance(categories_metadata, CategoriesMetadata)
         assert categories_metadata.values == document.body.categories
 
-    def test_metadata_registry_is_built_from_metadata_types_tuple(self, mock_api_client):
+    def test_metadata_registry_is_built_from_annotated_fields(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert len(DocumentMetadataRegistry.METADATA_TYPES) == 6
-        for metadata_cls in DocumentMetadataRegistry.METADATA_TYPES:
-            assert isinstance(getattr(document.metadata, metadata_cls.key), metadata_cls)
+        metadata_types = DocumentMetadataRegistry.metadata_types()
+        assert len(metadata_types) == 6
+        for key, metadata_cls in metadata_types.items():
+            assert isinstance(getattr(document.metadata, key), metadata_cls)

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -194,20 +194,6 @@ class TestDocumentMetadata:
 
         assert isinstance(document.metadata, DocumentMetadataRegistry)
 
-    def test_metadata_keys_match_registered_types(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert document.metadata.keys() == {
-            "name",
-            "court",
-            "jurisdiction",
-            "date",
-            "case_number",
-            "categories",
-        }
-
     def test_metadata_entries_are_expected_types(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
@@ -243,20 +229,6 @@ class TestDocumentMetadata:
         categories_metadata = document.metadata.categories
         assert isinstance(categories_metadata, CategoriesMetadata)
         assert categories_metadata.values == document.body.categories
-
-    def test_metadata_get_returns_none_for_unknown_key(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert document.metadata.get("nonexistent") is None
-
-    def test_metadata_values_yields_all_registered_instances(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert len(document.metadata.values()) == 6
 
     def test_metadata_registry_is_built_from_metadata_types_tuple(self, mock_api_client):
         from caselawclient.factories import DocumentFactory


### PR DESCRIPTION
## Summary
- Replace the `DocumentMetadataRegistry` TypedDict with a real class
- Registry is still maintained via a structured `METADATA_TYPES` tuple
- Access is now strictly typed attributes: `document.metadata.name.value` (breaking)

## Test plan
- [ ] Document unit tests pass
- [ ] Spot-check comparison / force_reparse / validation helper paths
- [ ] Confirm deprecated Document attrs still route through registry attributes