### PR TITLE
bump: version 48.0.0 → 49.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v49.0.0 (2026-08-03)
 
 ### BREAKING CHANGE
 
-- DocumentFactory, JudgmentFactory, PressSummaryFactory, and SimpleFactory subclasses now use `TargetClass` instead of `target_class`. Update any subclasses or callers that referenced the old attribute name.
+- DocumentFactory, JudgmentFactory, PressSummaryFactory,
+  and SimpleFactory subclasses now use `TargetClass` instead of
+  `target_class`. Update any subclasses or callers that referenced the old
+  attribute name.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
-- **Factories**: `DocumentFactory`, `JudgmentFactory`, `PressSummaryFactory`, and `SimpleFactory` subclasses now use `TargetClass` instead of `target_class`
+- DocumentFactory, JudgmentFactory, PressSummaryFactory, and SimpleFactory subclasses now use `TargetClass` instead of `target_class`. Update any subclasses or callers that referenced the old attribute name.
 
 ### Fix
 
 - escape special characters in document body factory XML
+
+### Refactor
+
+- rename factory target_class to TargetClass
 
 ## v48.0.0 (2026-07-30)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "48.0.0"
+version = "49.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- DocumentFactory, JudgmentFactory, PressSummaryFactory,
  and SimpleFactory subclasses now use `TargetClass` instead of
  `target_class`. Update any subclasses or callers that referenced the old
  attribute name.

### Fix

- escape special characters in document body factory XML

### Refactor

- rename factory target_class to TargetClass