### PR TITLE
[FCLC-2175] Add ability to store and retrieve structured metadata in MarkLogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### Feat
+
+- resolve document.metadata from metadata_fields with body fallback
+- load and save metadata_fields on Document
+- add metadata_fields storage model with pack/unpack and resolution
+
 ### Fix
 
 - Put param back into query that was required

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -18,7 +18,13 @@ from caselawclient.errors import (
     OnlySupportedOnVersion,
 )
 from caselawclient.identifier_resolution import IdentifierResolutions
-from caselawclient.models.documents.metadata.registry import DocumentMetadataRegistry, MetadataAttributeKey
+from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
+from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
+from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
+from caselawclient.models.documents.metadata.registry import (
+    DocumentMetadata,
+    MetadataAttributeKey,
+)
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -142,7 +148,8 @@ class Document:
     Individual document classes should extend this list where necessary to validate document type-specific attributes.
     """
 
-    metadata: DocumentMetadataRegistry
+    metadata: DocumentMetadata
+    metadata_fields: MetadataFieldsCollection
 
     def __init__(self, uri: DocumentURIString, api_client: "MarklogicApiClient", search_query: Optional[str] = None):
         """
@@ -159,10 +166,11 @@ class Document:
 
         self._initialise_document_body(search_query=search_query)
         self._initialise_identifiers()
+        self._initialise_metadata_fields()
         self._initialise_metadata()
 
     def __repr__(self) -> str:
-        name = self.metadata["name"].value or "un-named"
+        name = self.metadata["title"].value or "un-named"
         return f"<{self.document_noun} {self.uri}: {name}>"
 
     def document_exists(self) -> bool:
@@ -200,16 +208,22 @@ class Document:
         identifiers_element_as_etree = self.api_client.get_property_as_node(self.uri, "identifiers")
         self.identifiers = unpack_all_identifiers_from_etree(identifiers_element_as_etree)
 
+    def _initialise_metadata_fields(self) -> None:
+        """Load this document's metadata_fields property from MarkLogic."""
+
+        metadata_fields_element = self.api_client.get_property_as_node(self.uri, "metadata_fields")
+        self.metadata_fields = unpack_all_metadata_fields_from_etree(metadata_fields_element)
+
     def _initialise_metadata(self) -> None:
         """Initialise all this document's metadata values."""
 
-        self.metadata = DocumentMetadataRegistry(
-            name=NameMetadata(self),
+        self.metadata = DocumentMetadata(
+            title=NameMetadata(self),
             court=CourtMetadata(self),
             jurisdiction=JurisdictionMetadata(self),
             date=DateMetadata(self),
             case_number=CaseNumberMetadata(self),
-            categories=CategoriesMetadata(self),
+            category=CategoriesMetadata(self),
         )
 
     @property
@@ -346,7 +360,7 @@ class Document:
 
     @cached_property
     def has_name(self) -> bool:
-        return bool(self.metadata["name"].value)
+        return bool(self.metadata["title"].value)
 
     @cached_property
     def has_valid_court(self) -> bool:
@@ -864,7 +878,7 @@ class Document:
 
         parser_instructions: ParserInstructionsDict = {
             "metadata": {
-                "name": self.metadata["name"].value or None,
+                "name": self.metadata["title"].value or None,
                 "cite": None,
                 "court": self.metadata["court"].value or None,
                 "date": checked_date,
@@ -922,14 +936,27 @@ class Document:
                 "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
             )
 
+    def validate_metadata_fields(self) -> SuccessFailureMessageTuple:
+        return self.metadata_fields.validate_ids_match_keys()
+
+    def save_metadata_fields(self) -> None:
+        """Validate metadata fields, and if validation passes save them to MarkLogic."""
+        validations = self.validate_metadata_fields()
+        if validations.success is True:
+            self.api_client.set_property_as_node(self.uri, "metadata_fields", self.metadata_fields.as_etree)
+        else:
+            raise MetadataFieldValidationException(
+                "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
+            )
+
     _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[MetadataAttributeKey, str]]] = {
-        "name": ("name", "value"),
+        "name": ("title", "value"),
         "court": ("court", "value"),
         "jurisdiction": ("jurisdiction", "value"),
         "document_date_as_date": ("date", "value"),
         "document_date_as_string": ("date", "as_string"),
         "case_number": ("case_number", "value"),
-        "categories": ("categories", "values"),
+        "categories": ("category", "values"),
     }
 
     def __getattr__(self, name: str) -> Any:

--- a/src/caselawclient/models/documents/comparison.py
+++ b/src/caselawclient/models/documents/comparison.py
@@ -32,9 +32,9 @@ class Comparison(dict[str, AttributeComparison]):
         )
         self["name"] = AttributeComparison(
             label="name",
-            this_value=this_doc.metadata["name"].value,
-            that_value=that_doc.metadata["name"].value,
-            match=this_doc.metadata["name"].value == that_doc.metadata["name"].value,
+            this_value=this_doc.metadata["title"].value,
+            that_value=that_doc.metadata["title"].value,
+            match=this_doc.metadata["title"].value == that_doc.metadata["title"].value,
         )
 
     def match(self) -> bool:

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 if TYPE_CHECKING:
     from caselawclient.models.documents import Document
+    from caselawclient.models.documents.metadata.fields.resolution import ResolvedMetadataField
 
 T = TypeVar("T")
 
@@ -17,6 +18,9 @@ class Metadata(ABC):
 
     def __init__(self, document: "Document") -> None:
         self.document = document
+
+    def _resolve_claims(self) -> "ResolvedMetadataField":
+        return self.document.metadata_fields.resolve(self.key)
 
 
 class SingleMetadata(Metadata, Generic[T]):

--- a/src/caselawclient/models/documents/metadata/fields/collection.py
+++ b/src/caselawclient/models/documents/metadata/fields/collection.py
@@ -1,0 +1,58 @@
+from lxml import etree
+
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    MetadataFieldRemovalNotAllowedException,
+)
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.resolution import ResolvedMetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.types import SuccessFailureMessageTuple
+from caselawclient.xml_helpers import Element
+
+
+class MetadataFieldsCollection(dict[str, MetadataField]):
+    """Collection of metadata claims keyed by claim id."""
+
+    def add(self, field: MetadataField) -> None:
+        self[field.id] = field
+
+    def by_name(self, name: str) -> list[MetadataField]:
+        return [field for field in self.values() if field.name == name]
+
+    def resolve(self, name: str) -> ResolvedMetadataField:
+        return ResolvedMetadataField(name=name, claims=self.by_name(name))
+
+    def reject(self, field_id: str) -> None:
+        """Soft-delete a claim by id."""
+        self[field_id].reject()
+
+    def remove(self, field_id: str) -> None:
+        """Hard-remove a claim. Only allowed for editor-sourced claims.
+
+        To change an editor-sourced value, remove the existing claim and add a
+        new one with a fresh id and timestamp.
+        """
+        field = self[field_id]
+        if field.source is not MetadataSource.EDITOR:
+            raise MetadataFieldRemovalNotAllowedException(
+                f"Cannot hard-remove metadata claim {field_id} with source "
+                f"'{field.source.value}'; use reject() to soft-delete document or external claims."
+            )
+        del self[field_id]
+
+    @property
+    def as_etree(self) -> Element:
+        """Return an etree representation of all metadata claims."""
+        root = etree.Element("metadata_fields")
+        for field in self.values():
+            root.append(field.as_etree)
+        return root
+
+    def validate_ids_match_keys(self) -> SuccessFailureMessageTuple:
+        for key, field in self.items():
+            if key != field.id:
+                return SuccessFailureMessageTuple(
+                    False,
+                    [f"Key of {field} in MetadataFieldsCollection is {key} not {field.id}"],
+                )
+        return SuccessFailureMessageTuple(True, [])

--- a/src/caselawclient/models/documents/metadata/fields/exceptions.py
+++ b/src/caselawclient/models/documents/metadata/fields/exceptions.py
@@ -1,0 +1,10 @@
+class InvalidMetadataFieldXMLRepresentationException(Exception):
+    """Raised when a metadata field cannot be unpacked from XML."""
+
+
+class MetadataFieldRemovalNotAllowedException(Exception):
+    """Raised when attempting to hard-remove a non-editor metadata claim."""
+
+
+class MetadataFieldValidationException(Exception):
+    """Raised when metadata fields fail validation before save."""

--- a/src/caselawclient/models/documents/metadata/fields/field.py
+++ b/src/caselawclient/models/documents/metadata/fields/field.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Optional, Union
+from uuid import uuid4
+
+from lxml import etree
+
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.xml_helpers import Element
+
+MetadataFieldValue = Union[str, "MetadataCategoryValue"]
+
+
+@dataclass(frozen=True)
+class MetadataCategoryValue:
+    """Structured value for a ``category`` metadata claim."""
+
+    name: str
+    parent: str | None = None
+
+
+class MetadataField:
+    """A single metadata claim stored in the MarkLogic ``metadata_fields`` property.
+
+    There is no in-place update API. To change an editor-sourced value, remove the
+    existing claim and add a new one (new id and timestamp).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        value: MetadataFieldValue,
+        source: MetadataSource,
+        *,
+        id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        rejected: bool = False,
+    ) -> None:
+        self.id = id or str(uuid4())
+        self.name = name
+        self.value = value
+        self.source = source
+        self.timestamp = timestamp if timestamp is not None else datetime.now(UTC)
+        self.rejected = rejected
+
+    def reject(self) -> None:
+        """Soft-delete this claim; retained for provenance but excluded from resolution."""
+        self.rejected = True
+
+    @property
+    def as_etree(self) -> Element:
+        """Pack this claim into a ``<metadata>`` element for MarkLogic storage."""
+        metadata_element = etree.Element(
+            "metadata",
+            id=self.id,
+            name=self.name,
+            source=self.source.value,
+            timestamp=self.timestamp.isoformat(),
+            rejected=str(self.rejected).lower(),
+        )
+
+        if isinstance(self.value, MetadataCategoryValue):
+            name_element = etree.SubElement(metadata_element, "name")
+            name_element.text = self.value.name
+            parent_element = etree.SubElement(metadata_element, "parent")
+            if self.value.parent is not None:
+                parent_element.text = self.value.parent
+        else:
+            metadata_element.text = self.value
+
+        return metadata_element
+
+    def __repr__(self) -> str:
+        rejected = " (rejected)" if self.rejected else ""
+        return f"<MetadataField {self.name}={self.value!r} source={self.source.value}{rejected}>"

--- a/src/caselawclient/models/documents/metadata/fields/resolution.py
+++ b/src/caselawclient/models/documents/metadata/fields/resolution.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+
+def _claim_sort_key(claim: MetadataField) -> tuple[int, float, str]:
+    """Order by source precedence, then first-seen time, then id.
+
+    Ascending order means the last active claim is the single-value winner
+    (highest source, then latest timestamp).
+    """
+    return (claim.source.precedence, claim.timestamp.timestamp(), claim.id)
+
+
+class ResolvedMetadataField:
+    """Resolved view of all claims sharing a metadata field name."""
+
+    def __init__(self, name: str, claims: list[MetadataField]) -> None:
+        self.name = name
+        self._claims = sorted(claims, key=_claim_sort_key)
+
+    @property
+    def has_any_claims(self) -> bool:
+        """True if any claims exist for this name, including suppressed ones."""
+        return len(self._claims) > 0
+
+    @property
+    def all_claims(self) -> list[MetadataField]:
+        """All claims for this name, including suppressed, lowest→highest precedence."""
+        return list(self._claims)
+
+    @property
+    def claims(self) -> list[MetadataField]:
+        """Active (non-suppressed) claims, lowest→highest precedence then timestamp."""
+        return [claim for claim in self._claims if not claim.rejected]
+
+    @property
+    def value(self) -> Optional[MetadataFieldValue]:
+        """Highest-precedence active claim value, or ``None`` if none are active.
+
+        When multiple active claims share the winning source, the latest
+        ``timestamp`` wins (editor changes are remove+add, so a new claim carries
+        a newer first-seen time).
+        """
+        active = self.claims
+        if not active:
+            return None
+        return active[-1].value
+
+    @property
+    def values(self) -> list[MetadataFieldValue]:
+        """All active claim values across every source (multi-value resolution)."""
+        return [claim.value for claim in self.claims]
+
+    @property
+    def winning_source(self) -> Optional[MetadataSource]:
+        """Source of the highest-precedence active claim, if any."""
+        active = self.claims
+        if not active:
+            return None
+        return active[-1].source

--- a/src/caselawclient/models/documents/metadata/fields/source.py
+++ b/src/caselawclient/models/documents/metadata/fields/source.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class MetadataSource(str, Enum):
+    """Origin of a metadata claim, ordered from lowest to highest precedence."""
+
+    DOCUMENT = "document"
+    EXTERNAL = "external"
+    EDITOR = "editor"
+
+    @property
+    def precedence(self) -> int:
+        """Higher numbers outrank lower ones when resolving a single-value field."""
+        return {
+            MetadataSource.DOCUMENT: 0,
+            MetadataSource.EXTERNAL: 1,
+            MetadataSource.EDITOR: 2,
+        }[self]

--- a/src/caselawclient/models/documents/metadata/fields/unpacker.py
+++ b/src/caselawclient/models/documents/metadata/fields/unpacker.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+from typing import Optional
+
+from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
+from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.xml_helpers import Element
+
+
+def unpack_all_metadata_fields_from_etree(
+    metadata_fields_etree: Optional[Element],
+) -> MetadataFieldsCollection:
+    """Unpack a ``<metadata_fields>`` property element into a collection."""
+    collection = MetadataFieldsCollection()
+    if metadata_fields_etree is None:
+        return collection
+
+    for metadata_element in metadata_fields_etree.findall("metadata"):
+        collection.add(unpack_a_metadata_field_from_etree(metadata_element))
+
+    return collection
+
+
+def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField:
+    """Unpack a single ``<metadata>`` element into a ``MetadataField``."""
+    field_id = metadata_xml.get("id")
+    name = metadata_xml.get("name")
+    source_value = metadata_xml.get("source")
+    timestamp_value = metadata_xml.get("timestamp")
+
+    if not field_id:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            "Metadata field XML representation is not valid: id not present or empty"
+        )
+    if not name:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            "Metadata field XML representation is not valid: name not present or empty"
+        )
+    if not source_value:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            "Metadata field XML representation is not valid: source not present or empty"
+        )
+    if not timestamp_value:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            "Metadata field XML representation is not valid: timestamp not present or empty"
+        )
+
+    try:
+        source = MetadataSource(source_value)
+    except ValueError as exc:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            f"Metadata field XML representation is not valid: unknown source '{source_value}'"
+        ) from exc
+
+    try:
+        timestamp = datetime.fromisoformat(timestamp_value)
+    except ValueError as exc:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            f"Metadata field XML representation is not valid: unparsable timestamp '{timestamp_value}'"
+        ) from exc
+
+    rejected_attr = metadata_xml.get("rejected")
+    rejected = rejected_attr is not None and rejected_attr.lower() == "true"
+
+    name_child = metadata_xml.find("name")
+    if name_child is not None:
+        category_name = name_child.text
+        if not category_name:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: category name not present or empty"
+            )
+        parent_child = metadata_xml.find("parent")
+        parent: str | None
+        if parent_child is None or parent_child.text is None or parent_child.text == "":
+            parent = None
+        else:
+            parent = parent_child.text
+        value: MetadataCategoryValue | str = MetadataCategoryValue(name=category_name, parent=parent)
+    else:
+        value = metadata_xml.text or ""
+
+    return MetadataField(
+        name=name,
+        value=value,
+        source=source,
+        id=field_id,
+        timestamp=timestamp,
+        rejected=rejected,
+    )

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,4 +1,7 @@
-from typing import Literal, TypedDict
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Literal, TypedDict, overload
 
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
@@ -7,13 +10,75 @@ from caselawclient.models.documents.metadata.types.date import DateMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 
-MetadataAttributeKey = Literal["name", "court", "jurisdiction", "date", "case_number", "categories"]
+if TYPE_CHECKING:
+    from caselawclient.models.documents.metadata.base import Metadata
+
+MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "category"]
+
+METADATA_KEY_ALIASES: dict[str, MetadataAttributeKey] = {
+    "name": "title",
+    "categories": "category",
+}
 
 
 class DocumentMetadataRegistry(TypedDict):
-    name: NameMetadata
+    title: NameMetadata
     court: CourtMetadata
     jurisdiction: JurisdictionMetadata
     date: DateMetadata
     case_number: CaseNumberMetadata
-    categories: CategoriesMetadata
+    category: CategoriesMetadata
+
+
+class DocumentMetadata(dict[str, "Metadata"]):
+    """Document metadata keyed by schema-aligned claim names.
+
+    Legacy facade keys ``name`` and ``categories`` are proxied to ``title`` and
+    ``category`` respectively.
+    """
+
+    def _canonical_key(self, key: str) -> str:
+        if key in METADATA_KEY_ALIASES:
+            canonical = METADATA_KEY_ALIASES[key]
+            warnings.warn(
+                f'metadata["{key}"] is deprecated; use metadata["{canonical}"]',
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return canonical
+        return key
+
+    @overload
+    def __getitem__(self, key: Literal["title", "name"]) -> NameMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["court"]) -> CourtMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["jurisdiction"]) -> JurisdictionMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["date"]) -> DateMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["case_number"]) -> CaseNumberMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["category", "categories"]) -> CategoriesMetadata: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Metadata: ...
+
+    def __getitem__(self, key: str) -> Metadata:
+        return super().__getitem__(self._canonical_key(key))
+
+    def get(self, key: str, default: Metadata | None = None) -> Metadata | None:  # type: ignore[override]
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return super().__contains__(METADATA_KEY_ALIASES.get(key, key))

--- a/src/caselawclient/models/documents/metadata/types/case_number.py
+++ b/src/caselawclient/models/documents/metadata/types/case_number.py
@@ -8,4 +8,11 @@ class CaseNumberMetadata(SingleMetadata[str | None]):
 
     @property
     def value(self) -> str | None:
-        return self.document.body.case_number
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.case_number
+        if resolved.value is None:
+            return None
+        if not isinstance(resolved.value, str):
+            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
+        return resolved.value

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -1,12 +1,47 @@
 from caselawclient.models.documents.metadata.base import MultipleMetadata
+from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataFieldValue
 from caselawclient.types import DocumentCategory
 
 
+def document_categories_from_field_values(values: list[MetadataFieldValue]) -> list[DocumentCategory]:
+    """Build a ``DocumentCategory`` tree from flat category metadata claim values.
+
+    Duplicate category names (e.g. the same category claimed by multiple sources)
+    are de-duplicated with first-seen order winning.
+    """
+    category_values = [value for value in values if isinstance(value, MetadataCategoryValue)]
+
+    categories: dict[str, DocumentCategory] = {}
+    children_map: dict[str, list[DocumentCategory]] = {}
+    top_level_order: list[str] = []
+
+    for category_value in category_values:
+        if category_value.name in categories:
+            continue
+
+        category = DocumentCategory(name=category_value.name)
+        categories[category_value.name] = category
+
+        if category_value.parent:
+            children_map.setdefault(category_value.parent, []).append(category)
+        else:
+            top_level_order.append(category_value.name)
+
+    for parent, subcategories in children_map.items():
+        if parent in categories:
+            categories[parent].subcategories.extend(subcategories)
+
+    return [categories[name] for name in top_level_order]
+
+
 class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
-    key = "categories"
-    title = "Categories"
+    key = "category"
+    title = "Category"
     description = "The categories assigned to the document."
 
     @property
     def values(self) -> list[DocumentCategory]:
-        return self.document.body.categories
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.categories
+        return document_categories_from_field_values(resolved.values)

--- a/src/caselawclient/models/documents/metadata/types/court.py
+++ b/src/caselawclient/models/documents/metadata/types/court.py
@@ -8,4 +8,11 @@ class CourtMetadata(SingleMetadata[str]):
 
     @property
     def value(self) -> str:
-        return self.document.body.court
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.court
+        if resolved.value is None:
+            return ""
+        if not isinstance(resolved.value, str):
+            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
+        return resolved.value

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 
 from caselawclient.models.documents.metadata.base import SingleMetadata
 
@@ -9,6 +10,24 @@ def date_as_string_from_value(value: datetime.date | None) -> str:
     return value.strftime("%Y-%m-%d")
 
 
+def date_from_metadata_field_value(value: object) -> datetime.date | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        # Import locally to avoid a circular dependency with DocumentBody.
+        from caselawclient.models.documents.body import UnparsableDate
+
+        warnings.warn(
+            f"Unparsable date encountered: {value}",
+            UnparsableDate,
+        )
+        return None
+
+
 class DateMetadata(SingleMetadata[datetime.date | None]):
     key = "date"
     title = "Date"
@@ -16,7 +35,10 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
 
     @property
     def value(self) -> datetime.date | None:
-        return self.document.body.document_date_as_date
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.document_date_as_date
+        return date_from_metadata_field_value(resolved.value)
 
     @property
     def as_string(self) -> str:

--- a/src/caselawclient/models/documents/metadata/types/jurisdiction.py
+++ b/src/caselawclient/models/documents/metadata/types/jurisdiction.py
@@ -8,4 +8,11 @@ class JurisdictionMetadata(SingleMetadata[str]):
 
     @property
     def value(self) -> str:
-        return self.document.body.jurisdiction
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.jurisdiction
+        if resolved.value is None:
+            return ""
+        if not isinstance(resolved.value, str):
+            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
+        return resolved.value

--- a/src/caselawclient/models/documents/metadata/types/name.py
+++ b/src/caselawclient/models/documents/metadata/types/name.py
@@ -2,10 +2,17 @@ from caselawclient.models.documents.metadata.base import SingleMetadata
 
 
 class NameMetadata(SingleMetadata[str]):
-    key = "name"
-    title = "Name"
-    description = "The name of the document."
+    key = "title"
+    title = "Title"
+    description = "The title of the document."
 
     @property
     def value(self) -> str:
-        return self.document.body.name
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.name
+        if resolved.value is None:
+            return ""
+        if not isinstance(resolved.value, str):
+            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
+        return resolved.value

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -1,0 +1,390 @@
+from datetime import UTC, datetime
+
+import pytest
+from lxml import etree
+
+from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+    MetadataFieldRemovalNotAllowedException,
+)
+from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.fields.unpacker import (
+    unpack_a_metadata_field_from_etree,
+    unpack_all_metadata_fields_from_etree,
+)
+
+EARLY_TIMESTAMP = datetime(2025, 12, 17, 18, 0, 0, tzinfo=UTC)
+LATE_TIMESTAMP = datetime(2025, 12, 18, 12, 0, 0, tzinfo=UTC)
+
+
+class TestMetadataSource:
+    def test_precedence_order(self):
+        assert MetadataSource.DOCUMENT.precedence < MetadataSource.EXTERNAL.precedence
+        assert MetadataSource.EXTERNAL.precedence < MetadataSource.EDITOR.precedence
+
+
+class TestMetadataFieldPacking:
+    def test_pack_scalar_value(self):
+        field = MetadataField(
+            name="title",
+            value="A Judgment",
+            source=MetadataSource.DOCUMENT,
+            id="2d80bf1d-e3ea-452f-965c-041f4399f2dd",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        element = field.as_etree
+
+        assert element.tag == "metadata"
+        assert element.get("id") == "2d80bf1d-e3ea-452f-965c-041f4399f2dd"
+        assert element.get("name") == "title"
+        assert element.get("source") == "document"
+        assert element.get("timestamp") == EARLY_TIMESTAMP.isoformat()
+        assert element.get("rejected") == "false"
+        assert element.text == "A Judgment"
+
+    def test_pack_category_value(self):
+        field = MetadataField(
+            name="category",
+            value=MetadataCategoryValue(name="Subcategory", parent="Category"),
+            source=MetadataSource.EXTERNAL,
+            id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        element = field.as_etree
+
+        assert element.findtext("name") == "Subcategory"
+        assert element.findtext("parent") == "Category"
+
+    def test_pack_category_with_null_parent(self):
+        field = MetadataField(
+            name="category",
+            value=MetadataCategoryValue(name="Category One", parent=None),
+            source=MetadataSource.EXTERNAL,
+            id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        parent = field.as_etree.find("parent")
+        assert parent is not None
+        assert parent.text is None
+
+    def test_pack_rejected(self):
+        field = MetadataField(
+            name="title",
+            value="Wrong",
+            source=MetadataSource.DOCUMENT,
+            id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            timestamp=EARLY_TIMESTAMP,
+            rejected=True,
+        )
+        assert field.as_etree.get("rejected") == "true"
+
+
+class TestMetadataFieldUnpacking:
+    def test_unpack_scalar(self):
+        xml = etree.fromstring(
+            '<metadata id="2d80bf1d-e3ea-452f-965c-041f4399f2dd" name="title" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}" rejected="false">A Judgment</metadata>'
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+
+        assert field.id == "2d80bf1d-e3ea-452f-965c-041f4399f2dd"
+        assert field.name == "title"
+        assert field.source is MetadataSource.DOCUMENT
+        assert field.value == "A Judgment"
+        assert field.timestamp == EARLY_TIMESTAMP
+        assert field.rejected is False
+
+    def test_unpack_category(self):
+        xml = etree.fromstring(
+            '<metadata id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67" name="category" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
+            "<name>Subcategory</name><parent>Category</parent></metadata>"
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+
+        assert isinstance(field.value, MetadataCategoryValue)
+        assert field.value.name == "Subcategory"
+        assert field.value.parent == "Category"
+
+    def test_unpack_category_empty_parent(self):
+        xml = etree.fromstring(
+            '<metadata id="a1b2c3d4-e5f6-7890-abcd-ef1234567890" name="category" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
+            "<name>Category One</name><parent/></metadata>"
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+
+        assert isinstance(field.value, MetadataCategoryValue)
+        assert field.value.parent is None
+
+    def test_unpack_rejected(self):
+        xml = etree.fromstring(
+            '<metadata id="f47ac10b-58cc-4372-a567-0e02b2c3d479" name="title" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}" rejected="true">Wrong</metadata>'
+        )
+        assert unpack_a_metadata_field_from_etree(xml).rejected is True
+
+    def test_unpack_missing_id_raises(self):
+        xml = etree.fromstring(
+            f'<metadata name="title" source="document" timestamp="{EARLY_TIMESTAMP.isoformat()}">A Judgment</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="id"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_missing_name_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="name"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_missing_source_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="source"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_missing_timestamp_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" source="document">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="timestamp"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_unparsable_timestamp_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" source="document" '
+            'timestamp="not-a-datetime">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unparsable timestamp"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_unknown_source_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" source="mystery" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unknown source"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_empty_category_name_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="category" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}"><name/><parent/></metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="category name"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_none_returns_empty_collection(self):
+        assert unpack_all_metadata_fields_from_etree(None) == MetadataFieldsCollection()
+
+    def test_roundtrip(self):
+        original = MetadataFieldsCollection()
+        original.add(
+            MetadataField(
+                name="title",
+                value="Judgment",
+                source=MetadataSource.DOCUMENT,
+                id="c0ffee00-dead-beef-cafe-0123456789ab",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        original.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Cat", parent=None),
+                source=MetadataSource.EXTERNAL,
+                id="1e2f3a4b-5c6d-7e8f-9012-3456789abcde",
+                timestamp=LATE_TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        unpacked = unpack_all_metadata_fields_from_etree(original.as_etree)
+
+        assert set(unpacked.keys()) == set(original.keys())
+        assert unpacked["c0ffee00-dead-beef-cafe-0123456789ab"].value == "Judgment"
+        assert unpacked["c0ffee00-dead-beef-cafe-0123456789ab"].timestamp == EARLY_TIMESTAMP
+        assert unpacked["1e2f3a4b-5c6d-7e8f-9012-3456789abcde"].rejected is True
+        category = unpacked["1e2f3a4b-5c6d-7e8f-9012-3456789abcde"].value
+        assert isinstance(category, MetadataCategoryValue)
+        assert category.name == "Cat"
+        assert category.parent is None
+
+
+class TestMetadataFieldsResolution:
+    def test_single_value_uses_highest_precedence(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="title",
+                value="From document",
+                source=MetadataSource.DOCUMENT,
+                id="10d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="title",
+                value="From editor",
+                source=MetadataSource.EDITOR,
+                id="71e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="title",
+                value="From external",
+                source=MetadataSource.EXTERNAL,
+                id="45b8c9d0-e1f2-4a3b-4c5d-6e7f8091a2b3",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+
+        resolved = collection.resolve("title")
+        assert resolved.value == "From editor"
+        assert resolved.winning_source is MetadataSource.EDITOR
+
+    def test_same_source_prefers_latest_timestamp(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="title",
+                value="Older editor title",
+                source=MetadataSource.EDITOR,
+                id="71e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="title",
+                value="Newer editor title",
+                source=MetadataSource.EDITOR,
+                id="81e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
+                timestamp=LATE_TIMESTAMP,
+            )
+        )
+
+        assert collection.resolve("title").value == "Newer editor title"
+
+    def test_winning_source_is_none_when_empty(self):
+        assert MetadataFieldsCollection().resolve("title").winning_source is None
+
+    def test_multi_value_returns_all_non_suppressed(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="A"),
+                source=MetadataSource.DOCUMENT,
+                id="d3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="B"),
+                source=MetadataSource.EXTERNAL,
+                id="e3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="C"),
+                source=MetadataSource.EDITOR,
+                id="f3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        collection.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Rejected"),
+                source=MetadataSource.EXTERNAL,
+                id="04a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+                timestamp=EARLY_TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        values = collection.resolve("category").values
+        assert [value.name for value in values if isinstance(value, MetadataCategoryValue)] == ["A", "B", "C"]
+
+    def test_suppressed_only_is_empty(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="title",
+                value="Wrong",
+                source=MetadataSource.DOCUMENT,
+                id="60d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
+                timestamp=EARLY_TIMESTAMP,
+                rejected=True,
+            )
+        )
+        resolved = collection.resolve("title")
+        assert resolved.has_any_claims is True
+        assert resolved.value is None
+        assert resolved.values == []
+        assert len(resolved.all_claims) == 1
+
+
+class TestMetadataFieldsMutation:
+    def test_reject_soft_deletes(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="category",
+            value=MetadataCategoryValue(name="Bad"),
+            source=MetadataSource.EXTERNAL,
+            id="14a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        collection.add(field)
+
+        collection.reject(field.id)
+
+        assert field.rejected is True
+        assert field.id in collection
+        assert collection.resolve("category").values == []
+
+    def test_remove_editor_claim(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="category",
+            value=MetadataCategoryValue(name="Editor cat"),
+            source=MetadataSource.EDITOR,
+            id="24a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        collection.add(field)
+
+        collection.remove(field.id)
+
+        assert field.id not in collection
+
+    def test_remove_external_claim_raises(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="category",
+            value=MetadataCategoryValue(name="External cat"),
+            source=MetadataSource.EXTERNAL,
+            id="34a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        collection.add(field)
+
+        with pytest.raises(MetadataFieldRemovalNotAllowedException):
+            collection.remove(field.id)
+
+        assert field.id in collection

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -62,11 +62,11 @@ class TestMetadataBase:
 
 
 class TestNameMetadata:
-    def test_name_metadata_is_single_metadata_with_name_key(self):
+    def test_name_metadata_is_single_metadata_with_title_key(self):
         from caselawclient.models.documents.metadata.types.name import NameMetadata
 
         assert issubclass(NameMetadata, SingleMetadata)
-        assert NameMetadata.key == "name"
+        assert NameMetadata.key == "title"
 
     def test_name_metadata_value_reads_from_xml(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory, DocumentFactory
@@ -80,9 +80,9 @@ class TestNameMetadata:
 
         assert metadata.value == "Custom Case Name"
         assert document.body.name == metadata.value
-        name_from_registry = document.metadata["name"]
-        assert isinstance(name_from_registry, NameMetadata)
-        assert name_from_registry.value == metadata.value
+        title_from_registry = document.metadata["title"]
+        assert isinstance(title_from_registry, NameMetadata)
+        assert title_from_registry.value == metadata.value
 
     def test_name_metadata_value_matches_document_body_name(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -173,6 +173,11 @@ class TestCaseNumberMetadata:
 
 
 class TestCategoriesMetadata:
+    def test_categories_metadata_uses_category_key(self):
+        from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
+
+        assert CategoriesMetadata.key == "category"
+
     def test_categories_metadata_values_match_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
@@ -189,19 +194,20 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        name_metadata = document.metadata["name"]
+        title_metadata = document.metadata["title"]
         court_metadata = document.metadata["court"]
-        assert isinstance(name_metadata, NameMetadata)
+        assert isinstance(title_metadata, NameMetadata)
         assert isinstance(court_metadata, CourtMetadata)
-        assert name_metadata.value == "Judgment v Judgement"
+        assert title_metadata.value == "Judgment v Judgement"
         assert court_metadata.value == "Court of Testing"
 
     def test_metadata_is_dict_keyed_by_metadata_type(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.registry import DocumentMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata, dict)
+        assert isinstance(document.metadata, DocumentMetadata)
         assert document.metadata
 
     def test_metadata_keys_match_registered_types(self, mock_api_client):
@@ -210,12 +216,12 @@ class TestDocumentMetadata:
         document = DocumentFactory.build(api_client=mock_api_client)
 
         assert set(document.metadata.keys()) == {
-            "name",
+            "title",
             "court",
             "jurisdiction",
             "date",
             "case_number",
-            "categories",
+            "category",
         }
 
     def test_metadata_entries_are_expected_types(self, mock_api_client):
@@ -229,30 +235,46 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata["name"], NameMetadata)
+        assert isinstance(document.metadata["title"], NameMetadata)
         assert isinstance(document.metadata["court"], CourtMetadata)
         assert isinstance(document.metadata["jurisdiction"], JurisdictionMetadata)
         assert isinstance(document.metadata["date"], DateMetadata)
         assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
-        assert isinstance(document.metadata["categories"], CategoriesMetadata)
+        assert isinstance(document.metadata["category"], CategoriesMetadata)
+
+    def test_legacy_name_and_categories_keys_proxy_to_schema_keys(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
+            assert document.metadata["name"] is document.metadata["title"]
+        with pytest.warns(DeprecationWarning, match=r'metadata\["categories"\] is deprecated'):
+            assert document.metadata["categories"] is document.metadata["category"]
+        assert "name" in document.metadata
+        assert "categories" in document.metadata
+        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
+            assert document.metadata.get("name") is document.metadata["title"]
+        with pytest.warns(DeprecationWarning, match=r'metadata\["categories"\] is deprecated'):
+            assert document.metadata.get("categories") is document.metadata["category"]
 
     def test_metadata_name_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.name import NameMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
-        name_metadata = document.metadata["name"]
-        assert isinstance(name_metadata, NameMetadata)
-        assert name_metadata.value == document.body.name
+        title_metadata = document.metadata["title"]
+        assert isinstance(title_metadata, NameMetadata)
+        assert title_metadata.value == document.body.name
 
     def test_metadata_categories_values_match_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
-        categories_metadata = document.metadata["categories"]
-        assert isinstance(categories_metadata, CategoriesMetadata)
-        assert categories_metadata.values == document.body.categories
+        category_metadata = document.metadata["category"]
+        assert isinstance(category_metadata, CategoriesMetadata)
+        assert category_metadata.values == document.body.categories
 
     def test_metadata_get_returns_none_for_unknown_key(self, mock_api_client):
         from caselawclient.factories import DocumentFactory

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -1,0 +1,492 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from lxml import etree
+
+from caselawclient.factories import DocumentFactory
+from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
+from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
+from caselawclient.types import SuccessFailureMessageTuple
+
+TIMESTAMP = datetime(2025, 12, 17, 18, 0, 0, tzinfo=UTC)
+
+
+def _id() -> str:
+    """Generate a claim id for tests where the specific value does not matter."""
+    return str(uuid4())
+
+
+class TestDocumentMetadataFieldsLoadSave:
+    def test_document_loads_empty_metadata_fields_when_property_missing(self, mock_api_client):
+        mock_api_client.get_property_as_node.return_value = None
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert list(document.metadata_fields.values()) == []
+
+    def test_document_loads_metadata_fields_from_property(self, mock_api_client):
+        claim_id = _id()
+        xml = etree.fromstring(
+            "<metadata_fields>"
+            f'<metadata id="{claim_id}" name="title" source="editor" '
+            f'timestamp="{TIMESTAMP.isoformat()}" rejected="false">'
+            "From fields"
+            "</metadata>"
+            "</metadata_fields>"
+        )
+
+        def get_property_as_node(_uri: str, name: str):
+            if name == "metadata_fields":
+                return xml
+            return None
+
+        mock_api_client.get_property_as_node.side_effect = get_property_as_node
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert document.metadata_fields.resolve("title").value == "From fields"
+
+    def test_save_metadata_fields_writes_property(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="title",
+                value="Saved title",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        document.save_metadata_fields()
+
+        mock_api_client.set_property_as_node.assert_called_once()
+        uri, property_name, tree = mock_api_client.set_property_as_node.call_args.args
+        assert uri == document.uri
+        assert property_name == "metadata_fields"
+        assert unpack_all_metadata_fields_from_etree(tree).resolve("title").value == "Saved title"
+
+    def test_validate_metadata_fields_returns_success_failure_tuple(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        field = MetadataField(
+            name="title",
+            value="Saved title",
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
+        )
+        document.metadata_fields["wrong-key"] = field
+
+        result = document.validate_metadata_fields()
+
+        assert result == SuccessFailureMessageTuple(
+            False,
+            [f"Key of {field} in MetadataFieldsCollection is wrong-key not {field.id}"],
+        )
+
+    def test_save_metadata_fields_rejects_mismatched_keys(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        field = MetadataField(
+            name="title",
+            value="Saved title",
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
+        )
+        document.metadata_fields["wrong-key"] = field
+
+        with pytest.raises(MetadataFieldValidationException, match="wrong-key"):
+            document.save_metadata_fields()
+
+        mock_api_client.set_property_as_node.assert_not_called()
+
+
+class TestDocumentMetadataFacadePrefersFields:
+    def test_name_falls_back_to_body_when_no_claims(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Name"),
+        )
+
+        assert document.metadata["title"].value == "Body Name"
+
+    def test_name_prefers_metadata_fields(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Name"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="title",
+                value="Fields Name",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["title"].value == "Fields Name"
+
+    def test_name_suppressed_only_is_empty(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Name"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="title",
+                value="Rejected Name",
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert document.metadata["title"].value == ""
+
+    def test_categories_prefers_all_non_suppressed_fields(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="From document"),
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="From external"),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Rejected"),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert [category.name for category in document.metadata["category"].values] == [
+            "From document",
+            "From external",
+        ]
+
+    def test_categories_dedupe_same_name_from_multiple_sources(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Shared", parent=None),
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Shared", parent=None),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        categories = document.metadata["category"].values
+        assert len(categories) == 1
+        assert categories[0].name == "Shared"
+
+    def test_categories_build_parent_child_tree(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Parent", parent=None),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Child", parent="Parent"),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        categories = document.metadata["category"].values
+        assert len(categories) == 1
+        assert categories[0].name == "Parent"
+        assert [child.name for child in categories[0].subcategories] == ["Child"]
+
+    def test_date_parses_field_value(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="date",
+                value="2024-06-15",
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["date"].as_string == "2024-06-15"
+
+    def test_date_suppressed_only_is_none(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="date",
+                value="2024-06-15",
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert document.metadata["date"].value is None
+        assert document.metadata["date"].as_string == ""
+
+    def test_date_unparsable_field_value_is_none(self, mock_api_client):
+        from caselawclient.models.documents.body import UnparsableDate
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="date",
+                value="not-a-date",
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        with pytest.warns(UnparsableDate, match="Unparsable date"):
+            assert document.metadata["date"].value is None
+
+    def test_date_empty_string_field_value_is_none(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="date",
+                value="",
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["date"].value is None
+
+    def test_case_number_prefers_metadata_fields(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="case_number",
+                value="ABC-123",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["case_number"].value == "ABC-123"
+
+    def test_case_number_suppressed_only_is_none(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="case_number",
+                value="ABC-123",
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert document.metadata["case_number"].value is None
+
+    def test_case_number_non_string_value_raises(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="case_number",
+                value=MetadataCategoryValue(name="not-a-case-number"),
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        with pytest.raises(TypeError, match="Expected string metadata value for 'case_number'"):
+            _ = document.metadata["case_number"].value
+
+    def test_court_prefers_metadata_fields(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(court="Body Court"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="court",
+                value="Fields Court",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["court"].value == "Fields Court"
+
+    def test_court_suppressed_only_is_empty(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(court="Body Court"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="court",
+                value="Rejected Court",
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert document.metadata["court"].value == ""
+
+    def test_court_non_string_value_raises(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="court",
+                value=MetadataCategoryValue(name="not-a-court"),
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        with pytest.raises(TypeError, match="Expected string metadata value for 'court'"):
+            _ = document.metadata["court"].value
+
+    def test_jurisdiction_prefers_metadata_fields(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(jurisdiction="Body Jurisdiction"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="jurisdiction",
+                value="Fields Jurisdiction",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["jurisdiction"].value == "Fields Jurisdiction"
+
+    def test_jurisdiction_suppressed_only_is_empty(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(jurisdiction="Body Jurisdiction"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="jurisdiction",
+                value="Rejected",
+                source=MetadataSource.DOCUMENT,
+                id=_id(),
+                timestamp=TIMESTAMP,
+                rejected=True,
+            )
+        )
+
+        assert document.metadata["jurisdiction"].value == ""
+
+    def test_jurisdiction_non_string_value_raises(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="jurisdiction",
+                value=MetadataCategoryValue(name="not-a-jurisdiction"),
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        with pytest.raises(TypeError, match="Expected string metadata value for 'jurisdiction'"):
+            _ = document.metadata["jurisdiction"].value
+
+    def test_title_non_string_value_raises(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="title",
+                value=MetadataCategoryValue(name="not-a-title"),
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        with pytest.raises(TypeError, match="Expected string metadata value for 'title'"):
+            _ = document.metadata["title"].value
+
+    def test_categories_orphan_child_without_parent_claim_is_omitted(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="category",
+                value=MetadataCategoryValue(name="Orphan", parent="Missing Parent"),
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["category"].values == []
+
+    def test_metadata_contains_rejects_non_string_keys(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert 123 not in document.metadata


### PR DESCRIPTION
We need to be able to store structured metadata for a document in MarkLogic, outside of the body proper. This PR introduces the ability to store and retrieve this structured metadata.

It supports the concepts of multiple conflicting claims from different sources, as well as falling back to the existing methods for getting values directly from the document body where no structured claims have been stored.

## Jira

FCLC-2175

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change
