### PR TITLE
FCLC-2356: Expose DocumentMetadata as typed attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### BREAKING CHANGE
+
+- Use document.metadata.title / .judges (etc), not
+  metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
+  values/in. Legacy name/judge keys are gone.
+
+### Feat
+
+- **Metadata**: expose DocumentMetadata as typed attribute facades
+
 ## v49.1.1 (2026-08-13)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## Unreleased
 
+### BREAKING CHANGE
+
+- Use document.metadata.title / .judges (etc), not
+  metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
+  values/in. Legacy name/judge keys are gone.
+
+### Feat
+
+- **Metadata**: expose DocumentMetadata as typed attribute facades
+
 ### Fix
 
 - Wrap query text with multiple words in a single <mark> tag, rather than each individual text in it's own mark tag

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -176,7 +176,7 @@ class Document:
         self._initialise_metadata()
 
     def __repr__(self) -> str:
-        name = self.metadata["title"].value or "un-named"
+        name = self.metadata.title.value or "un-named"
         return f"<{self.document_noun} {self.uri}: {name}>"
 
     def document_exists(self) -> bool:
@@ -367,12 +367,12 @@ class Document:
 
     @cached_property
     def has_name(self) -> bool:
-        return bool(self.metadata["title"].value)
+        return bool(self.metadata.title.value)
 
     @cached_property
     def has_valid_court(self) -> bool:
-        court = self.metadata["court"].value
-        jurisdiction = self.metadata["jurisdiction"].value
+        court = self.metadata.court.value
+        jurisdiction = self.metadata.jurisdiction.value
         court_code = CourtCode(f"{court}/{jurisdiction}") if jurisdiction != "" else CourtCode(court)
         try:
             return bool(courts.get_by_code(court_code))
@@ -627,7 +627,7 @@ class Document:
         Idempotent: existing DOCUMENT claims with the same value are not overwritten.
         Safe to call from maintenance backfills as well as from ``save()``.
         """
-        for field in self.metadata.values():
+        for field in self.metadata:
             field.materialise_body_claims()
         self.save_metadata_fields()
         self.api_client.set_property(
@@ -908,8 +908,8 @@ class Document:
         self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
 
         checked_date: str | None = (
-            self.metadata["date"].value.isoformat()
-            if self.metadata["date"].value and self.metadata["date"].value > datetime.date(1001, 1, 1)
+            self.metadata.date.value.isoformat()
+            if self.metadata.date.value and self.metadata.date.value > datetime.date(1001, 1, 1)
             else None
         )
 
@@ -919,9 +919,9 @@ class Document:
 
         parser_instructions: ParserInstructionsDict = {
             "metadata": {
-                "name": self.metadata["title"].value or None,
+                "name": self.metadata.title.value or None,
                 "cite": None,
-                "court": self.metadata["court"].value or None,
+                "court": self.metadata.court.value or None,
                 "date": checked_date,
                 "uri": self.uri,
             }
@@ -1007,7 +1007,7 @@ class Document:
                 f"{name} no longer exists on Document, using Document.metadata instead",
                 DeprecationWarning,
             )
-            return getattr(self.metadata[metadata_key], attribute)
+            return getattr(getattr(self.metadata, metadata_key), attribute)
 
         warnings.warn(f"{name} no longer exists on Document, using Document.body instead", DeprecationWarning)
         try:

--- a/src/caselawclient/models/documents/comparison.py
+++ b/src/caselawclient/models/documents/comparison.py
@@ -19,22 +19,22 @@ class Comparison(dict[str, AttributeComparison]):
         # court, date, title
         self["court"] = AttributeComparison(
             label="court",
-            this_value=this_doc.metadata["court"].value,
-            that_value=that_doc.metadata["court"].value,
-            match=this_doc.metadata["court"].value == that_doc.metadata["court"].value,
+            this_value=this_doc.metadata.court.value,
+            that_value=that_doc.metadata.court.value,
+            match=this_doc.metadata.court.value == that_doc.metadata.court.value,
         )
 
         self["date"] = AttributeComparison(
             label="date",
-            this_value=this_doc.metadata["date"].as_string,
-            that_value=that_doc.metadata["date"].as_string,
-            match=this_doc.metadata["date"].as_string == that_doc.metadata["date"].as_string,
+            this_value=this_doc.metadata.date.as_string,
+            that_value=that_doc.metadata.date.as_string,
+            match=this_doc.metadata.date.as_string == that_doc.metadata.date.as_string,
         )
         self["name"] = AttributeComparison(
             label="name",
-            this_value=this_doc.metadata["title"].value,
-            that_value=that_doc.metadata["title"].value,
-            match=this_doc.metadata["title"].value == that_doc.metadata["title"].value,
+            this_value=this_doc.metadata.title.value,
+            that_value=that_doc.metadata.title.value,
+            match=this_doc.metadata.title.value == that_doc.metadata.title.value,
         )
 
     def match(self) -> bool:

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING, Literal, TypedDict, overload
+from collections.abc import Iterator
+from dataclasses import dataclass, fields
+from typing import Literal
 
+from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -11,18 +13,17 @@ from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 
-if TYPE_CHECKING:
-    from caselawclient.models.documents.metadata.base import Metadata
-
 MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "categories", "judges"]
 
-METADATA_KEY_ALIASES: dict[str, MetadataAttributeKey] = {
-    "name": "title",
-    "judge": "judges",
-}
 
+@dataclass(slots=True)
+class DocumentMetadata:
+    """Typed facades for document metadata, accessed as attributes.
 
-class DocumentMetadataRegistry(TypedDict):
+    Example: ``document.metadata.date``, ``document.metadata.judges``.
+    Not a mapping — iterate the instance to walk all facades.
+    """
+
     title: NameMetadata
     court: CourtMetadata
     jurisdiction: JurisdictionMetadata
@@ -31,59 +32,15 @@ class DocumentMetadataRegistry(TypedDict):
     categories: CategoriesMetadata
     judges: JudgesMetadata
 
+    def __iter__(self) -> Iterator[Metadata]:
+        for field in fields(self):
+            yield getattr(self, field.name)
 
-class DocumentMetadata(dict[str, "Metadata"]):
-    """Document metadata keyed by schema-aligned claim names.
+    def __len__(self) -> int:
+        return len(fields(self))
 
-    Legacy facade keys ``name`` and ``judge`` are proxied to ``title`` and
-    ``judges`` respectively.
-    """
-
-    def _canonical_key(self, key: str) -> str:
-        if key in METADATA_KEY_ALIASES:
-            canonical = METADATA_KEY_ALIASES[key]
-            warnings.warn(
-                f'metadata["{key}"] is deprecated; use metadata["{canonical}"]',
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            return canonical
-        return key
-
-    @overload
-    def __getitem__(self, key: Literal["title", "name"]) -> NameMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["court"]) -> CourtMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["jurisdiction"]) -> JurisdictionMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["date"]) -> DateMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["case_number"]) -> CaseNumberMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["categories"]) -> CategoriesMetadata: ...
-
-    @overload
-    def __getitem__(self, key: Literal["judges", "judge"]) -> JudgesMetadata: ...
-
-    @overload
-    def __getitem__(self, key: str) -> Metadata: ...
-
-    def __getitem__(self, key: str) -> Metadata:
-        return super().__getitem__(self._canonical_key(key))
-
-    def get(self, key: str, default: Metadata | None = None) -> Metadata | None:  # type: ignore[override]
-        try:
-            return self[key]
-        except KeyError:
-            return default
-
-    def __contains__(self, key: object) -> bool:
-        if not isinstance(key, str):
-            return False
-        return super().__contains__(METADATA_KEY_ALIASES.get(key, key))
+    def __contains__(self, item: object) -> bool:
+        raise TypeError(
+            "DocumentMetadata does not support membership tests; access facades as attributes "
+            "(e.g. document.metadata.title)"
+        )

--- a/tests/models/documents/metadata/test_judges_editing.py
+++ b/tests/models/documents/metadata/test_judges_editing.py
@@ -31,7 +31,7 @@ class TestJudgesMetadataEditing:
             api_client=mock_api_client,
             body=_body_with_judges("Judge A", "Judge B"),
         )
-        judges = document.metadata["judges"]
+        judges = document.metadata.judges
 
         judges.materialise_body_claims()
 
@@ -53,7 +53,7 @@ class TestJudgesMetadataEditing:
                 timestamp=TIMESTAMP,
             )
         )
-        document.metadata["judges"].materialise_body_claims()
+        document.metadata.judges.materialise_body_claims()
         claims = document.metadata_fields.by_name("judges")
         assert {(claim.source, claim.value) for claim in claims} == {
             (MetadataSource.EXTERNAL, "Claim Judge"),
@@ -62,7 +62,7 @@ class TestJudgesMetadataEditing:
 
     def test_add_editor_judge_yanks_then_adds(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Body Judge"))
-        document.metadata["judges"].add_editor_judge("Editor Judge")
+        document.metadata.judges.add_editor_judge("Editor Judge")
 
         claims = document.metadata_fields.by_name("judges")
         assert len(claims) == 2
@@ -70,11 +70,11 @@ class TestJudgesMetadataEditing:
         assert claims[0].value == "Body Judge"
         assert claims[1].source is MetadataSource.EDITOR
         assert claims[1].value == "Editor Judge"
-        assert document.metadata["judges"].values == ["Body Judge", "Editor Judge"]
+        assert document.metadata.judges.values == ["Body Judge", "Editor Judge"]
 
     def test_suppress_document_claim_rejects(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A", "Judge B"))
-        judges = document.metadata["judges"]
+        judges = document.metadata.judges
         judges.materialise_body_claims()
         claim_a = next(claim for claim in document.metadata_fields.by_name("judges") if claim.value == "Judge A")
 
@@ -97,12 +97,12 @@ class TestJudgesMetadataEditing:
             )
         )
         claim_id = next(iter(document.metadata_fields.by_name("judges"))).id
-        document.metadata["judges"].suppress_claim(claim_id)
+        document.metadata.judges.suppress_claim(claim_id)
         assert document.metadata_fields.by_name("judges") == []
 
     def test_restore_rejected_document_claim(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A"))
-        judges = document.metadata["judges"]
+        judges = document.metadata.judges
         judges.materialise_body_claims()
         claim = document.metadata_fields.by_name("judges")[0]
         judges.suppress_claim(claim.id)

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -55,7 +55,7 @@ class TestMaterialiseBodyClaims:
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(name="Body Title"),
         )
-        document.metadata["title"].materialise_body_claims()
+        document.metadata.title.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
@@ -67,9 +67,9 @@ class TestMaterialiseBodyClaims:
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(name="Body Title"),
         )
-        document.metadata["title"].materialise_body_claims()
+        document.metadata.title.materialise_body_claims()
         first_id = document.metadata_fields.by_name("title")[0].id
-        document.metadata["title"].materialise_body_claims()
+        document.metadata.title.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
@@ -89,7 +89,7 @@ class TestMaterialiseBodyClaims:
                 timestamp=TIMESTAMP,
             )
         )
-        document.metadata["title"].materialise_body_claims()
+        document.metadata.title.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("title")
         assert {(c.source, c.value) for c in claims} == {
@@ -102,15 +102,15 @@ class TestMaterialiseBodyClaims:
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(jurisdiction="", case_number=""),
         )
-        document.metadata["jurisdiction"].materialise_body_claims()
-        document.metadata["case_number"].materialise_body_claims()
+        document.metadata.jurisdiction.materialise_body_claims()
+        document.metadata.case_number.materialise_body_claims()
 
         assert document.metadata_fields.by_name("jurisdiction") == []
         assert document.metadata_fields.by_name("case_number") == []
 
     def test_strips_whitespace_when_materialising(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata["title"]._materialise_document_values(["  Body Title  "])  # noqa: SLF001
+        document.metadata.title._materialise_document_values(["  Body Title  "])  # noqa: SLF001
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
@@ -118,13 +118,13 @@ class TestMaterialiseBodyClaims:
 
     def test_skips_whitespace_only_string(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata["title"]._materialise_document_values(["   "])  # noqa: SLF001
+        document.metadata.title._materialise_document_values(["   "])  # noqa: SLF001
         assert document.metadata_fields.by_name("title") == []
 
     def test_skips_none_case_number(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         document.body.__dict__["case_number"] = None
-        document.metadata["case_number"].materialise_body_claims()
+        document.metadata.case_number.materialise_body_claims()
         assert document.metadata_fields.by_name("case_number") == []
 
     def test_date_materialises_isoformat(self, mock_api_client):
@@ -132,7 +132,7 @@ class TestMaterialiseBodyClaims:
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(document_date_as_string="2023-02-03"),
         )
-        document.metadata["date"].materialise_body_claims()
+        document.metadata.date.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("date")
         assert len(claims) == 1
@@ -145,13 +145,13 @@ class TestMaterialiseBodyClaims:
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(document_date_as_string=None),
         )
-        document.metadata["date"].materialise_body_claims()
+        document.metadata.date.materialise_body_claims()
         assert document.metadata_fields.by_name("date") == []
 
     def test_base_materialise_body_claims_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         with pytest.raises(NotImplementedError, match="does not implement materialise_body_claims"):
-            Metadata.materialise_body_claims(document.metadata["title"])
+            Metadata.materialise_body_claims(document.metadata.title)
 
     def test_does_not_resurrect_rejected_document_claim(self, mock_api_client):
         document = DocumentFactory.build(
@@ -167,7 +167,7 @@ class TestMaterialiseBodyClaims:
             rejected=True,
         )
         document.metadata_fields.add(rejected)
-        document.metadata["title"].materialise_body_claims()
+        document.metadata.title.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
@@ -198,7 +198,7 @@ class TestMaterialiseBodyClaims:
             """
         )
         document = DocumentFactory.build(api_client=mock_api_client, body=categories_xml)
-        document.metadata["categories"].materialise_body_claims()
+        document.metadata.categories.materialise_body_claims()
 
         values = {
             (claim.value.name, claim.value.parent)  # type: ignore[union-attr]
@@ -208,7 +208,7 @@ class TestMaterialiseBodyClaims:
 
     def test_empty_category_name_is_not_materialised(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata["categories"]._materialise_document_values(  # noqa: SLF001
+        document.metadata.categories._materialise_document_values(  # noqa: SLF001
             [MetadataCategoryValue(name="", parent=None)]
         )
         assert document.metadata_fields.by_name("categories") == []

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -28,11 +28,11 @@ class _TestMultipleMetadata(MultipleMetadata[str]):
 class TestMetadataBase:
     def test_single_metadata_cannot_be_instantiated_directly(self):
         with pytest.raises(TypeError):
-            SingleMetadata(Mock())  # type: ignore[abstract]
+            SingleMetadata(Mock())  # type: ignore[abstract, unused-ignore]
 
     def test_multiple_metadata_cannot_be_instantiated_directly(self):
         with pytest.raises(TypeError):
-            MultipleMetadata(Mock())  # type: ignore[abstract]
+            MultipleMetadata(Mock())  # type: ignore[abstract, unused-ignore]
 
     def test_concrete_single_metadata_exposes_key_title_description_and_value(self):
         metadata = _TestSingleMetadata(Mock())
@@ -80,7 +80,7 @@ class TestNameMetadata:
 
         assert metadata.value == "Custom Case Name"
         assert document.body.name == metadata.value
-        title_from_registry = document.metadata["title"]
+        title_from_registry = document.metadata.title
         assert isinstance(title_from_registry, NameMetadata)
         assert title_from_registry.value == metadata.value
 
@@ -208,50 +208,13 @@ class TestJudgesMetadata:
         )
         document = DocumentFactory.build(api_client=mock_api_client, body=body)
         assert JudgesMetadata(document).values == ["Judge A", "Judge B"]
-        assert document.metadata["judges"].values == document.body.judges
+        assert document.metadata.judges.values == document.body.judges
 
 
 class TestDocumentMetadata:
-    def test_factory_built_document_metadata_reads_from_xml(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.court import CourtMetadata
-        from caselawclient.models.documents.metadata.types.name import NameMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        title_metadata = document.metadata["title"]
-        court_metadata = document.metadata["court"]
-        assert isinstance(title_metadata, NameMetadata)
-        assert isinstance(court_metadata, CourtMetadata)
-        assert title_metadata.value == "Judgment v Judgement"
-        assert court_metadata.value == "Court of Testing"
-
-    def test_metadata_is_dict_keyed_by_metadata_type(self, mock_api_client):
+    def test_factory_built_document_metadata_exposes_typed_facades(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.registry import DocumentMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert isinstance(document.metadata, DocumentMetadata)
-        assert document.metadata
-
-    def test_metadata_keys_match_registered_types(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert set(document.metadata.keys()) == {
-            "title",
-            "court",
-            "jurisdiction",
-            "date",
-            "case_number",
-            "categories",
-            "judges",
-        }
-
-    def test_metadata_entries_are_expected_types(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
         from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -262,64 +225,39 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata["title"], NameMetadata)
-        assert isinstance(document.metadata["court"], CourtMetadata)
-        assert isinstance(document.metadata["jurisdiction"], JurisdictionMetadata)
-        assert isinstance(document.metadata["date"], DateMetadata)
-        assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
-        assert isinstance(document.metadata["categories"], CategoriesMetadata)
-        assert isinstance(document.metadata["judges"], JudgesMetadata)
+        assert isinstance(document.metadata, DocumentMetadata)
+        assert isinstance(document.metadata.title, NameMetadata)
+        assert isinstance(document.metadata.court, CourtMetadata)
+        assert isinstance(document.metadata.jurisdiction, JurisdictionMetadata)
+        assert isinstance(document.metadata.date, DateMetadata)
+        assert isinstance(document.metadata.case_number, CaseNumberMetadata)
+        assert isinstance(document.metadata.categories, CategoriesMetadata)
+        assert isinstance(document.metadata.judges, JudgesMetadata)
+        assert document.metadata.title.value == "Judgment v Judgement"
+        assert document.metadata.court.value == "Court of Testing"
 
-    def test_legacy_name_key_proxies_to_title(self, mock_api_client):
+    def test_metadata_rejects_mapping_apis(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
-            assert document.metadata["name"] is document.metadata["title"]
-        assert "name" in document.metadata
-        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
-            assert document.metadata.get("name") is document.metadata["title"]
+        with pytest.raises(TypeError):
+            document.metadata["title"]  # type: ignore[index, unused-ignore]
+        with pytest.raises(TypeError, match="does not support membership tests"):
+            _ = "title" in document.metadata
+        assert not hasattr(document.metadata, "get")
+        assert not hasattr(document.metadata, "keys")
+        assert not hasattr(document.metadata, "values")
 
-    def test_legacy_judge_key_proxies_to_judges(self, mock_api_client):
+    def test_metadata_iterates_registered_facades(self, mock_api_client):
+        from dataclasses import fields
+
         from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.base import Metadata
+        from caselawclient.models.documents.metadata.registry import DocumentMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
-            assert document.metadata["judge"] is document.metadata["judges"]
-        assert "judge" in document.metadata
-        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
-            assert document.metadata.get("judge") is document.metadata["judges"]
-
-    def test_metadata_name_value_matches_document_body(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.name import NameMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-        title_metadata = document.metadata["title"]
-        assert isinstance(title_metadata, NameMetadata)
-        assert title_metadata.value == document.body.name
-
-    def test_metadata_categories_values_match_document_body(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-        category_metadata = document.metadata["categories"]
-        assert isinstance(category_metadata, CategoriesMetadata)
-        assert category_metadata.values == document.body.categories
-
-    def test_metadata_get_returns_none_for_unknown_key(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert document.metadata.get("nonexistent") is None
-
-    def test_metadata_values_yields_all_registered_instances(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert len(list(document.metadata.values())) == 7
+        facades = list(document.metadata)
+        assert all(isinstance(facade, Metadata) for facade in facades)
+        assert facades == [getattr(document.metadata, field.name) for field in fields(DocumentMetadata)]

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -80,7 +80,7 @@ class TestNameMetadata:
 
         assert metadata.value == "Custom Case Name"
         assert document.body.name == metadata.value
-        title_from_registry = document.metadata["title"]
+        title_from_registry = document.metadata.title
         assert isinstance(title_from_registry, NameMetadata)
         assert title_from_registry.value == metadata.value
 
@@ -208,50 +208,13 @@ class TestJudgesMetadata:
         )
         document = DocumentFactory.build(api_client=mock_api_client, body=body)
         assert JudgesMetadata(document).values == ["Judge A", "Judge B"]
-        assert document.metadata["judges"].values == document.body.judges
+        assert document.metadata.judges.values == document.body.judges
 
 
 class TestDocumentMetadata:
-    def test_factory_built_document_metadata_reads_from_xml(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.court import CourtMetadata
-        from caselawclient.models.documents.metadata.types.name import NameMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        title_metadata = document.metadata["title"]
-        court_metadata = document.metadata["court"]
-        assert isinstance(title_metadata, NameMetadata)
-        assert isinstance(court_metadata, CourtMetadata)
-        assert title_metadata.value == "Judgment v Judgement"
-        assert court_metadata.value == "Court of Testing"
-
-    def test_metadata_is_dict_keyed_by_metadata_type(self, mock_api_client):
+    def test_factory_built_document_metadata_exposes_typed_facades(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.registry import DocumentMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert isinstance(document.metadata, DocumentMetadata)
-        assert document.metadata
-
-    def test_metadata_keys_match_registered_types(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert set(document.metadata.keys()) == {
-            "title",
-            "court",
-            "jurisdiction",
-            "date",
-            "case_number",
-            "categories",
-            "judges",
-        }
-
-    def test_metadata_entries_are_expected_types(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
         from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
         from caselawclient.models.documents.metadata.types.court import CourtMetadata
@@ -262,64 +225,36 @@ class TestDocumentMetadata:
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert isinstance(document.metadata["title"], NameMetadata)
-        assert isinstance(document.metadata["court"], CourtMetadata)
-        assert isinstance(document.metadata["jurisdiction"], JurisdictionMetadata)
-        assert isinstance(document.metadata["date"], DateMetadata)
-        assert isinstance(document.metadata["case_number"], CaseNumberMetadata)
-        assert isinstance(document.metadata["categories"], CategoriesMetadata)
-        assert isinstance(document.metadata["judges"], JudgesMetadata)
+        assert isinstance(document.metadata, DocumentMetadata)
+        assert isinstance(document.metadata.title, NameMetadata)
+        assert isinstance(document.metadata.court, CourtMetadata)
+        assert isinstance(document.metadata.jurisdiction, JurisdictionMetadata)
+        assert isinstance(document.metadata.date, DateMetadata)
+        assert isinstance(document.metadata.case_number, CaseNumberMetadata)
+        assert isinstance(document.metadata.categories, CategoriesMetadata)
+        assert isinstance(document.metadata.judges, JudgesMetadata)
+        assert document.metadata.title.value == "Judgment v Judgement"
+        assert document.metadata.court.value == "Court of Testing"
 
-    def test_legacy_name_key_proxies_to_title(self, mock_api_client):
+    def test_metadata_rejects_mapping_apis(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
-            assert document.metadata["name"] is document.metadata["title"]
-        assert "name" in document.metadata
-        with pytest.warns(DeprecationWarning, match=r'metadata\["name"\] is deprecated'):
-            assert document.metadata.get("name") is document.metadata["title"]
+        with pytest.raises(TypeError):
+            document.metadata["title"]  # type: ignore[index]
+        with pytest.raises(TypeError, match="does not support membership tests"):
+            _ = "title" in document.metadata
 
-    def test_legacy_judge_key_proxies_to_judges(self, mock_api_client):
+    def test_metadata_iterates_registered_facades(self, mock_api_client):
+        from dataclasses import fields
+
         from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.base import Metadata
+        from caselawclient.models.documents.metadata.registry import DocumentMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
-            assert document.metadata["judge"] is document.metadata["judges"]
-        assert "judge" in document.metadata
-        with pytest.warns(DeprecationWarning, match=r'metadata\["judge"\] is deprecated'):
-            assert document.metadata.get("judge") is document.metadata["judges"]
-
-    def test_metadata_name_value_matches_document_body(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.name import NameMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-        title_metadata = document.metadata["title"]
-        assert isinstance(title_metadata, NameMetadata)
-        assert title_metadata.value == document.body.name
-
-    def test_metadata_categories_values_match_document_body(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-        from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-        category_metadata = document.metadata["categories"]
-        assert isinstance(category_metadata, CategoriesMetadata)
-        assert category_metadata.values == document.body.categories
-
-    def test_metadata_get_returns_none_for_unknown_key(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert document.metadata.get("nonexistent") is None
-
-    def test_metadata_values_yields_all_registered_instances(self, mock_api_client):
-        from caselawclient.factories import DocumentFactory
-
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert len(list(document.metadata.values())) == 7
+        facades = list(document.metadata)
+        assert all(isinstance(facade, Metadata) for facade in facades)
+        assert facades == [getattr(document.metadata, field.name) for field in fields(DocumentMetadata)]

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -111,7 +111,7 @@ class TestDocumentMetadataFacadePrefersFields:
             body=DocumentBodyFactory.build(name="Body Name"),
         )
 
-        assert document.metadata["title"].value == "Body Name"
+        assert document.metadata.title.value == "Body Name"
 
     def test_name_prefers_metadata_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -130,7 +130,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["title"].value == "Fields Name"
+        assert document.metadata.title.value == "Fields Name"
 
     def test_name_suppressed_only_is_empty(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -150,7 +150,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["title"].value == ""
+        assert document.metadata.title.value == ""
 
     def test_categories_prefers_all_non_suppressed_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -188,7 +188,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert [category.name for category in document.metadata["categories"].values] == [
+        assert [category.name for category in document.metadata.categories.values] == [
             "From document",
             "From external",
         ]
@@ -214,7 +214,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        categories = document.metadata["categories"].values
+        categories = document.metadata.categories.values
         assert len(categories) == 1
         assert categories[0].name == "Shared"
 
@@ -239,7 +239,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        categories = document.metadata["categories"].values
+        categories = document.metadata.categories.values
         assert len(categories) == 1
         assert categories[0].name == "Parent"
         assert [child.name for child in categories[0].subcategories] == ["Child"]
@@ -256,7 +256,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["date"].as_string == "2024-06-15"
+        assert document.metadata.date.as_string == "2024-06-15"
 
     def test_date_suppressed_only_is_none(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -271,8 +271,8 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["date"].value is None
-        assert document.metadata["date"].as_string == ""
+        assert document.metadata.date.value is None
+        assert document.metadata.date.as_string == ""
 
     def test_date_unparsable_field_value_is_none(self, mock_api_client):
         from caselawclient.models.documents.body import UnparsableDate
@@ -289,7 +289,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
 
         with pytest.warns(UnparsableDate, match="Unparsable date"):
-            assert document.metadata["date"].value is None
+            assert document.metadata.date.value is None
 
     def test_date_empty_string_field_value_is_none(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -303,7 +303,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["date"].value is None
+        assert document.metadata.date.value is None
 
     def test_case_number_prefers_metadata_fields(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -317,7 +317,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["case_number"].value == "ABC-123"
+        assert document.metadata.case_number.value == "ABC-123"
 
     def test_case_number_suppressed_only_is_none(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -332,7 +332,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["case_number"].value is None
+        assert document.metadata.case_number.value is None
 
     def test_case_number_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -347,7 +347,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
 
         with pytest.raises(TypeError, match="Expected string metadata value for 'case_number'"):
-            _ = document.metadata["case_number"].value
+            _ = document.metadata.case_number.value
 
     def test_court_prefers_metadata_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -366,7 +366,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["court"].value == "Fields Court"
+        assert document.metadata.court.value == "Fields Court"
 
     def test_court_suppressed_only_is_empty(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -386,7 +386,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["court"].value == ""
+        assert document.metadata.court.value == ""
 
     def test_court_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -401,7 +401,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
 
         with pytest.raises(TypeError, match="Expected string metadata value for 'court'"):
-            _ = document.metadata["court"].value
+            _ = document.metadata.court.value
 
     def test_jurisdiction_prefers_metadata_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -420,7 +420,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["jurisdiction"].value == "Fields Jurisdiction"
+        assert document.metadata.jurisdiction.value == "Fields Jurisdiction"
 
     def test_jurisdiction_suppressed_only_is_empty(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -440,7 +440,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["jurisdiction"].value == ""
+        assert document.metadata.jurisdiction.value == ""
 
     def test_jurisdiction_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -455,7 +455,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
 
         with pytest.raises(TypeError, match="Expected string metadata value for 'jurisdiction'"):
-            _ = document.metadata["jurisdiction"].value
+            _ = document.metadata.jurisdiction.value
 
     def test_title_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -470,7 +470,7 @@ class TestDocumentMetadataFacadePrefersFields:
         )
 
         with pytest.raises(TypeError, match="Expected string metadata value for 'title'"):
-            _ = document.metadata["title"].value
+            _ = document.metadata.title.value
 
     def test_categories_orphan_child_without_parent_claim_is_omitted(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -484,7 +484,7 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["categories"].values == []
+        assert document.metadata.categories.values == []
 
     def test_judges_prefers_claims_over_body(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -509,9 +509,4 @@ class TestDocumentMetadataFacadePrefersFields:
             )
         )
 
-        assert document.metadata["judges"].values == ["Claim Judge"]
-
-    def test_metadata_contains_rejects_non_string_keys(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-
-        assert 123 not in document.metadata
+        assert document.metadata.judges.values == ["Claim Judge"]

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -57,4 +57,4 @@ class TestDocumentBodyXmlEscaping:
         )
 
         assert judgment.body.name == "R v G & B"
-        assert judgment.metadata["title"].value == "R v G & B"
+        assert judgment.metadata.title.value == "R v G & B"


### PR DESCRIPTION
- Replace dict-like `DocumentMetadata` with a class of typed attributes (`document.metadata.date`, `.judges`, `.title`, etc) so callers get real types without `dict.get` overrides.
- Drop legacy `name` / `judge` key aliases and mapping APIs (`[]`, `get`, `keys`, `values`, `in`).

## Jira

FCLC-2356