### PR TITLE
[FCLC-2174] Add editable flag to metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Metadata**: add editable flag to metadata fields
+
 ## v47.2.2 (2026-07-21)
 
 ### Fix

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -12,6 +12,9 @@ class Metadata(ABC):
     title: ClassVar[str]
     description: ClassVar[str]
 
+    editable: ClassVar[bool] = False
+    """Should editors be allowed to manually edit this metadata field?"""
+
     def __init__(self, document: "Document") -> None:
         self.document = document
 

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -40,6 +40,7 @@ class TestMetadataBase:
         assert metadata.key == "test_single"
         assert metadata.title == "Test Single"
         assert metadata.description == "A test single metadata item."
+        assert metadata.editable is False
         assert metadata.value == "single value"
 
     def test_concrete_multiple_metadata_exposes_values(self):
@@ -48,7 +49,16 @@ class TestMetadataBase:
         assert metadata.key == "test_multiple"
         assert metadata.title == "Test Multiple"
         assert metadata.description == "A test multiple metadata item."
+        assert metadata.editable is False
         assert metadata.values == ["first", "second"]
+
+    def test_editable_can_be_overridden_on_subclass(self):
+        class _EditableMetadata(_TestSingleMetadata):
+            editable = True
+
+        metadata = _EditableMetadata(Mock())
+
+        assert metadata.editable is True
 
 
 class TestNameMetadata:


### PR DESCRIPTION
## Summary
- Add an `editable` ClassVar on the base `Metadata` class so consumers can tell whether a field should be manually edited
- Default all metadata fields to `editable = False` (overridable per subclass)

## Jira

FCLC-2174

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change