### PR TITLE
fix: Fix document.has_content for XML documents with judgment body but no header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## v47.2.1 (2026-07-17)
+
+### Fix
+
+- treat judgments with visible content in `judgmentBody` as having content even when the `header` is empty
+
 ## v47.2.0 (2026-07-15)
 
 ### Feat

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -185,11 +185,25 @@ class DocumentBody:
 
     @cached_property
     def has_content(self) -> bool:
-        """If we do not have a word document, the XML will not contain
-        the contents of the judgment, but will have content in the header if a judgment.
-        All press summaries (which have <doc> not <judgment> tags) are assumed to have content"""
+        """Does this XML contain rendered document content?
+
+        There are two main judgment shapes we need to handle.
+
+        PDF-only documents may have visible text only in the header and no usable
+        judgment body content.
+
+        DOCX-backed documents usually have visible text in both the header and the
+        judgment body, but parser edge cases can leave the header empty even when
+        the judgment body still contains the rendered judgment text.
+
+        Press summaries are represented as top-level ``doc`` nodes and
+        are assumed to have content.
+        """
         return bool(
             self._xml.xml_as_tree.xpath("//akn:header[normalize-space(string(.))]", namespaces=DEFAULT_NAMESPACES)
+            or self._xml.xml_as_tree.xpath(
+                "//akn:judgmentBody[normalize-space(string(.))]", namespaces=DEFAULT_NAMESPACES
+            )
             or self._xml.xml_as_tree.xpath("//akn:doc", namespaces=DEFAULT_NAMESPACES)
         )
 

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -400,6 +400,21 @@ class TestDocumentBody:
             </akomaNtoso>""")
         assert body.has_content
 
+    def test_actual_content_judgment_body(self):
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <judgment name="decision">
+                <meta/>
+                <header/>
+                <judgmentBody>
+                <decision>
+                    <p><span>a</span></p>
+                </decision>
+                </judgmentBody>
+            </judgment>
+            </akomaNtoso>""")
+        assert body.has_content
+
         def test_actual_content_preface(self):
             body = DocumentBodyFactory.build("""
                 <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCLC-2158
…[

<!-- Replace this with a short summary of changes in this PR -->
](fix: Fix document.has_content for XML documents with judgment body but no header)
## Jira


## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
