### PR TITLE
bump: version 47.3.0 → 47.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v47.4.0 (2026-07-23)
 
 ### Feat
 
 - resolve document.metadata from metadata_fields with body fallback
 - load and save metadata_fields on Document
 - add metadata_fields storage model with pack/unpack and resolution
-
-### Fix
-
-- Put param back into query that was required
 
 ## v47.3.0 (2026-07-23)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "47.3.0"
+version = "47.4.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
- resolve document.metadata from metadata_fields with body fallback
- load and save metadata_fields on Document
- add metadata_fields storage model with pack/unpack and resolution
