### PR TITLE
refactor!: use categories as the only metadata key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### BREAKING CHANGE
+
+- **Metadata**: `Document.metadata` and metadata claims use canonical key `categories` (was `category`); the `categories`/`category` facade alias is removed
+
 ### Feat
 
 - **Document**: documents can now retrieve and will set latest_published_datetime

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -223,7 +223,7 @@ class Document:
             jurisdiction=JurisdictionMetadata(self),
             date=DateMetadata(self),
             case_number=CaseNumberMetadata(self),
-            category=CategoriesMetadata(self),
+            categories=CategoriesMetadata(self),
         )
 
     @property
@@ -967,7 +967,7 @@ class Document:
         "document_date_as_date": ("date", "value"),
         "document_date_as_string": ("date", "as_string"),
         "case_number": ("case_number", "value"),
-        "categories": ("category", "values"),
+        "categories": ("categories", "values"),
     }
 
     def __getattr__(self, name: str) -> Any:

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -13,11 +13,10 @@ from caselawclient.models.documents.metadata.types.name import NameMetadata
 if TYPE_CHECKING:
     from caselawclient.models.documents.metadata.base import Metadata
 
-MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "category"]
+MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "categories"]
 
 METADATA_KEY_ALIASES: dict[str, MetadataAttributeKey] = {
     "name": "title",
-    "categories": "category",
 }
 
 
@@ -27,14 +26,13 @@ class DocumentMetadataRegistry(TypedDict):
     jurisdiction: JurisdictionMetadata
     date: DateMetadata
     case_number: CaseNumberMetadata
-    category: CategoriesMetadata
+    categories: CategoriesMetadata
 
 
 class DocumentMetadata(dict[str, "Metadata"]):
     """Document metadata keyed by schema-aligned claim names.
 
-    Legacy facade keys ``name`` and ``categories`` are proxied to ``title`` and
-    ``category`` respectively.
+    Legacy facade key ``name`` is proxied to ``title``.
     """
 
     def _canonical_key(self, key: str) -> str:
@@ -64,7 +62,7 @@ class DocumentMetadata(dict[str, "Metadata"]):
     def __getitem__(self, key: Literal["case_number"]) -> CaseNumberMetadata: ...
 
     @overload
-    def __getitem__(self, key: Literal["category", "categories"]) -> CategoriesMetadata: ...
+    def __getitem__(self, key: Literal["categories"]) -> CategoriesMetadata: ...
 
     @overload
     def __getitem__(self, key: str) -> Metadata: ...

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -35,8 +35,8 @@ def document_categories_from_field_values(values: list[MetadataFieldValue]) -> l
 
 
 class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
-    key = "category"
-    title = "Category"
+    key = "categories"
+    title = "Categories"
     description = "The categories assigned to the document."
 
     @property

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -46,7 +46,7 @@ class TestMetadataFieldPacking:
 
     def test_pack_category_value(self):
         field = MetadataField(
-            name="category",
+            name="categories",
             value=MetadataCategoryValue(name="Subcategory", parent="Category"),
             source=MetadataSource.EXTERNAL,
             id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67",
@@ -59,7 +59,7 @@ class TestMetadataFieldPacking:
 
     def test_pack_category_with_null_parent(self):
         field = MetadataField(
-            name="category",
+            name="categories",
             value=MetadataCategoryValue(name="Category One", parent=None),
             source=MetadataSource.EXTERNAL,
             id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -98,7 +98,7 @@ class TestMetadataFieldUnpacking:
 
     def test_unpack_category(self):
         xml = etree.fromstring(
-            '<metadata id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67" name="category" source="external" '
+            '<metadata id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67" name="categories" source="external" '
             f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
             "<name>Subcategory</name><parent>Category</parent></metadata>"
         )
@@ -110,7 +110,7 @@ class TestMetadataFieldUnpacking:
 
     def test_unpack_category_empty_parent(self):
         xml = etree.fromstring(
-            '<metadata id="a1b2c3d4-e5f6-7890-abcd-ef1234567890" name="category" source="external" '
+            '<metadata id="a1b2c3d4-e5f6-7890-abcd-ef1234567890" name="categories" source="external" '
             f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
             "<name>Category One</name><parent/></metadata>"
         )
@@ -174,7 +174,7 @@ class TestMetadataFieldUnpacking:
 
     def test_unpack_empty_category_name_raises(self):
         xml = etree.fromstring(
-            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="category" source="external" '
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="categories" source="external" '
             f'timestamp="{EARLY_TIMESTAMP.isoformat()}"><name/><parent/></metadata>'
         )
         with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="category name"):
@@ -196,7 +196,7 @@ class TestMetadataFieldUnpacking:
         )
         original.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Cat", parent=None),
                 source=MetadataSource.EXTERNAL,
                 id="1e2f3a4b-5c6d-7e8f-9012-3456789abcde",
@@ -282,7 +282,7 @@ class TestMetadataFieldsResolution:
         collection = MetadataFieldsCollection()
         collection.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="A"),
                 source=MetadataSource.DOCUMENT,
                 id="d3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -291,7 +291,7 @@ class TestMetadataFieldsResolution:
         )
         collection.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="B"),
                 source=MetadataSource.EXTERNAL,
                 id="e3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -300,7 +300,7 @@ class TestMetadataFieldsResolution:
         )
         collection.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="C"),
                 source=MetadataSource.EDITOR,
                 id="f3a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -309,7 +309,7 @@ class TestMetadataFieldsResolution:
         )
         collection.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Rejected"),
                 source=MetadataSource.EXTERNAL,
                 id="04a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -318,7 +318,7 @@ class TestMetadataFieldsResolution:
             )
         )
 
-        values = collection.resolve("category").values
+        values = collection.resolve("categories").values
         assert [value.name for value in values if isinstance(value, MetadataCategoryValue)] == ["A", "B", "C"]
 
     def test_suppressed_only_is_empty(self):
@@ -344,7 +344,7 @@ class TestMetadataFieldsMutation:
     def test_reject_soft_deletes(self):
         collection = MetadataFieldsCollection()
         field = MetadataField(
-            name="category",
+            name="categories",
             value=MetadataCategoryValue(name="Bad"),
             source=MetadataSource.EXTERNAL,
             id="14a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -356,12 +356,12 @@ class TestMetadataFieldsMutation:
 
         assert field.rejected is True
         assert field.id in collection
-        assert collection.resolve("category").values == []
+        assert collection.resolve("categories").values == []
 
     def test_remove_editor_claim(self):
         collection = MetadataFieldsCollection()
         field = MetadataField(
-            name="category",
+            name="categories",
             value=MetadataCategoryValue(name="Editor cat"),
             source=MetadataSource.EDITOR,
             id="24a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",
@@ -376,7 +376,7 @@ class TestMetadataFieldsMutation:
     def test_remove_external_claim_raises(self):
         collection = MetadataFieldsCollection()
         field = MetadataField(
-            name="category",
+            name="categories",
             value=MetadataCategoryValue(name="External cat"),
             source=MetadataSource.EXTERNAL,
             id="34a7b8c9-d0e1-4f2a-3b4c-5d6e7f8091a2",

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -173,10 +173,10 @@ class TestCaseNumberMetadata:
 
 
 class TestCategoriesMetadata:
-    def test_categories_metadata_uses_category_key(self):
+    def test_categories_metadata_uses_categories_key(self):
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 
-        assert CategoriesMetadata.key == "category"
+        assert CategoriesMetadata.key == "categories"
 
     def test_categories_metadata_values_match_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -221,7 +221,7 @@ class TestDocumentMetadata:
             "jurisdiction",
             "date",
             "case_number",
-            "category",
+            "categories",
         }
 
     def test_metadata_entries_are_expected_types(self, mock_api_client):
@@ -240,23 +240,18 @@ class TestDocumentMetadata:
         assert isinstance(document.metadata["jurisdiction"], JurisdictionMetadata)
         assert isinstance(document.metadata["date"], DateMetadata)
         assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
-        assert isinstance(document.metadata["category"], CategoriesMetadata)
+        assert isinstance(document.metadata["categories"], CategoriesMetadata)
 
-    def test_legacy_name_and_categories_keys_proxy_to_schema_keys(self, mock_api_client):
+    def test_legacy_name_key_proxies_to_title(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
         with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
             assert document.metadata["name"] is document.metadata["title"]
-        with pytest.warns(DeprecationWarning, match=r'metadata\["categories"\] is deprecated'):
-            assert document.metadata["categories"] is document.metadata["category"]
         assert "name" in document.metadata
-        assert "categories" in document.metadata
         with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
             assert document.metadata.get("name") is document.metadata["title"]
-        with pytest.warns(DeprecationWarning, match=r'metadata\["categories"\] is deprecated'):
-            assert document.metadata.get("categories") is document.metadata["category"]
 
     def test_metadata_name_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -272,7 +267,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
-        category_metadata = document.metadata["category"]
+        category_metadata = document.metadata["categories"]
         assert isinstance(category_metadata, CategoriesMetadata)
         assert category_metadata.values == document.body.categories
 

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -161,7 +161,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="From document"),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
@@ -170,7 +170,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="From external"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -179,7 +179,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Rejected"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -188,7 +188,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert [category.name for category in document.metadata["category"].values] == [
+        assert [category.name for category in document.metadata["categories"].values] == [
             "From document",
             "From external",
         ]
@@ -197,7 +197,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Shared", parent=None),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
@@ -206,7 +206,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Shared", parent=None),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -214,7 +214,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        categories = document.metadata["category"].values
+        categories = document.metadata["categories"].values
         assert len(categories) == 1
         assert categories[0].name == "Shared"
 
@@ -222,7 +222,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Parent", parent=None),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -231,7 +231,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Child", parent="Parent"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -239,7 +239,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        categories = document.metadata["category"].values
+        categories = document.metadata["categories"].values
         assert len(categories) == 1
         assert categories[0].name == "Parent"
         assert [child.name for child in categories[0].subcategories] == ["Child"]
@@ -476,7 +476,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
-                name="category",
+                name="categories",
                 value=MetadataCategoryValue(name="Orphan", parent="Missing Parent"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
@@ -484,7 +484,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["category"].values == []
+        assert document.metadata["categories"].values == []
 
     def test_metadata_contains_rejects_non_string_keys(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)


### PR DESCRIPTION
- Make `categories` the only metadata key for `Document.metadata` and metadata claims
- Remove the `category`/`categories` facade alias so callers using `category` break loudly