### PR TITLE
[FCLC-2225] Migrate to fully timezone-aware datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Fix
 
+- enforce UTC-aware datetime handling
 - **deps**: update dependency certifi to >=2026.7.22,<2026.8.0
 
 ### Refactor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # longlines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "SLF", "SIM", "C90", "S"]
+extend-select = ["W", "I", "SLF", "SIM", "C90", "S", "DTZ"]
 # extend-select = [ "B", "Q", "I", "UP", "YTT", "ASYNC", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLOT", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import warnings
-from datetime import datetime, time, timedelta
+from datetime import UTC, datetime, time, timedelta
 from pathlib import Path
 from typing import Any, Optional, Type, Union
 
@@ -31,6 +31,7 @@ from caselawclient.models.documents.versions import VersionAnnotation, VersionTy
 from caselawclient.models.judgments import Judgment
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.models.utilities import move
+from caselawclient.models.utilities.dates import require_aware_utc
 from caselawclient.search_parameters import SearchParameters
 from caselawclient.types import DocumentIdentifierSlug, DocumentIdentifierValue, DocumentLock, DocumentURIString
 from caselawclient.xml_helpers import Element
@@ -998,6 +999,7 @@ class MarklogicApiClient:
         value: datetime,
     ) -> requests.Response:
         """Set a property within MarkLogic which is specifically a datetime."""
+        value = require_aware_utc(value, name="value")
         uri = self._format_uri_for_marklogic(judgment_uri)
         vars: query_dicts.SetDatetimePropertyDict = {
             "uri": uri,
@@ -1015,7 +1017,7 @@ class MarklogicApiClient:
         content = self.get_property(judgment_uri, name)
 
         if content:
-            return isoparse(content)
+            return require_aware_utc(isoparse(content), name=name)
 
         return None
 
@@ -1167,10 +1169,11 @@ class MarklogicApiClient:
         Get timedelta until end of day on the datetime passed, or current time.
         https://stackoverflow.com/questions/45986035/seconds-until-end-of-day-in-python
         """
-        if not now:
-            now = datetime.now()
-        tomorrow = now + timedelta(days=1)
-        difference = datetime.combine(tomorrow, time.min) - now
+        if now is None:
+            now = datetime.now(UTC)
+        now = require_aware_utc(now, name="now")
+        tomorrow = now.date() + timedelta(days=1)
+        difference = datetime.combine(tomorrow, time.min, tzinfo=UTC) - now
 
         return difference.seconds
 

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -163,7 +163,7 @@ class SearchResultMetadataFactory(SimpleFactory[SearchResultMetadata]):
         "author": "Fake Name",
         "author_email": "fake.email@gov.invalid",
         "consignment_reference": "TDR-2023-ABC",
-        "submission_datetime": datetime.datetime(2023, 2, 3, 9, 12, 34),
+        "submission_datetime": datetime.datetime(2023, 2, 3, 9, 12, 34, tzinfo=datetime.UTC),
         "editor_status": "New",
     }
 
@@ -205,8 +205,8 @@ class SearchResultFactory(SimpleFactory[SearchResult]):
         "name": "Judgment v Judgement",
         "neutral_citation": "[2025] UKSC 123",
         "court": "Court of Testing",
-        "date": datetime.datetime(2023, 2, 3),
-        "transformation_date": str(datetime.datetime(2023, 2, 3, 12, 34)),
+        "date": datetime.datetime(2023, 2, 3, tzinfo=datetime.UTC),
+        "transformation_date": "2023-02-03 12:34:00+00:00",
         "metadata": SearchResultMetadataFactory.build(),
         "is_failure": False,
         "matches": None,

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -117,10 +117,7 @@ class DocumentBody:
         if not date_as_string:
             return None
         try:
-            return datetime.datetime.strptime(
-                date_as_string,
-                "%Y-%m-%d",
-            ).date()
+            return datetime.date.fromisoformat(date_as_string)
         except ValueError:
             warnings.warn(
                 f"Unparsable date encountered: {date_as_string}",

--- a/src/caselawclient/models/documents/metadata/fields/unpacker.py
+++ b/src/caselawclient/models/documents/metadata/fields/unpacker.py
@@ -7,6 +7,7 @@ from caselawclient.models.documents.metadata.fields.exceptions import (
 )
 from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.utilities.dates import require_aware_utc
 from caselawclient.xml_helpers import Element
 
 
@@ -56,7 +57,7 @@ def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField:
         ) from exc
 
     try:
-        timestamp = datetime.fromisoformat(timestamp_value)
+        timestamp = require_aware_utc(datetime.fromisoformat(timestamp_value), name="timestamp")
     except ValueError as exc:
         raise InvalidMetadataFieldXMLRepresentationException(
             f"Metadata field XML representation is not valid: unparsable timestamp '{timestamp_value}'"

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -16,7 +16,7 @@ def date_from_metadata_field_value(value: object) -> datetime.date | None:
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+        return datetime.date.fromisoformat(value)
     except ValueError:
         # Import locally to avoid a circular dependency with DocumentBody.
         from caselawclient.models.documents.body import UnparsableDate

--- a/src/caselawclient/models/utilities/dates.py
+++ b/src/caselawclient/models/utilities/dates.py
@@ -3,6 +3,12 @@ from datetime import UTC, datetime, tzinfo
 from dateutil.parser import isoparse
 
 
+def require_aware_utc(value: datetime, name: str = "datetime") -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{name} must be timezone-aware")
+    return value.astimezone(UTC)
+
+
 def parse_string_date_as_utc(iso_string: str, timezone: tzinfo) -> datetime:
     """iso_string might be aware or unaware:
     ensure that it is converted to a UTC-aware datetime"""

--- a/src/caselawclient/responses/search_result.py
+++ b/src/caselawclient/responses/search_result.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from functools import cached_property
 from typing import Any, Dict, Optional
@@ -116,10 +116,10 @@ class SearchResultMetadata:
         :return: The submission datetime
         """
         if tdr_time := self._get_xpath_match_string("//transfer-received-at/text()"):
-            return datetime.strptime(tdr_time, "%Y-%m-%dT%H:%M:%SZ")
+            return datetime.fromisoformat(tdr_time.replace("Z", "+00:00")).astimezone(UTC)
         if email_time := self._get_xpath_match_string("//email-received-at/text()"):
-            return datetime.strptime(email_time, "%Y-%m-%dT%H:%M:%SZ")
-        return datetime.min
+            return datetime.fromisoformat(email_time.replace("Z", "+00:00")).astimezone(UTC)
+        return datetime.min.replace(tzinfo=UTC)
 
     @property
     def editor_status(

--- a/tests/client/test_checkout_checkin_judgment.py
+++ b/tests/client/test_checkout_checkin_judgment.py
@@ -1,8 +1,10 @@
 import json
 import os
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import ANY, patch
+
+import pytest
 
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
@@ -169,13 +171,15 @@ class TestGetCheckoutStatus(unittest.TestCase):
             assert result is None
 
     def test_calculate_seconds_until_midnight(self):
-        dt = datetime.strptime(
-            "2020-01-01 23:00",
-            "%Y-%m-%d %H:%M",
-        )  # 1 hour until midnight
+        dt = datetime(2020, 1, 1, 23, 0, tzinfo=UTC)  # 1 hour until midnight
         result = self.client.calculate_seconds_until_midnight(dt)
         expected_result = 3600  # 1 hour in seconds
         assert result == expected_result
+
+    def test_calculate_seconds_until_midnight_rejects_naive_datetime(self):
+        naive_datetime = datetime.fromisoformat("2020-01-01T23:00:00")
+        with pytest.raises(ValueError, match="now must be timezone-aware"):
+            self.client.calculate_seconds_until_midnight(naive_datetime)
 
     def test_break_judgment_checkout(self):
         client = MarklogicApiClient("", "", "", False)

--- a/tests/client/test_get_set_properties.py
+++ b/tests/client/test_get_set_properties.py
@@ -3,6 +3,8 @@ import os
 from datetime import UTC, datetime
 from unittest.mock import ANY, patch
 
+import pytest
+
 from caselawclient.Client import ROOT_DIR, MarklogicApiClient
 from caselawclient.models.documents import DocumentURIString
 
@@ -172,3 +174,19 @@ class TestGetSetDatetimeDocumentProperties:
             result = self.client.get_datetime_property(DocumentURIString("judgment/uri"), "my-property")
 
             assert result is None
+
+    def test_set_datetime_property_rejects_naive_datetime(self):
+        naive_datetime = datetime.fromisoformat("2025-08-19T08:00:00")
+        with pytest.raises(ValueError, match="value must be timezone-aware"):
+            self.client.set_datetime_property(
+                DocumentURIString("judgment/uri"),
+                name="my-property",
+                value=naive_datetime,
+            )
+
+    def test_get_datetime_property_rejects_naive_datetime(self):
+        with (
+            patch.object(self.client, "get_property", return_value="2025-08-19T12:05:53.398214"),
+            pytest.raises(ValueError, match="my-property must be timezone-aware"),
+        ):
+            self.client.get_datetime_property(DocumentURIString("judgment/uri"), "my-property")

--- a/tests/managers/merge/test_merge_checks.py
+++ b/tests/managers/merge/test_merge_checks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from caselawclient.managers.merge import checks
 from caselawclient.models.documents import Document, DocumentURIString
@@ -144,8 +144,8 @@ class TestCheckSourceDocumentIsNewerThanTarget:
         source_document = Judgment(DocumentURIString("test/1234"), mock_api_client)
         target_document = Judgment(DocumentURIString("test/5678"), mock_api_client)
 
-        source_document.version_created_datetime = datetime(2025, 2, 1, 12, 34, 56)
-        target_document.version_created_datetime = datetime(2025, 1, 1, 12, 34, 56)
+        source_document.version_created_datetime = datetime(2025, 2, 1, 12, 34, 56, tzinfo=UTC)
+        target_document.version_created_datetime = datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)
 
         check_result = checks.check_source_document_is_newer_than_target(source_document, target_document)
 
@@ -156,8 +156,8 @@ class TestCheckSourceDocumentIsNewerThanTarget:
         source_document = Judgment(DocumentURIString("test/1234"), mock_api_client)
         target_document = Judgment(DocumentURIString("test/5678"), mock_api_client)
 
-        source_document.version_created_datetime = datetime(2025, 1, 1, 12, 34, 56)
-        target_document.version_created_datetime = datetime(2025, 2, 1, 12, 34, 56)
+        source_document.version_created_datetime = datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)
+        target_document.version_created_datetime = datetime(2025, 2, 1, 12, 34, 56, tzinfo=UTC)
 
         check_result = checks.check_source_document_is_newer_than_target(source_document, target_document)
 

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -164,6 +164,14 @@ class TestMetadataFieldUnpacking:
         with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unparsable timestamp"):
             unpack_a_metadata_field_from_etree(xml)
 
+    def test_unpack_naive_timestamp_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" source="document" '
+            'timestamp="2025-08-19T08:00:00">X</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unparsable timestamp"):
+            unpack_a_metadata_field_from_etree(xml)
+
     def test_unpack_unknown_source_raises(self):
         xml = etree.fromstring(
             '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="title" source="mystery" '

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -156,7 +156,7 @@ class TestDocumentPublish:
         mock_api_client.set_datetime_property.assert_any_call("test/1234", "latest_published_datetime", expected_now)
         assert mock_api_client.set_datetime_property.call_count == 2
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.publish_documents")
     @patch("caselawclient.models.documents.Document.enrich")
@@ -180,7 +180,7 @@ class TestDocumentPublish:
             datetime.datetime(1955, 11, 5, 6, 0, tzinfo=datetime.timezone.utc),
         )
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.publish_documents")
     @patch("caselawclient.models.documents.Document.enrich")

--- a/tests/models/documents/test_document_verbs.py
+++ b/tests/models/documents/test_document_verbs.py
@@ -135,7 +135,7 @@ class TestDocumentPublish:
         assert len(document.identifiers.of_type(FindCaseLawIdentifier)) == 1
         assert [identifier.value for identifier in document.identifiers.of_type(FindCaseLawIdentifier)][0] == "tn4t35ts"
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.publish_documents")
     @patch("caselawclient.models.documents.Document.enrich")
@@ -229,7 +229,7 @@ class TestDocumentUnpublish:
 
 
 class TestDocumentForceEnrich:
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=True)
     def test_force_enrich(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
@@ -248,7 +248,7 @@ class TestDocumentForceEnrich:
             enrich=True,
         )
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
     def test_force_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
@@ -280,7 +280,7 @@ class TestDocumentCanEnrich:
 
 
 class TestDocumentEnrich:
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
     def test_enrich_but_not_enrichable(self, mock_can_enrich, mock_announce_document_event, mock_api_client):
@@ -296,7 +296,7 @@ class TestDocumentEnrich:
 
         mock_announce_document_event.assert_not_called()
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.documents.announce_document_event")
     @patch("caselawclient.models.documents.Document.can_enrich", new_callable=PropertyMock, return_value=False)
     def test_enrich_of_unenrichable_but_exception_ignored(
@@ -405,7 +405,7 @@ class TestDocumentDelete:
 
 
 class TestReparse:
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.utilities.aws.create_sns_client")
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
@@ -462,7 +462,7 @@ class TestReparse:
             },
         }
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.utilities.aws.create_sns_client")
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
@@ -520,7 +520,7 @@ class TestReparse:
             },
         }
 
-    @time_machine.travel(datetime.datetime(1955, 11, 5, 6))
+    @time_machine.travel(datetime.datetime(1955, 11, 5, 6, tzinfo=datetime.UTC))
     @patch("caselawclient.models.utilities.aws.create_sns_client")
     @patch.dict(os.environ, {"PRIVATE_ASSET_BUCKET": "MY_BUCKET"})
     @patch.dict(os.environ, {"REPARSE_SNS_TOPIC": "MY_TOPIC"})
@@ -568,7 +568,7 @@ class TestReparse:
             },
         }
 
-    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29))
+    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29, tzinfo=datetime.UTC))
     def test_reparse_sets_last_sent_if_no_docx(self, mock_api_client):
         document = JudgmentFactory().build(api_client=mock_api_client)
         document.can_reparse = False
@@ -579,7 +579,7 @@ class TestReparse:
             "2015-10-21T16:29:00+00:00",
         )
 
-    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29))
+    @time_machine.travel(datetime.datetime(2015, 10, 21, 16, 29, tzinfo=datetime.UTC))
     def test_reparse_sets_last_sent_if_docx(self, mock_api_client):
         document = JudgmentFactory().build(api_client=mock_api_client)
         document.can_reparse = True

--- a/tests/models/utilities/test_util_dates.py
+++ b/tests/models/utilities/test_util_dates.py
@@ -1,7 +1,9 @@
-from datetime import datetime
+from datetime import UTC, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
-from caselawclient.models.utilities.dates import parse_string_date_as_utc
+import pytest
+
+from caselawclient.models.utilities.dates import parse_string_date_as_utc, require_aware_utc
 
 TOKYO = ZoneInfo("Asia/Tokyo")
 PLUS_4 = ZoneInfo("Etc/GMT+4")
@@ -21,3 +23,14 @@ def test_parse_string_date():
     assert parse_string_date_as_utc("2002-06-01T12-05:00", TOKYO) == datetime.fromisoformat("2002-06-01T17:00:00+00:00")
     assert parse_string_date_as_utc("2002", timezone=TOKYO) == datetime.fromisoformat("2001-12-31T15:00:00+00:00")
     assert parse_string_date_as_utc("2002", timezone=PLUS_4) == datetime.fromisoformat("2002-01-01T04:00:00+00:00")
+
+
+def test_require_aware_utc_rejects_naive_datetime():
+    naive_datetime = datetime.fromisoformat("2025-08-19T08:00:00")
+    with pytest.raises(ValueError, match="timestamp must be timezone-aware"):
+        require_aware_utc(naive_datetime, name="timestamp")
+
+
+def test_require_aware_utc_normalizes_to_utc():
+    offset_datetime = datetime(2025, 8, 19, 9, 0, tzinfo=timezone(timedelta(hours=1)))
+    assert require_aware_utc(offset_datetime) == datetime(2025, 8, 19, 8, 0, tzinfo=UTC)

--- a/tests/responses/test_search_result.py
+++ b/tests/responses/test_search_result.py
@@ -47,7 +47,7 @@ class TestSearchResult:
             assert search_result.uri == "a/c/2015/20"
             assert search_result.neutral_citation == "[2015] UKSC 123"
             assert search_result.name == "Another made up case name"
-            assert search_result.date == datetime.datetime(2017, 8, 8, 0, 0)
+            assert search_result.date and search_result.date.isoformat() == "2017-08-08T00:00:00"
             assert search_result.court is None
             assert search_result.matches == (
                 "<p data-path=\"fn:doc('/a/c/2015/20.xml')/*:akomaNtoso\">"
@@ -297,7 +297,7 @@ class TestSearchResultMeta:
         assert meta.consignment_reference == "test_consignment_reference"
         assert meta.editor_hold == "false"
         assert meta.editor_priority == "30"
-        assert meta.submission_datetime == datetime.datetime(2023, 1, 26, 14, 17, 2)
+        assert meta.submission_datetime == datetime.datetime(2023, 1, 26, 14, 17, 2, tzinfo=datetime.UTC)
         assert meta.last_modified == "test_last_modified"
         assert meta.is_published is True
 
@@ -318,7 +318,7 @@ class TestSearchResultMeta:
         assert meta.consignment_reference == ""
         assert meta.editor_hold == ""
         assert meta.editor_priority == EditorPriority.MEDIUM.value
-        assert meta.submission_datetime == datetime.datetime.min
+        assert meta.submission_datetime == datetime.datetime.min.replace(tzinfo=datetime.UTC)
         assert meta.last_modified == "test_last_modified"
         assert meta.is_published is False
 
@@ -376,7 +376,7 @@ class TestSearchResultMeta:
         )
         meta = SearchResultMetadata(node, last_modified="foo")
 
-        assert meta.submission_datetime == datetime.datetime.min
+        assert meta.submission_datetime == datetime.datetime.min.replace(tzinfo=datetime.UTC)
 
 
 class TestSearchResultMetadataSubmissionDatetime:
@@ -394,7 +394,7 @@ class TestSearchResultMetadataSubmissionDatetime:
             "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
-        assert meta.submission_datetime == datetime.datetime(1111, 11, 11, 11, 11, 11)
+        assert meta.submission_datetime == datetime.datetime(1111, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
 
     def test_submission_datetime_both(self):
         """
@@ -411,7 +411,7 @@ class TestSearchResultMetadataSubmissionDatetime:
             "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
-        assert meta.submission_datetime == datetime.datetime(1111, 11, 11, 11, 11, 11)
+        assert meta.submission_datetime == datetime.datetime(1111, 11, 11, 11, 11, 11, tzinfo=datetime.UTC)
 
     def test_submission_datetime_email(self):
         """
@@ -427,7 +427,7 @@ class TestSearchResultMetadataSubmissionDatetime:
             "</property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
-        assert meta.submission_datetime == datetime.datetime(2222, 2, 22, 22, 22, 22)
+        assert meta.submission_datetime == datetime.datetime(2222, 2, 22, 22, 22, 22, tzinfo=datetime.UTC)
 
     def test_submission_datetime_neither(self):
         """
@@ -439,4 +439,4 @@ class TestSearchResultMetadataSubmissionDatetime:
             "<property-results><property-result></property-result></property-results>",
         )
         meta = SearchResultMetadata(node, last_modified="test_last_modified")
-        assert meta.submission_datetime == datetime.datetime(1, 1, 1, 0, 0, 0)
+        assert meta.submission_datetime == datetime.datetime.min.replace(tzinfo=datetime.UTC)


### PR DESCRIPTION
- enforce UTC-aware datetimes at the strict `Client` and metadata parsing boundaries, rejecting naive inputs
- parse search result submission datetimes as UTC-aware values and normalize MarkLogic datetime properties to UTC
- enable `DTZ` in ruff and update affected tests and changelog output

## Jira

FCLC-2225