### PR TITLE
[FCLC-2260] Materialise body metadata claims into metadata_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### Feat
+
+- materialise body-derived DOCUMENT metadata claims with per-field `LOGIC_VERSION` tracking
+- stamp `latest_metadata_materialisation_version` when materialising; `Document.save()` triggers materialisation
+
 ### Refactor
 
 - Remove courts and documents count query

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -21,6 +21,11 @@ from caselawclient.models.documents import comparison
 from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
 from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
 from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
+from caselawclient.models.documents.metadata.materialisation import (
+    CURRENT_METADATA_MATERIALISATION_VERSION,
+    LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+    document_needs_metadata_materialisation,
+)
 from caselawclient.models.documents.metadata.registry import (
     DocumentMetadata,
     MetadataAttributeKey,
@@ -591,6 +596,7 @@ class Document:
         Save the document's XML representation back to MarkLogic as a new version.
 
         Creates a new version with type EDIT, recording the changes made to the document.
+        Also materialises body-derived DOCUMENT metadata claims and persists them.
 
         :param message: Human-readable message describing the changes made.
         """
@@ -606,6 +612,28 @@ class Document:
             self.uri,
             self.body.content_as_xml_tree,
             annotation,
+        )
+        self.materialise_metadata_claims()
+
+    @property
+    def needs_metadata_materialisation(self) -> bool:
+        """True if this document's stored materialisation version is missing or outdated."""
+        stored = self.api_client.get_property(self.uri, LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY)
+        return document_needs_metadata_materialisation(stored or None)
+
+    def materialise_metadata_claims(self) -> None:
+        """Materialise body-derived DOCUMENT claims, persist metadata_fields, and stamp version.
+
+        Idempotent: existing DOCUMENT claims with the same value are not overwritten.
+        Safe to call from maintenance backfills as well as from ``save()``.
+        """
+        for field in self.metadata.values():
+            field.materialise_body_claims()
+        self.save_metadata_fields()
+        self.api_client.set_property(
+            self.uri,
+            LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+            CURRENT_METADATA_MATERIALISATION_VERSION,
         )
 
     def publish(self) -> None:

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -1,5 +1,13 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+
+from caselawclient.models.documents.metadata.fields.field import (
+    MetadataCategoryValue,
+    MetadataField,
+    MetadataFieldValue,
+)
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
 
 if TYPE_CHECKING:
     from caselawclient.models.documents import Document
@@ -16,11 +24,41 @@ class Metadata(ABC):
     editable: ClassVar[bool] = False
     """Should editors be allowed to manually edit this metadata field?"""
 
+    LOGIC_VERSION: ClassVar[int] = 1
+    """Bump when this field's body-extraction / materialisation rules change."""
+
     def __init__(self, document: "Document") -> None:
         self.document = document
 
     def _resolve_claims(self) -> "ResolvedMetadataField":
         return self.document.metadata_fields.resolve(self.key)
+
+    @staticmethod
+    def _value_resolves(value: MetadataFieldValue) -> bool:
+        if isinstance(value, str):
+            return bool(value)
+        if isinstance(value, MetadataCategoryValue):
+            return bool(value.name)
+        return False
+
+    def _materialise_document_values(self, values: Iterable[MetadataFieldValue]) -> None:
+        """Add DOCUMENT claims for each resolving value that is not already present."""
+        for value in values:
+            if not self._value_resolves(value):
+                continue
+            if self.document.metadata_fields.has_claim(self.key, value, MetadataSource.DOCUMENT):
+                continue
+            self.document.metadata_fields.add(
+                MetadataField(
+                    name=self.key,
+                    value=value,
+                    source=MetadataSource.DOCUMENT,
+                )
+            )
+
+    def materialise_body_claims(self) -> None:
+        """Yank body-derived values into DOCUMENT claims (in-memory, additive)."""
+        raise NotImplementedError(f"{type(self).__name__} does not implement materialise_body_claims")
 
 
 class SingleMetadata(Metadata, Generic[T]):

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -24,7 +24,7 @@ class Metadata(ABC):
     editable: ClassVar[bool] = False
     """Should editors be allowed to manually edit this metadata field?"""
 
-    LOGIC_VERSION: ClassVar[int] = 1
+    LOGIC_VERSION: ClassVar[int] = 2
     """Bump when this field's body-extraction / materialisation rules change."""
 
     def __init__(self, document: "Document") -> None:
@@ -34,24 +34,37 @@ class Metadata(ABC):
         return self.document.metadata_fields.resolve(self.key)
 
     @staticmethod
-    def _value_resolves(value: MetadataFieldValue) -> bool:
+    def _normalise_for_materialisation(value: MetadataFieldValue) -> MetadataFieldValue | None:
+        """Strip whitespace; return ``None`` when the value does not resolve."""
         if isinstance(value, str):
-            return bool(value)
+            cleaned = value.strip()
+            return cleaned or None
         if isinstance(value, MetadataCategoryValue):
-            return bool(value.name)
-        return False
+            cleaned_name = value.name.strip()
+            if not cleaned_name:
+                return None
+            parent = value.parent.strip() if value.parent else None
+            if parent == "":
+                parent = None
+            return MetadataCategoryValue(name=cleaned_name, parent=parent)
+        return None
+
+    @staticmethod
+    def _value_resolves(value: MetadataFieldValue) -> bool:
+        return Metadata._normalise_for_materialisation(value) is not None
 
     def _materialise_document_values(self, values: Iterable[MetadataFieldValue]) -> None:
         """Add DOCUMENT claims for each resolving value that is not already present."""
         for value in values:
-            if not self._value_resolves(value):
+            normalised = self._normalise_for_materialisation(value)
+            if normalised is None:
                 continue
-            if self.document.metadata_fields.has_claim(self.key, value, MetadataSource.DOCUMENT):
+            if self.document.metadata_fields.has_claim(self.key, normalised, MetadataSource.DOCUMENT):
                 continue
             self.document.metadata_fields.add(
                 MetadataField(
                     name=self.key,
-                    value=value,
+                    value=normalised,
                     source=MetadataSource.DOCUMENT,
                 )
             )

--- a/src/caselawclient/models/documents/metadata/fields/collection.py
+++ b/src/caselawclient/models/documents/metadata/fields/collection.py
@@ -3,7 +3,7 @@ from lxml import etree
 from caselawclient.models.documents.metadata.fields.exceptions import (
     MetadataFieldRemovalNotAllowedException,
 )
-from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
 from caselawclient.models.documents.metadata.fields.resolution import ResolvedMetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.types import SuccessFailureMessageTuple
@@ -18,6 +18,10 @@ class MetadataFieldsCollection(dict[str, MetadataField]):
 
     def by_name(self, name: str) -> list[MetadataField]:
         return [field for field in self.values() if field.name == name]
+
+    def has_claim(self, name: str, value: MetadataFieldValue, source: MetadataSource) -> bool:
+        """True if any claim (including rejected) matches name, value, and source."""
+        return any(field.value == value and field.source is source for field in self.by_name(name))
 
     def resolve(self, name: str) -> ResolvedMetadataField:
         return ResolvedMetadataField(name=name, claims=self.by_name(name))

--- a/src/caselawclient/models/documents/metadata/materialisation.py
+++ b/src/caselawclient/models/documents/metadata/materialisation.py
@@ -1,0 +1,51 @@
+"""Import-time metadata materialisation version derived from per-field LOGIC_VERSION."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
+from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
+from caselawclient.models.documents.metadata.types.court import CourtMetadata
+from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
+from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
+from caselawclient.models.documents.metadata.types.name import NameMetadata
+
+if TYPE_CHECKING:
+    from caselawclient.models.documents.metadata.base import Metadata
+
+METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
+    CaseNumberMetadata,
+    CategoriesMetadata,
+    CourtMetadata,
+    DateMetadata,
+    JudgesMetadata,
+    JurisdictionMetadata,
+    NameMetadata,
+)
+
+LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY = "latest_metadata_materialisation_version"
+
+
+def metadata_logic_versions() -> dict[str, int]:
+    """Return the shape descriptor ``{metadata_key: LOGIC_VERSION}`` (sorted keys)."""
+    return {cls.key: cls.LOGIC_VERSION for cls in sorted(METADATA_FIELD_CLASSES, key=lambda c: c.key)}
+
+
+def compute_metadata_materialisation_version(versions: dict[str, int] | None = None) -> str:
+    """Stable hash of the metadata shape (keys and logic versions, not claim values)."""
+    shape = versions if versions is not None else metadata_logic_versions()
+    payload = json.dumps(shape, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# Computed once at import — callers compare documents against this constant.
+CURRENT_METADATA_MATERIALISATION_VERSION = compute_metadata_materialisation_version()
+
+
+def document_needs_metadata_materialisation(stored_version: str | None) -> bool:
+    """True when a document has never been materialised, or was materialised under older rules."""
+    return not stored_version or stored_version != CURRENT_METADATA_MATERIALISATION_VERSION

--- a/src/caselawclient/models/documents/metadata/types/case_number.py
+++ b/src/caselawclient/models/documents/metadata/types/case_number.py
@@ -16,3 +16,9 @@ class CaseNumberMetadata(SingleMetadata[str | None]):
         if not isinstance(resolved.value, str):
             raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
         return resolved.value
+
+    def materialise_body_claims(self) -> None:
+        case_number = self.document.body.case_number
+        if case_number is None:
+            return
+        self._materialise_document_values([case_number])

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -34,6 +34,18 @@ def document_categories_from_field_values(values: list[MetadataFieldValue]) -> l
     return [categories[name] for name in top_level_order]
 
 
+def category_claim_values_from_document_categories(
+    categories: list[DocumentCategory],
+    parent: str | None = None,
+) -> list[MetadataCategoryValue]:
+    """Flatten a category tree into claim values suitable for DOCUMENT materialisation."""
+    values: list[MetadataCategoryValue] = []
+    for category in categories:
+        values.append(MetadataCategoryValue(name=category.name, parent=parent))
+        values.extend(category_claim_values_from_document_categories(category.subcategories, parent=category.name))
+    return values
+
+
 class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
     key = "categories"
     title = "Categories"
@@ -45,3 +57,6 @@ class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
         if not resolved.has_any_claims:
             return self.document.body.categories
         return document_categories_from_field_values(resolved.values)
+
+    def materialise_body_claims(self) -> None:
+        self._materialise_document_values(category_claim_values_from_document_categories(self.document.body.categories))

--- a/src/caselawclient/models/documents/metadata/types/court.py
+++ b/src/caselawclient/models/documents/metadata/types/court.py
@@ -16,3 +16,6 @@ class CourtMetadata(SingleMetadata[str]):
         if not isinstance(resolved.value, str):
             raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
         return resolved.value
+
+    def materialise_body_claims(self) -> None:
+        self._materialise_document_values([self.document.body.court])

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -44,5 +44,11 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
     def as_string(self) -> str:
         return date_as_string_from_value(self.value)
 
+    def materialise_body_claims(self) -> None:
+        document_date = self.document.body.document_date_as_date
+        if document_date is None:
+            return
+        self._materialise_document_values([document_date.isoformat()])
+
     def __str__(self) -> str:
         return self.as_string

--- a/src/caselawclient/models/documents/metadata/types/judges.py
+++ b/src/caselawclient/models/documents/metadata/types/judges.py
@@ -37,23 +37,12 @@ class JudgesMetadata(MultipleMetadata[str]):
         return judge_names_from_field_values(resolved.values)
 
     def materialise_body_claims(self) -> None:
-        """Yank body judge names into DOCUMENT claims when no claims exist yet.
+        """Yank body judge names into DOCUMENT claims (additive, idempotent).
 
-        After this, resolution is claim-based and soft-delete can suppress names
-        without the body fallback resurrecting them.
+        Existing DOCUMENT claims with the same value are left alone (including
+        rejected ones). EDITOR/EXTERNAL claims do not block materialisation.
         """
-        resolved = self._resolve_claims()
-        if resolved.has_any_claims:
-            return
-
-        for name in self.document.body.judges:
-            self.document.metadata_fields.add(
-                MetadataField(
-                    name=self.key,
-                    value=name,
-                    source=MetadataSource.DOCUMENT,
-                )
-            )
+        self._materialise_document_values(self.document.body.judges)
 
     def add_editor_judge(self, name: str) -> None:
         """Add an EDITOR claim for a judge name, yanking body first if needed."""

--- a/src/caselawclient/models/documents/metadata/types/jurisdiction.py
+++ b/src/caselawclient/models/documents/metadata/types/jurisdiction.py
@@ -16,3 +16,6 @@ class JurisdictionMetadata(SingleMetadata[str]):
         if not isinstance(resolved.value, str):
             raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
         return resolved.value
+
+    def materialise_body_claims(self) -> None:
+        self._materialise_document_values([self.document.body.jurisdiction])

--- a/src/caselawclient/models/documents/metadata/types/name.py
+++ b/src/caselawclient/models/documents/metadata/types/name.py
@@ -16,3 +16,6 @@ class NameMetadata(SingleMetadata[str]):
         if not isinstance(resolved.value, str):
             raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
         return resolved.value
+
+    def materialise_body_claims(self) -> None:
+        self._materialise_document_values([self.document.body.name])

--- a/tests/models/documents/metadata/test_judges_editing.py
+++ b/tests/models/documents/metadata/test_judges_editing.py
@@ -42,7 +42,7 @@ class TestJudgesMetadataEditing:
         assert all(claim.source is MetadataSource.DOCUMENT for claim in document.metadata_fields.by_name("judges"))
         assert judges.values == ["Judge A", "Judge B"]
 
-    def test_materialise_body_claims_is_noop_when_claims_exist(self, mock_api_client):
+    def test_materialise_body_claims_adds_alongside_existing_external(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Body Judge"))
         document.metadata_fields.add(
             MetadataField(
@@ -54,7 +54,11 @@ class TestJudgesMetadataEditing:
             )
         )
         document.metadata["judges"].materialise_body_claims()
-        assert [claim.value for claim in document.metadata_fields.by_name("judges")] == ["Claim Judge"]
+        claims = document.metadata_fields.by_name("judges")
+        assert {(claim.source, claim.value) for claim in claims} == {
+            (MetadataSource.EXTERNAL, "Claim Judge"),
+            (MetadataSource.DOCUMENT, "Body Judge"),
+        }
 
     def test_add_editor_judge_yanks_then_adds(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Body Judge"))

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -1,8 +1,11 @@
 from datetime import UTC, date, datetime
 from uuid import uuid4
 
+import pytest
+
 from caselawclient.factories import DocumentBodyFactory, DocumentFactory
-from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.base import Metadata
+from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -33,6 +36,14 @@ class TestMetadataMaterialisationVersion:
         assert document_needs_metadata_materialisation("") is True
         assert document_needs_metadata_materialisation("stale") is True
         assert document_needs_metadata_materialisation(CURRENT_METADATA_MATERIALISATION_VERSION) is False
+
+
+class TestValueResolves:
+    def test_empty_category_name_does_not_resolve(self):
+        assert Metadata._value_resolves(MetadataCategoryValue(name="")) is False  # noqa: SLF001
+
+    def test_unexpected_value_type_does_not_resolve(self):
+        assert Metadata._value_resolves(123) is False  # noqa: SLF001
 
 
 class TestMaterialiseBodyClaims:
@@ -94,6 +105,12 @@ class TestMaterialiseBodyClaims:
         assert document.metadata_fields.by_name("jurisdiction") == []
         assert document.metadata_fields.by_name("case_number") == []
 
+    def test_skips_none_case_number(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.body.__dict__["case_number"] = None
+        document.metadata["case_number"].materialise_body_claims()
+        assert document.metadata_fields.by_name("case_number") == []
+
     def test_date_materialises_isoformat(self, mock_api_client):
         document = DocumentFactory.build(
             api_client=mock_api_client,
@@ -106,6 +123,19 @@ class TestMaterialiseBodyClaims:
         assert claims[0].value == "2023-02-03"
         assert isinstance(claims[0].value, str)
         assert date.fromisoformat(claims[0].value) == date(2023, 2, 3)
+
+    def test_skips_missing_document_date(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(document_date_as_string=None),
+        )
+        document.metadata["date"].materialise_body_claims()
+        assert document.metadata_fields.by_name("date") == []
+
+    def test_base_materialise_body_claims_raises(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        with pytest.raises(NotImplementedError, match="does not implement materialise_body_claims"):
+            Metadata.materialise_body_claims(document.metadata["title"])
 
     def test_does_not_resurrect_rejected_document_claim(self, mock_api_client):
         document = DocumentFactory.build(
@@ -154,11 +184,15 @@ class TestMaterialiseBodyClaims:
         document = DocumentFactory.build(api_client=mock_api_client, body=categories_xml)
         document.metadata["categories"].materialise_body_claims()
 
-        values = {
-            (claim.value.name, claim.value.parent)  # type: ignore[union-attr]
-            for claim in document.metadata_fields.by_name("categories")
-        }
+        values = {(claim.value.name, claim.value.parent) for claim in document.metadata_fields.by_name("categories")}
         assert values == {("Parent", None), ("Child", "Parent")}
+
+    def test_empty_category_name_is_not_materialised(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata["categories"]._materialise_document_values(  # noqa: SLF001
+            [MetadataCategoryValue(name="", parent=None)]
+        )
+        assert document.metadata_fields.by_name("categories") == []
 
 
 class TestDocumentMaterialiseMetadataClaims:

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -1,0 +1,191 @@
+from datetime import UTC, date, datetime
+from uuid import uuid4
+
+from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.materialisation import (
+    CURRENT_METADATA_MATERIALISATION_VERSION,
+    LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+    compute_metadata_materialisation_version,
+    document_needs_metadata_materialisation,
+    metadata_logic_versions,
+)
+
+TIMESTAMP = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _id() -> str:
+    return str(uuid4())
+
+
+class TestMetadataMaterialisationVersion:
+    def test_current_version_matches_recomputed_hash(self):
+        assert compute_metadata_materialisation_version() == CURRENT_METADATA_MATERIALISATION_VERSION
+
+    def test_version_changes_when_logic_version_bumps(self):
+        bumped = metadata_logic_versions()
+        bumped["title"] = bumped["title"] + 1
+        assert compute_metadata_materialisation_version(bumped) != CURRENT_METADATA_MATERIALISATION_VERSION
+
+    def test_document_needs_materialisation_when_missing_or_stale(self):
+        assert document_needs_metadata_materialisation(None) is True
+        assert document_needs_metadata_materialisation("") is True
+        assert document_needs_metadata_materialisation("stale") is True
+        assert document_needs_metadata_materialisation(CURRENT_METADATA_MATERIALISATION_VERSION) is False
+
+
+class TestMaterialiseBodyClaims:
+    def test_title_materialises_document_claim(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Title"),
+        )
+        document.metadata["title"].materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("title")
+        assert len(claims) == 1
+        assert claims[0].value == "Body Title"
+        assert claims[0].source is MetadataSource.DOCUMENT
+
+    def test_materialise_is_idempotent_for_same_document_value(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Title"),
+        )
+        document.metadata["title"].materialise_body_claims()
+        first_id = document.metadata_fields.by_name("title")[0].id
+        document.metadata["title"].materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("title")
+        assert len(claims) == 1
+        assert claims[0].id == first_id
+
+    def test_editor_claim_does_not_block_document_materialisation(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Title"),
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="title",
+                value="Editor Title",
+                source=MetadataSource.EDITOR,
+                id=_id(),
+                timestamp=TIMESTAMP,
+            )
+        )
+        document.metadata["title"].materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("title")
+        assert {(c.source, c.value) for c in claims} == {
+            (MetadataSource.EDITOR, "Editor Title"),
+            (MetadataSource.DOCUMENT, "Body Title"),
+        }
+
+    def test_skips_empty_body_values(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(jurisdiction="", case_number=""),
+        )
+        document.metadata["jurisdiction"].materialise_body_claims()
+        document.metadata["case_number"].materialise_body_claims()
+
+        assert document.metadata_fields.by_name("jurisdiction") == []
+        assert document.metadata_fields.by_name("case_number") == []
+
+    def test_date_materialises_isoformat(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(document_date_as_string="2023-02-03"),
+        )
+        document.metadata["date"].materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("date")
+        assert len(claims) == 1
+        assert claims[0].value == "2023-02-03"
+        assert isinstance(claims[0].value, str)
+        assert date.fromisoformat(claims[0].value) == date(2023, 2, 3)
+
+    def test_does_not_resurrect_rejected_document_claim(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Body Title"),
+        )
+        rejected = MetadataField(
+            name="title",
+            value="Body Title",
+            source=MetadataSource.DOCUMENT,
+            id=_id(),
+            timestamp=TIMESTAMP,
+            rejected=True,
+        )
+        document.metadata_fields.add(rejected)
+        document.metadata["title"].materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("title")
+        assert len(claims) == 1
+        assert claims[0].id == rejected.id
+        assert claims[0].rejected is True
+
+    def test_categories_materialise_flat_claim_values(self, mock_api_client):
+        categories_xml = DocumentBodyFactory.build(
+            """
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                        xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <identification><FRBRWork>
+                            <FRBRname value="Name"/>
+                            <FRBRdate date="2023-02-03"/>
+                        </FRBRWork></identification>
+                        <proprietary>
+                            <uk:court>Court</uk:court>
+                            <uk:category>Parent</uk:category>
+                            <uk:category parent="Parent">Child</uk:category>
+                        </proprietary>
+                    </meta>
+                    <header><p/></header>
+                    <judgmentBody><decision><p/></decision></judgmentBody>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=categories_xml)
+        document.metadata["categories"].materialise_body_claims()
+
+        values = {
+            (claim.value.name, claim.value.parent)  # type: ignore[union-attr]
+            for claim in document.metadata_fields.by_name("categories")
+        }
+        assert values == {("Parent", None), ("Child", "Parent")}
+
+
+class TestDocumentMaterialiseMetadataClaims:
+    def test_materialise_persists_fields_and_version(self, mock_api_client):
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="Saved Title", court="Saved Court"),
+        )
+
+        document.materialise_metadata_claims()
+
+        mock_api_client.set_property_as_node.assert_called_once()
+        uri, property_name, _tree = mock_api_client.set_property_as_node.call_args.args
+        assert uri == document.uri
+        assert property_name == "metadata_fields"
+        mock_api_client.set_property.assert_any_call(
+            document.uri,
+            LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+            CURRENT_METADATA_MATERIALISATION_VERSION,
+        )
+        assert document.metadata_fields.resolve("title").value == "Saved Title"
+        assert document.metadata_fields.resolve("court").value == "Saved Court"
+
+    def test_needs_metadata_materialisation(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        mock_api_client.get_property.return_value = ""
+        assert document.needs_metadata_materialisation is True
+
+        mock_api_client.get_property.return_value = CURRENT_METADATA_MATERIALISATION_VERSION
+        assert document.needs_metadata_materialisation is False

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -42,8 +42,11 @@ class TestValueResolves:
     def test_empty_category_name_does_not_resolve(self):
         assert Metadata._value_resolves(MetadataCategoryValue(name="")) is False  # noqa: SLF001
 
+    def test_whitespace_only_string_does_not_resolve(self):
+        assert Metadata._value_resolves("   ") is False  # noqa: SLF001
+
     def test_unexpected_value_type_does_not_resolve(self):
-        assert Metadata._value_resolves(123) is False  # noqa: SLF001
+        assert Metadata._value_resolves(123) is False  # type: ignore[arg-type]  # noqa: SLF001
 
 
 class TestMaterialiseBodyClaims:
@@ -104,6 +107,19 @@ class TestMaterialiseBodyClaims:
 
         assert document.metadata_fields.by_name("jurisdiction") == []
         assert document.metadata_fields.by_name("case_number") == []
+
+    def test_strips_whitespace_when_materialising(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata["title"]._materialise_document_values(["  Body Title  "])  # noqa: SLF001
+
+        claims = document.metadata_fields.by_name("title")
+        assert len(claims) == 1
+        assert claims[0].value == "Body Title"
+
+    def test_skips_whitespace_only_string(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata["title"]._materialise_document_values(["   "])  # noqa: SLF001
+        assert document.metadata_fields.by_name("title") == []
 
     def test_skips_none_case_number(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -184,7 +200,10 @@ class TestMaterialiseBodyClaims:
         document = DocumentFactory.build(api_client=mock_api_client, body=categories_xml)
         document.metadata["categories"].materialise_body_claims()
 
-        values = {(claim.value.name, claim.value.parent) for claim in document.metadata_fields.by_name("categories")}
+        values = {
+            (claim.value.name, claim.value.parent)  # type: ignore[union-attr]
+            for claim in document.metadata_fields.by_name("categories")
+        }
         assert values == {("Parent", None), ("Child", "Parent")}
 
     def test_empty_category_name_is_not_materialised(self, mock_api_client):

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -4,6 +4,10 @@ from unittest.mock import patch
 
 from caselawclient.factories import DocumentFactory
 from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.metadata.materialisation import (
+    CURRENT_METADATA_MATERIALISATION_VERSION,
+    LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+)
 from caselawclient.models.documents.versions import VersionAnnotation, VersionType
 
 
@@ -15,17 +19,24 @@ class TestDocumentSave:
         uri = DocumentURIString("test/2023/101")
         document = DocumentFactory.build(uri=uri)
 
-        with patch.object(document.api_client, "update_document_xml") as mock_update:
+        with (
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document, "materialise_metadata_claims") as mock_materialise,
+        ):
             document.save(message="Changed document")
 
             mock_update.assert_called_once()
+            mock_materialise.assert_called_once()
 
     def test_save_creates_edit_annotation(self):
         """Test that save() creates an EDIT annotation with automated=False."""
         uri = DocumentURIString("test/2023/123")
         document = DocumentFactory.build(uri=uri)
 
-        with patch.object(document.api_client, "update_document_xml") as mock_update:
+        with (
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document, "materialise_metadata_claims"),
+        ):
             document.save(message="Changed document")
 
             # Verify the annotation was created correctly
@@ -41,7 +52,10 @@ class TestDocumentSave:
         document = DocumentFactory.build(uri=uri)
         expected_xml = document.body.content_as_xml_tree
 
-        with patch.object(document.api_client, "update_document_xml") as mock_update:
+        with (
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document, "materialise_metadata_claims"),
+        ):
             document.save(message="Changed document")
 
             # Verify the correct URI and XML are passed
@@ -55,9 +69,44 @@ class TestDocumentSave:
         document = DocumentFactory.build(uri=uri)
         test_message = "Fixed typo in court name"
 
-        with patch.object(document.api_client, "update_document_xml") as mock_update:
+        with (
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document, "materialise_metadata_claims"),
+        ):
             document.save(message=test_message)
 
             call_args = mock_update.call_args
             annotation = call_args[0][2]
             assert annotation.message == test_message
+
+    def test_save_calls_materialise_after_xml_update(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        call_order: list[str] = []
+
+        def track_xml(*_args, **_kwargs):
+            call_order.append("xml")
+
+        def track_materialise():
+            call_order.append("materialise")
+
+        with (
+            patch.object(document.api_client, "update_document_xml", side_effect=track_xml),
+            patch.object(document, "materialise_metadata_claims", side_effect=track_materialise) as mock_materialise,
+        ):
+            document.save(message="Changed document")
+
+        assert call_order == ["xml", "materialise"]
+        mock_materialise.assert_called_once()
+
+    def test_save_materialise_persists_version(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        with patch.object(document.api_client, "update_document_xml"):
+            document.save(message="Changed document")
+
+        mock_api_client.set_property_as_node.assert_called()
+        mock_api_client.set_property.assert_any_call(
+            document.uri,
+            LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
+            CURRENT_METADATA_MATERIALISATION_VERSION,
+        )


### PR DESCRIPTION
- Add idempotent materialisation of body-derived DOCUMENT metadata claims for all metadata fields
- Hash `LOGIC_VERSION` into `CURRENT_METADATA_MATERIALISATION_VERSION`, stored on documents as `latest_metadata_materialisation_version` to allow finding documents which don't have latest materialisation during maintenance
- `Document.materialise_metadata_claims()` stores claims and version, `Document.save()` runs it after saving XML.

MarkLogic change to add index: [range index on `latest_metadata_materialisation_version` (same branch name in `ds-caselaw-marklogic`).](https://github.com/nationalarchives/ds-caselaw-marklogic/pull/678)

## Jira
FCLC-2260