### PR TITLE
FCLC-2172 | add get courts with document count method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **Metadata**: add editable flag to metadata fields
+- Add method to fetch a list of all courts and their document counts
 
 ## v47.2.2 (2026-07-21)
 

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -1220,6 +1220,16 @@ class MarklogicApiClient:
 
         return results
 
+    def get_courts_with_document_count(self) -> dict[str, int]:
+        """Retrieve the number of published documents for each court."""
+        results: dict[str, int] = json.loads(
+            get_single_string_from_marklogic_response(
+                self._send_to_eval({}, "get_courts_with_document_count.xqy"),
+            ),
+        )
+
+        return results
+
     def get_highest_enrichment_version(self) -> tuple[int, int]:
         """This gets the highest enrichment version in the database,
         so if nothing has been enriched with the most recent version of enrichment,

--- a/src/caselawclient/xquery/get_courts_with_document_count.xqy
+++ b/src/caselawclient/xquery/get_courts_with_document_count.xqy
@@ -1,22 +1,26 @@
 xquery version "1.0-ml";
 
-declare namespace cts = "http://marklogic.com/cts";
-declare namespace map = "http://marklogic.com/xdmp/map";
+import module namespace dls = "http://marklogic.com/xdmp/dls" at "/MarkLogic/dls.xqy";
+
+declare namespace akn = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0";
 declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 
 let $query := cts:and-query((
-  cts:collection-query("http://marklogic.com/collections/dls/latest-version"),
+  dls:documents-query(),
   cts:properties-fragment-query(
-    cts:element-value-query(xs:QName("published"), "true")
+    cts:element-value-query(fn:QName("", "published"), "true")
   )
 ))
+let $court-ref := cts:path-reference(
+  "//akn:proprietary/uk:court",
+  ("type=string", "collation=http://marklogic.com/collation/")
+)
 let $court-counts := map:map()
 let $_ := (
-  for $doc in cts:search(fn:collection(), $query)
-  let $court-key := fn:lower-case(fn:normalize-space(fn:string(($doc//uk:court)[1])))
+  for $court in cts:values($court-ref, (), ("item-order"), $query)
+  let $court-key := fn:lower-case(fn:normalize-space($court))
   let $existing-count := (map:get($court-counts, $court-key), 0)[1]
   where $court-key
-  return map:put($court-counts, $court-key, $existing-count + 1)
+  return map:put($court-counts, $court-key, $existing-count + cts:frequency($court))
 )
-
 return xdmp:to-json($court-counts)

--- a/src/caselawclient/xquery/get_courts_with_document_count.xqy
+++ b/src/caselawclient/xquery/get_courts_with_document_count.xqy
@@ -1,0 +1,22 @@
+xquery version "1.0-ml";
+
+declare namespace cts = "http://marklogic.com/cts";
+declare namespace map = "http://marklogic.com/xdmp/map";
+declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
+
+let $query := cts:and-query((
+  cts:collection-query("http://marklogic.com/collections/dls/latest-version"),
+  cts:properties-fragment-query(
+    cts:element-value-query(xs:QName("published"), "true")
+  )
+))
+let $court-counts := map:map()
+let $_ := (
+  for $doc in cts:search(fn:collection(), $query)
+  let $court-key := fn:lower-case(fn:normalize-space(fn:string(($doc//uk:court)[1])))
+  let $existing-count := (map:get($court-counts, $court-key), 0)[1]
+  where $court-key
+  return map:put($court-counts, $court-key, $existing-count + 1)
+)
+
+return xdmp:to-json($court-counts)

--- a/src/caselawclient/xquery/get_courts_with_document_count.xqy
+++ b/src/caselawclient/xquery/get_courts_with_document_count.xqy
@@ -8,7 +8,7 @@ declare namespace uk = "https://caselaw.nationalarchives.gov.uk/akn";
 let $query := cts:and-query((
   dls:documents-query(),
   cts:properties-fragment-query(
-    cts:element-value-query(fn:QName("", "published"), "true")
+    cts:element-value-query(fn:QName("published"), "true")
   )
 ))
 let $court-ref := cts:path-reference(

--- a/tests/client/test_stats.py
+++ b/tests/client/test_stats.py
@@ -26,3 +26,19 @@ class TestStats(unittest.TestCase):
                 ["R1C1", "R1C2"],
                 ["R2C1", "R2C2"],
             ]
+
+    def test_get_courts_with_document_count(self):
+        with patch.object(self.client, "eval") as mock_eval:
+            mock_eval.return_value.text = '{"uksc":12,"ukip":42}'
+            mock_eval.return_value.headers = {
+                "content-type": "multipart/mixed; boundary=595658fa1db1aa98",
+            }
+            mock_eval.return_value.content = (
+                b"\r\n--595658fa1db1aa98\r\n"
+                b"Content-Type: text/plain\r\n"
+                b'\r\n{"uksc":12,"ukip":42}\r\n'
+                b"--595658fa1db1aa98--\r\n"
+            )
+            result = self.client.get_courts_with_document_count()
+
+            assert result == {"uksc": 12, "ukip": 42}


### PR DESCRIPTION
This adds a method to the client to allow getting all the courts and their document counts.

Currently in the PUI, we loop over the list of courts and tribunals and fetch the count for each individually which massively slows the loading of the page.

Once this is in, we can do a single fetch to get the counts for all courts.

## Jira

https://national-archives.atlassian.net/browse/FCLC-2172

FCL-

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
