### PR TITLE
feat: add judges as structured document metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Feat
 
 - **Document**: documents can now retrieve and will set latest_published_datetime
+- **Metadata**: add judges as structured document metadata with body fallback and claim editing
 
 ### Fix
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -29,6 +29,7 @@ from caselawclient.models.documents.metadata.types.case_number import CaseNumber
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
 from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
@@ -224,6 +225,7 @@ class Document:
             date=DateMetadata(self),
             case_number=CaseNumberMetadata(self),
             categories=CategoriesMetadata(self),
+            judges=JudgesMetadata(self),
         )
 
     @property

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -69,13 +69,11 @@ def judges_from_nodes(nodes: list[Element]) -> list[str]:
     inside a ``judge`` node is flattened via ``itertext``.
     """
     judges: list[str] = []
-    seen: set[str] = set()
 
     for node in nodes:
         name = "".join(node.itertext()).strip()
-        if not name or name in seen:
+        if not name or name in judges:
             continue
-        seen.add(name)
         judges.append(name)
 
     return judges

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -26,6 +26,7 @@ JURISDICTION_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdic
 CATEGORIES_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
 CASE_NUMBER_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()"
 DATE_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date"
+JUDGES_XPATH = "//akn:judge"
 
 
 def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
@@ -58,6 +59,25 @@ def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
     return [
         categories[name] for node in nodes if node.get("parent") is None if (name := node.text) and name in categories
     ]
+
+
+def judges_from_nodes(nodes: list[Element]) -> list[str]:
+    """Extract unique judge display names from Akoma Ntoso ``judge`` nodes.
+
+    Names are returned in first-seen document order. Empty or whitespace-only
+    text is skipped; duplicate names are de-duplicated.
+    """
+    judges: list[str] = []
+    seen: set[str] = set()
+
+    for node in nodes:
+        name = (node.text or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        judges.append(name)
+
+    return judges
 
 
 class DocumentBody:
@@ -104,6 +124,10 @@ class DocumentBody:
     @cached_property
     def case_number(self) -> Optional[str]:
         return self.get_xpath_match_string(CASE_NUMBER_XPATH)
+
+    @cached_property
+    def judges(self) -> list[str]:
+        return judges_from_nodes(self.get_xpath_nodes(JUDGES_XPATH))
 
     @property
     def court_and_jurisdiction_identifier_string(self) -> CourtCode:

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -26,7 +26,7 @@ JURISDICTION_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:jurisdic
 CATEGORIES_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
 CASE_NUMBER_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()"
 DATE_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date"
-JUDGES_XPATH = "//akn:judge"
+JUDGES_XPATH = "/akn:akomaNtoso/akn:*/akn:header//akn:judge"
 
 
 def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
@@ -65,13 +65,14 @@ def judges_from_nodes(nodes: list[Element]) -> list[str]:
     """Extract unique judge display names from Akoma Ntoso ``judge`` nodes.
 
     Names are returned in first-seen document order. Empty or whitespace-only
-    text is skipped; duplicate names are de-duplicated.
+    text is skipped; duplicate names are de-duplicated. Nested inline markup
+    inside a ``judge`` node is flattened via ``itertext``.
     """
     judges: list[str] = []
     seen: set[str] = set()
 
     for node in nodes:
-        name = (node.text or "").strip()
+        name = "".join(node.itertext()).strip()
         if not name or name in seen:
             continue
         seen.add(name)

--- a/src/caselawclient/models/documents/metadata/fields/collection.py
+++ b/src/caselawclient/models/documents/metadata/fields/collection.py
@@ -26,6 +26,10 @@ class MetadataFieldsCollection(dict[str, MetadataField]):
         """Soft-delete a claim by id."""
         self[field_id].reject()
 
+    def restore(self, field_id: str) -> None:
+        """Undo soft-delete for a claim by id."""
+        self[field_id].restore()
+
     def remove(self, field_id: str) -> None:
         """Hard-remove a claim. Only allowed for editor-sourced claims.
 

--- a/src/caselawclient/models/documents/metadata/fields/field.py
+++ b/src/caselawclient/models/documents/metadata/fields/field.py
@@ -47,6 +47,10 @@ class MetadataField:
         """Soft-delete this claim; retained for provenance but excluded from resolution."""
         self.rejected = True
 
+    def restore(self) -> None:
+        """Undo a soft-delete so this claim can participate in resolution again."""
+        self.rejected = False
+
     @property
     def as_etree(self) -> Element:
         """Pack this claim into a ``<metadata>`` element for MarkLogic storage."""

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -7,16 +7,18 @@ from caselawclient.models.documents.metadata.types.case_number import CaseNumber
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
 from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 
 if TYPE_CHECKING:
     from caselawclient.models.documents.metadata.base import Metadata
 
-MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "categories"]
+MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "categories", "judges"]
 
 METADATA_KEY_ALIASES: dict[str, MetadataAttributeKey] = {
     "name": "title",
+    "judge": "judges",
 }
 
 
@@ -27,12 +29,14 @@ class DocumentMetadataRegistry(TypedDict):
     date: DateMetadata
     case_number: CaseNumberMetadata
     categories: CategoriesMetadata
+    judges: JudgesMetadata
 
 
 class DocumentMetadata(dict[str, "Metadata"]):
     """Document metadata keyed by schema-aligned claim names.
 
-    Legacy facade key ``name`` is proxied to ``title``.
+    Legacy facade keys ``name`` and ``judge`` are proxied to ``title`` and
+    ``judges`` respectively.
     """
 
     def _canonical_key(self, key: str) -> str:
@@ -63,6 +67,9 @@ class DocumentMetadata(dict[str, "Metadata"]):
 
     @overload
     def __getitem__(self, key: Literal["categories"]) -> CategoriesMetadata: ...
+
+    @overload
+    def __getitem__(self, key: Literal["judges", "judge"]) -> JudgesMetadata: ...
 
     @overload
     def __getitem__(self, key: str) -> Metadata: ...

--- a/src/caselawclient/models/documents/metadata/types/judges.py
+++ b/src/caselawclient/models/documents/metadata/types/judges.py
@@ -1,0 +1,110 @@
+from caselawclient.models.documents.metadata.base import MultipleMetadata
+from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldRemovalNotAllowedException
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+
+def judge_names_from_field_values(values: list[MetadataFieldValue]) -> list[str]:
+    """Extract unique judge name strings from metadata claim values.
+
+    Non-string claim values are ignored. Duplicate names are de-duplicated with
+    first-seen order winning.
+    """
+    judges: list[str] = []
+    seen: set[str] = set()
+
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        name = value.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        judges.append(name)
+
+    return judges
+
+
+class JudgesMetadata(MultipleMetadata[str]):
+    key = "judges"
+    title = "Judges"
+    description = "A list of the names of the judges (or equivalent for the body) involved in any particular case."
+    editable = True
+
+    @property
+    def values(self) -> list[str]:
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.judges
+        return judge_names_from_field_values(resolved.values)
+
+    def materialise_body_claims(self) -> None:
+        """Yank body judge names into DOCUMENT claims when no claims exist yet.
+
+        After this, resolution is claim-based and soft-delete can suppress names
+        without the body fallback resurrecting them.
+        """
+        resolved = self._resolve_claims()
+        if resolved.has_any_claims:
+            return
+
+        for name in self.document.body.judges:
+            self.document.metadata_fields.add(
+                MetadataField(
+                    name=self.key,
+                    value=name,
+                    source=MetadataSource.DOCUMENT,
+                )
+            )
+
+    def add_editor_judge(self, name: str) -> None:
+        """Add an EDITOR claim for a judge name, yanking body first if needed."""
+        cleaned = name.strip()
+        if not cleaned:
+            return
+
+        self.materialise_body_claims()
+        self.document.metadata_fields.add(
+            MetadataField(
+                name=self.key,
+                value=cleaned,
+                source=MetadataSource.EDITOR,
+            )
+        )
+
+    def suppress_claim(self, claim_id: str) -> None:
+        """Suppress a judges claim: reject document/external, hard-remove editor."""
+        self.materialise_body_claims()
+        claim = self.document.metadata_fields[claim_id]
+        if claim.name != self.key:
+            raise KeyError(f"Claim {claim_id} is not a '{self.key}' claim")
+
+        if claim.source is MetadataSource.EDITOR:
+            self.document.metadata_fields.remove(claim_id)
+        else:
+            self.document.metadata_fields.reject(claim_id)
+
+    def restore_claim(self, claim_id: str) -> None:
+        """Restore a previously rejected judges claim."""
+        claim = self.document.metadata_fields[claim_id]
+        if claim.name != self.key:
+            raise KeyError(f"Claim {claim_id} is not a '{self.key}' claim")
+        if claim.source is MetadataSource.EDITOR:
+            raise MetadataFieldRemovalNotAllowedException(
+                f"Cannot restore editor claim {claim_id}; editor claims are hard-removed rather than rejected."
+            )
+        self.document.metadata_fields.restore(claim_id)
+
+    def suppress_body_value(self, name: str) -> None:
+        """Yank body claims if needed, then reject the DOCUMENT claim matching ``name``."""
+        cleaned = name.strip()
+        if not cleaned:
+            return
+
+        self.materialise_body_claims()
+        for claim in self.document.metadata_fields.by_name(self.key):
+            if claim.rejected:
+                continue
+            if claim.source is MetadataSource.DOCUMENT and claim.value == cleaned:
+                self.document.metadata_fields.reject(claim.id)
+                return

--- a/src/caselawclient/models/documents/metadata/types/judges.py
+++ b/src/caselawclient/models/documents/metadata/types/judges.py
@@ -11,15 +11,13 @@ def judge_names_from_field_values(values: list[MetadataFieldValue]) -> list[str]
     first-seen order winning.
     """
     judges: list[str] = []
-    seen: set[str] = set()
 
     for value in values:
         if not isinstance(value, str):
             continue
         name = value.strip()
-        if not name or name in seen:
+        if not name or name in judges:
             continue
-        seen.add(name)
         judges.append(name)
 
     return judges

--- a/tests/models/documents/metadata/test_judges_editing.py
+++ b/tests/models/documents/metadata/test_judges_editing.py
@@ -1,0 +1,108 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+TIMESTAMP = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _id() -> str:
+    return str(uuid4())
+
+
+def _body_with_judges(*names: str) -> object:
+    judges_xml = "".join(f"<judge>{name}</judge>" for name in names)
+    return DocumentBodyFactory.build(
+        f"""
+        <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+            <judgment>
+                <header><p>{judges_xml}</p></header>
+            </judgment>
+        </akomaNtoso>
+        """
+    )
+
+
+class TestJudgesMetadataEditing:
+    def test_materialise_body_claims_yanks_body_names(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=_body_with_judges("Judge A", "Judge B"),
+        )
+        judges = document.metadata["judges"]
+
+        judges.materialise_body_claims()
+
+        assert [claim.value for claim in document.metadata_fields.by_name("judges")] == [
+            "Judge A",
+            "Judge B",
+        ]
+        assert all(claim.source is MetadataSource.DOCUMENT for claim in document.metadata_fields.by_name("judges"))
+        assert judges.values == ["Judge A", "Judge B"]
+
+    def test_materialise_body_claims_is_noop_when_claims_exist(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Body Judge"))
+        document.metadata_fields.add(
+            MetadataField(
+                name="judges",
+                value="Claim Judge",
+                source=MetadataSource.EXTERNAL,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata["judges"].materialise_body_claims()
+        assert [claim.value for claim in document.metadata_fields.by_name("judges")] == ["Claim Judge"]
+
+    def test_add_editor_judge_yanks_then_adds(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Body Judge"))
+        document.metadata["judges"].add_editor_judge("Editor Judge")
+
+        claims = document.metadata_fields.by_name("judges")
+        assert len(claims) == 2
+        assert claims[0].source is MetadataSource.DOCUMENT
+        assert claims[0].value == "Body Judge"
+        assert claims[1].source is MetadataSource.EDITOR
+        assert claims[1].value == "Editor Judge"
+        assert document.metadata["judges"].values == ["Body Judge", "Editor Judge"]
+
+    def test_suppress_document_claim_rejects(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A", "Judge B"))
+        judges = document.metadata["judges"]
+        judges.materialise_body_claims()
+        claim_a = next(claim for claim in document.metadata_fields.by_name("judges") if claim.value == "Judge A")
+
+        judges.suppress_claim(claim_a.id)
+
+        assert claim_a.rejected is True
+        assert judges.values == ["Judge B"]
+        # Body must not resurrect Judge A
+        assert "Judge A" not in judges.values
+
+    def test_suppress_editor_claim_hard_removes(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="judges",
+                value="Editor Judge",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        claim_id = next(iter(document.metadata_fields.by_name("judges"))).id
+        document.metadata["judges"].suppress_claim(claim_id)
+        assert document.metadata_fields.by_name("judges") == []
+
+    def test_restore_rejected_document_claim(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A"))
+        judges = document.metadata["judges"]
+        judges.materialise_body_claims()
+        claim = document.metadata_fields.by_name("judges")[0]
+        judges.suppress_claim(claim.id)
+        assert judges.values == []
+
+        judges.restore_claim(claim.id)
+        assert judges.values == ["Judge A"]

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -146,6 +146,45 @@ class TestDocumentBody:
             ('doc name="pressSummary"', "doc"),
         ],
     )
+    def test_judges(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <header>
+                        <p><judge refersTo="#judge-one">Judge One</judge></p>
+                        <p><judge refersTo="#judge-two">Judge Two</judge></p>
+                        <p><judge refersTo="#judge-one">Judge One</judge></p>
+                        <p><judge>   </judge></p>
+                    </header>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.judges == ["Judge One", "Judge Two"]
+
+    def test_judges_empty_when_absent(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <header><p>No judges here</p></header>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.judges == []
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
     def test_category(self, opening_tag, closing_tag):
         body = DocumentBody(
             f"""

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -178,6 +178,42 @@ class TestDocumentBody:
 
         assert body.judges == []
 
+    def test_judges_ignores_judges_outside_header(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <header>
+                        <p><judge>Header Judge</judge></p>
+                    </header>
+                    <judgmentBody>
+                        <decision>
+                            <p>As <judge>Body Judge</judge> noted earlier...</p>
+                        </decision>
+                    </judgmentBody>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.judges == ["Header Judge"]
+
+    def test_judges_flattens_nested_inline_markup(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <header>
+                        <p><judge>Lord <span>Justice</span> Smith</judge></p>
+                        <p><judge>Mrs Justice <i>Jones</i> &amp; Co</judge></p>
+                    </header>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.judges == ["Lord Justice Smith", "Mrs Justice Jones & Co"]
+
     @pytest.mark.parametrize(
         "opening_tag, closing_tag",
         [

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -186,6 +186,31 @@ class TestCategoriesMetadata:
         assert CategoriesMetadata(document).values == document.body.categories
 
 
+class TestJudgesMetadata:
+    def test_judges_metadata_uses_judges_key(self):
+        from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
+
+        assert JudgesMetadata.key == "judges"
+        assert JudgesMetadata.title == "Judges"
+
+    def test_judges_metadata_values_match_document_body(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+        from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
+
+        body = DocumentBodyFactory.build(
+            """
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <header><p><judge>Judge A</judge> and <judge>Judge B</judge></p></header>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=body)
+        assert JudgesMetadata(document).values == ["Judge A", "Judge B"]
+        assert document.metadata["judges"].values == document.body.judges
+
+
 class TestDocumentMetadata:
     def test_factory_built_document_metadata_reads_from_xml(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -222,6 +247,7 @@ class TestDocumentMetadata:
             "date",
             "case_number",
             "categories",
+            "judges",
         }
 
     def test_metadata_entries_are_expected_types(self, mock_api_client):
@@ -230,6 +256,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
         from caselawclient.models.documents.metadata.types.court import CourtMetadata
         from caselawclient.models.documents.metadata.types.date import DateMetadata
+        from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
         from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
         from caselawclient.models.documents.metadata.types.name import NameMetadata
 
@@ -241,6 +268,7 @@ class TestDocumentMetadata:
         assert isinstance(document.metadata["date"], DateMetadata)
         assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
         assert isinstance(document.metadata["categories"], CategoriesMetadata)
+        assert isinstance(document.metadata["judges"], JudgesMetadata)
 
     def test_legacy_name_key_proxies_to_title(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -252,6 +280,17 @@ class TestDocumentMetadata:
         assert "name" in document.metadata
         with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
             assert document.metadata.get("name") is document.metadata["title"]
+
+    def test_legacy_judge_key_proxies_to_judges(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
+            assert document.metadata["judge"] is document.metadata["judges"]
+        assert "judge" in document.metadata
+        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
+            assert document.metadata.get("judge") is document.metadata["judges"]
 
     def test_metadata_name_value_matches_document_body(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -283,4 +322,4 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert len(list(document.metadata.values())) == 6
+        assert len(list(document.metadata.values())) == 7

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -486,6 +486,31 @@ class TestDocumentMetadataFacadePrefersFields:
 
         assert document.metadata["categories"].values == []
 
+    def test_judges_prefers_claims_over_body(self, mock_api_client):
+        from caselawclient.factories import DocumentBodyFactory
+
+        body = DocumentBodyFactory.build(
+            """
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <header><p><judge>Body Judge</judge></p></header>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=body)
+        document.metadata_fields.add(
+            MetadataField(
+                name="judges",
+                value="Claim Judge",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+
+        assert document.metadata["judges"].values == ["Claim Judge"]
+
     def test_metadata_contains_rejects_non_string_keys(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
 


### PR DESCRIPTION
- Add `JudgesMetadata` with body fallback and metadata_fields claim resolution
- Expose `DocumentBody.judges` from Akoma Ntoso `judge` nodes
- Support editor claim add/suppress/restore, including materialising body names into DOCUMENT claims

Depends on the categories rename PR as base.