### PR TITLE
fix: escape special characters in document body factory XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- escape special characters in document body factory XML
+
 ## v48.0.0 (2026-07-30)
 
 ### BREAKING CHANGE

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from typing import Any, Generic, Optional, Type, TypeAlias, TypeVar, cast
 from unittest.mock import Mock
+from xml.sax.saxutils import escape
 
 from caselawclient.Client import MarklogicApiClient
 from caselawclient.identifier_resolution import IdentifierResolution, IdentifierResolutions
@@ -18,6 +19,13 @@ from caselawclient.types import DocumentURIString
 
 T = TypeVar("T")
 
+_ATTR_ESCAPES = {'"': "&quot;", "'": "&apos;"}
+
+
+def _escape_xml_attr(value: str) -> str:
+    """Escape a value for inclusion in a double-quoted XML attribute."""
+    return escape(value, _ATTR_ESCAPES)
+
 
 def build_document_body_xml(
     *,
@@ -28,20 +36,22 @@ def build_document_body_xml(
     case_number: str = "",
 ) -> str:
     frbr_date_line = (
-        f'                            <FRBRdate date="{document_date_as_string}"/>\n' if document_date_as_string else ""
+        f'                            <FRBRdate date="{_escape_xml_attr(document_date_as_string)}"/>\n'
+        if document_date_as_string
+        else ""
     )
     return f"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
             <judgment name="decision">
                 <meta>
                     <identification>
                         <FRBRWork>
-                            <FRBRname value="{name}"/>
+                            <FRBRname value="{_escape_xml_attr(name)}"/>
 {frbr_date_line}                        </FRBRWork>
                     </identification>
                     <proprietary>
-                        <uk:court>{court}</uk:court>
-                        <uk:jurisdiction>{jurisdiction}</uk:jurisdiction>
-                        <uk:caseNumber>{case_number}</uk:caseNumber>
+                        <uk:court>{escape(court)}</uk:court>
+                        <uk:jurisdiction>{escape(jurisdiction)}</uk:jurisdiction>
+                        <uk:caseNumber>{escape(case_number)}</uk:caseNumber>
                     </proprietary>
                 </meta>
                 <header><p>Header contains text</p></header>

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,6 +1,13 @@
 import pytest
 
-from caselawclient.factories import DocumentFactory, JudgmentFactory, PressSummaryFactory, SearchResultFactory
+from caselawclient.factories import (
+    DocumentBodyFactory,
+    DocumentFactory,
+    JudgmentFactory,
+    PressSummaryFactory,
+    SearchResultFactory,
+    build_document_body_xml,
+)
 
 
 class TestSearchStatusBehaviour:
@@ -22,3 +29,32 @@ class TestDocumentNCNBehaviour:
         doc = DocumentFactory.build(neutral_citation="not the default")
         with pytest.raises(AttributeError):
             doc.neutral_citation
+
+
+class TestDocumentBodyXmlEscaping:
+    def test_build_document_body_xml_escapes_special_characters_in_attributes_and_text(self):
+        xml = build_document_body_xml(
+            name='R v G & B <"quoted">',
+            court="Court of Testing & Appeals",
+            jurisdiction='A & B <"jurisdiction">',
+            case_number="ABC & 123",
+        )
+
+        assert 'value="R v G &amp; B &lt;&quot;quoted&quot;&gt;"' in xml
+        assert "<uk:court>Court of Testing &amp; Appeals</uk:court>" in xml
+        assert '<uk:jurisdiction>A &amp; B &lt;"jurisdiction"&gt;</uk:jurisdiction>' in xml
+        assert "<uk:caseNumber>ABC &amp; 123</uk:caseNumber>" in xml
+
+    def test_document_body_factory_accepts_ampersand_in_name(self):
+        body = DocumentBodyFactory.build(name="R v G & B")
+
+        assert body.name == "R v G & B"
+
+    def test_judgment_factory_accepts_ampersand_in_body_name(self, mock_api_client):
+        judgment = JudgmentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="R v G & B"),
+        )
+
+        assert judgment.body.name == "R v G & B"
+        assert judgment.metadata["title"].value == "R v G & B"


### PR DESCRIPTION
From v47.2 factories embed metadata defaults in XML. Unescaped `&` (and similar) cause `XMLSyntaxError` / `NonXMLDocumentError`, which is currently blocking the EUI API client bump ([ds-caselaw-editor-ui#3195](https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/3195)).

- Escape attribute and text values when building factory document XML so names like `R v G & B` parse correctly
- Add unit coverage for ampersands and other XML special characters in `DocumentBodyFactory` / `JudgmentFactory`