### PR TITLE
FCLC-2357: Centralise METADATA_FIELD_CLASSES in the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - Wrap query text with multiple words in a single <mark> tag, rather than each individual text in it's own mark tag
 
+### Refactor
+
+- **Metadata**: drop MetadataAttributeKey from the registry
+- **Metadata**: centralise METADATA_FIELD_CLASSES in the registry
+
 ## v49.1.1 (2026-08-13)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - **Metadata**: expose DocumentMetadata as typed attribute facades
 
+### Refactor
+
+- **Metadata**: drop MetadataAttributeKey from the registry
+- **Metadata**: centralise METADATA_FIELD_CLASSES in the registry
+
 ## v49.1.1 (2026-08-13)
 
 ### Fix

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -27,16 +27,9 @@ from caselawclient.models.documents.metadata.materialisation import (
     document_needs_metadata_materialisation,
 )
 from caselawclient.models.documents.metadata.registry import (
+    METADATA_FIELD_CLASSES,
     DocumentMetadata,
-    MetadataAttributeKey,
 )
-from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
-from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
-from caselawclient.models.documents.metadata.types.court import CourtMetadata
-from caselawclient.models.documents.metadata.types.date import DateMetadata
-from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
-from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
-from caselawclient.models.documents.metadata.types.name import NameMetadata
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
@@ -224,13 +217,7 @@ class Document:
         """Initialise all this document's metadata values."""
 
         self.metadata = DocumentMetadata(
-            title=NameMetadata(self),
-            court=CourtMetadata(self),
-            jurisdiction=JurisdictionMetadata(self),
-            date=DateMetadata(self),
-            case_number=CaseNumberMetadata(self),
-            categories=CategoriesMetadata(self),
-            judges=JudgesMetadata(self),
+            **{cls.key: cls(self) for cls in METADATA_FIELD_CLASSES}  # type: ignore[arg-type]
         )
 
     @property
@@ -990,7 +977,7 @@ class Document:
                 "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
             )
 
-    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[MetadataAttributeKey, str]]] = {
+    _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
         "name": ("title", "value"),
         "court": ("court", "value"),
         "jurisdiction": ("jurisdiction", "value"),

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -49,10 +49,6 @@ class Metadata(ABC):
             return MetadataCategoryValue(name=cleaned_name, parent=parent)
         return None
 
-    @staticmethod
-    def _value_resolves(value: MetadataFieldValue) -> bool:
-        return Metadata._normalise_for_materialisation(value) is not None
-
     def _materialise_document_values(self, values: Iterable[MetadataFieldValue]) -> None:
         """Add DOCUMENT claims for each resolving value that is not already present."""
         for value in values:

--- a/src/caselawclient/models/documents/metadata/materialisation.py
+++ b/src/caselawclient/models/documents/metadata/materialisation.py
@@ -4,28 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING
 
-from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
-from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
-from caselawclient.models.documents.metadata.types.court import CourtMetadata
-from caselawclient.models.documents.metadata.types.date import DateMetadata
-from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
-from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
-from caselawclient.models.documents.metadata.types.name import NameMetadata
-
-if TYPE_CHECKING:
-    from caselawclient.models.documents.metadata.base import Metadata
-
-METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
-    CaseNumberMetadata,
-    CategoriesMetadata,
-    CourtMetadata,
-    DateMetadata,
-    JudgesMetadata,
-    JurisdictionMetadata,
-    NameMetadata,
-)
+from caselawclient.models.documents.metadata.registry import METADATA_FIELD_CLASSES
 
 LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY = "latest_metadata_materialisation_version"
 

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, fields
-from typing import Literal
 
 from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
@@ -13,7 +12,15 @@ from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 
-MetadataAttributeKey = Literal["title", "court", "jurisdiction", "date", "case_number", "categories", "judges"]
+METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
+    CaseNumberMetadata,
+    CategoriesMetadata,
+    CourtMetadata,
+    DateMetadata,
+    JudgesMetadata,
+    JurisdictionMetadata,
+    NameMetadata,
+)
 
 
 @dataclass(slots=True)

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime
+from unittest.mock import PropertyMock, patch
 from uuid import uuid4
 
 import pytest
@@ -14,6 +15,7 @@ from caselawclient.models.documents.metadata.materialisation import (
     document_needs_metadata_materialisation,
     metadata_logic_versions,
 )
+from caselawclient.types import DocumentCategory
 
 TIMESTAMP = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
 
@@ -36,17 +38,6 @@ class TestMetadataMaterialisationVersion:
         assert document_needs_metadata_materialisation("") is True
         assert document_needs_metadata_materialisation("stale") is True
         assert document_needs_metadata_materialisation(CURRENT_METADATA_MATERIALISATION_VERSION) is False
-
-
-class TestValueResolves:
-    def test_empty_category_name_does_not_resolve(self):
-        assert Metadata._value_resolves(MetadataCategoryValue(name="")) is False  # noqa: SLF001
-
-    def test_whitespace_only_string_does_not_resolve(self):
-        assert Metadata._value_resolves("   ") is False  # noqa: SLF001
-
-    def test_unexpected_value_type_does_not_resolve(self):
-        assert Metadata._value_resolves(123) is False  # type: ignore[arg-type]  # noqa: SLF001
 
 
 class TestMaterialiseBodyClaims:
@@ -109,16 +100,22 @@ class TestMaterialiseBodyClaims:
         assert document.metadata_fields.by_name("case_number") == []
 
     def test_strips_whitespace_when_materialising(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata.title._materialise_document_values(["  Body Title  "])  # noqa: SLF001
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="  Body Title  "),
+        )
+        document.metadata.title.materialise_body_claims()
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
         assert claims[0].value == "Body Title"
 
     def test_skips_whitespace_only_string(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata.title._materialise_document_values(["   "])  # noqa: SLF001
+        document = DocumentFactory.build(
+            api_client=mock_api_client,
+            body=DocumentBodyFactory.build(name="   "),
+        )
+        document.metadata.title.materialise_body_claims()
         assert document.metadata_fields.by_name("title") == []
 
     def test_skips_none_case_number(self, mock_api_client):
@@ -201,17 +198,45 @@ class TestMaterialiseBodyClaims:
         document.metadata.categories.materialise_body_claims()
 
         values = {
-            (claim.value.name, claim.value.parent)  # type: ignore[union-attr]
+            (claim.value.name, claim.value.parent)
             for claim in document.metadata_fields.by_name("categories")
+            if isinstance(claim.value, MetadataCategoryValue)
         }
         assert values == {("Parent", None), ("Child", "Parent")}
 
-    def test_empty_category_name_is_not_materialised(self, mock_api_client):
+    def test_skips_empty_category_names_from_body(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata.categories._materialise_document_values(  # noqa: SLF001
-            [MetadataCategoryValue(name="", parent=None)]
-        )
+        with patch.object(
+            type(document.body),
+            "categories",
+            new_callable=PropertyMock,
+            return_value=[DocumentCategory(name="")],
+        ):
+            document.metadata.categories.materialise_body_claims()
+
         assert document.metadata_fields.by_name("categories") == []
+
+    def test_strips_whitespace_only_category_parent(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+        with patch.object(
+            type(document.body),
+            "categories",
+            new_callable=PropertyMock,
+            return_value=[
+                DocumentCategory(
+                    name="   ",
+                    subcategories=[DocumentCategory(name="Child")],
+                )
+            ],
+        ):
+            document.metadata.categories.materialise_body_claims()
+
+        values = {
+            (claim.value.name, claim.value.parent)
+            for claim in document.metadata_fields.by_name("categories")
+            if isinstance(claim.value, MetadataCategoryValue)
+        }
+        assert values == {("Child", None)}
 
 
 class TestDocumentMaterialiseMetadataClaims:

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -236,6 +236,15 @@ class TestDocumentMetadata:
         assert document.metadata.title.value == "Judgment v Judgement"
         assert document.metadata.court.value == "Court of Testing"
 
+    def test_metadata_facades_match_field_class_registry(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.registry import METADATA_FIELD_CLASSES
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        for cls in METADATA_FIELD_CLASSES:
+            assert isinstance(getattr(document.metadata, cls.key), cls)
+
     def test_metadata_rejects_mapping_apis(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
 


### PR DESCRIPTION
Reduce the number of places we're explicitly enumerating all possible metadata field types

- Move `METADATA_FIELD_CLASSES` into `registry.py` beside `DocumentMetadata` so the list of types and the class type hints live in the same place (reducing the chance of one moving without the other)
  - Also add a quick sense check that these two match in the tests
- `Document._initialise_metadata` now builds from that same list

## Jira

FCLC-2357