### PR TITLE
[FCLC-2213] Add latest_published_datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Feat
+
+- **Document**: documents can now retrieve and will set latest_published_datetime on publish
+
 ## v47.4.0 (2026-07-23)
 
 ### Feat

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -82,6 +82,7 @@ class DocumentFactory:
         "source_email": "uploader@example.com",
         "consignment_reference": "TDR-12345",
         "first_published_datetime": None,
+        "latest_published_datetime": None,
         "has_ever_been_published": False,
         "assigned_to": "",
         "versions": [],

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -442,6 +442,15 @@ class Document:
         return self.first_published_datetime
 
     @cached_property
+    def latest_published_datetime(self) -> Optional[datetime.datetime]:
+        """
+        Return the database value for the date and time this document was most recently published.
+
+        :return: The datetime value in the database for "latest published".
+        """
+        return self.api_client.get_datetime_property(self.uri, "latest_published_datetime")
+
+    @cached_property
     def has_ever_been_published(self) -> bool:
         """
         Do we consider this document to have ever been published?
@@ -618,10 +627,12 @@ class Document:
         self.api_client.set_published(self.uri, True)
 
         ## If necessary, set the first published date
+        now = datetime.datetime.now(datetime.timezone.utc)
         if not self.first_published_datetime:
-            self.api_client.set_datetime_property(
-                self.uri, "first_published_datetime", datetime.datetime.now(datetime.timezone.utc)
-            )
+            self.api_client.set_datetime_property(self.uri, "first_published_datetime", now)
+
+        ## Always update the latest published date
+        self.api_client.set_datetime_property(self.uri, "latest_published_datetime", now)
 
         ## Announce the publication on the event bus
         announce_document_event(

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -151,10 +151,12 @@ class TestDocumentPublish:
         document.first_published_datetime = None
         document.publish()
 
-        mock_api_client.set_datetime_property.assert_called_once_with(
-            "test/1234", "first_published_datetime", datetime.datetime(1955, 11, 5, 6, 0, tzinfo=datetime.timezone.utc)
-        )
+        expected_now = datetime.datetime(1955, 11, 5, 6, 0, tzinfo=datetime.timezone.utc)
+        mock_api_client.set_datetime_property.assert_any_call("test/1234", "first_published_datetime", expected_now)
+        mock_api_client.set_datetime_property.assert_any_call("test/1234", "latest_published_datetime", expected_now)
+        assert mock_api_client.set_datetime_property.call_count == 2
 
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.publish_documents")
     @patch("caselawclient.models.documents.Document.enrich")
@@ -172,7 +174,38 @@ class TestDocumentPublish:
         )
         document.publish()
 
-        mock_api_client.set_datetime_property.assert_not_called()
+        mock_api_client.set_datetime_property.assert_called_once_with(
+            "test/1234",
+            "latest_published_datetime",
+            datetime.datetime(1955, 11, 5, 6, 0, tzinfo=datetime.timezone.utc),
+        )
+
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @patch("caselawclient.models.documents.announce_document_event")
+    @patch("caselawclient.models.documents.publish_documents")
+    @patch("caselawclient.models.documents.Document.enrich")
+    def test_publish_always_sets_latest_published_date(
+        self,
+        mock_enrich,
+        mock_publish_documents,
+        mock_announce_document_event,
+        mock_api_client,
+    ):
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+        document.is_publishable = True
+        document.first_published_datetime = datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+        document.latest_published_datetime = datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+        document.publish()
+
+        mock_api_client.set_datetime_property.assert_called_once_with(
+            "test/1234",
+            "latest_published_datetime",
+            datetime.datetime(1955, 11, 5, 6, 0, tzinfo=datetime.timezone.utc),
+        )
 
 
 class TestDocumentUnpublish:

--- a/tests/models/documents/test_documents.py
+++ b/tests/models/documents/test_documents.py
@@ -233,6 +233,18 @@ class TestDocument:
         assert document.first_published_datetime_display is None
         mock_api_client.get_datetime_property.assert_called_once_with("test/1234", "first_published_datetime")
 
+    def test_document_latest_published_datetime(self, mock_api_client):
+        mock_api_client.get_datetime_property.return_value = datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+
+        document = Document(DocumentURIString("test/1234"), mock_api_client)
+
+        assert document.latest_published_datetime == datetime.datetime(
+            2025, 8, 19, 12, 5, 53, 398214, tzinfo=datetime.timezone.utc
+        )
+        mock_api_client.get_datetime_property.assert_called_once_with("test/1234", "latest_published_datetime")
+
     @pytest.mark.parametrize(
         "is_published, first_published_datetime, expected_outcome",
         [


### PR DESCRIPTION
Add `Document.latest_published_datetime` and set it on every publish (while keeping first-published only-if-unset).

## Jira

FCLC-2213

## Checklist

- [x] I have written tests to cover the new behaviour
- [x] I have created/updated method docstrings (if necessary)
- [x] I have considered if this is a breaking change