### PR TITLE
FCLC-2358: Per-type metadata pack/unpack; date claims as date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,19 @@ The format is based on [Keep a Changelog 1.0.0].
 - Use document.metadata.title / .judges (etc), not
   metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
   values/in. Legacy name/judge keys are gone.
+- Date metadata claim values are `datetime.date`, not `str`.
+- Claim payloads are structured `MetadataStringValue` /
+  `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
 
 ### Feat
 
+- **Metadata**: wrap all claim values in structured Metadata\*Value types
+- **Metadata**: per-type pack/unpack with date claims as date
 - **Metadata**: expose DocumentMetadata as typed attribute facades
+
+### Fix
+
+- **Metadata**: harden claim unpack (strip text, validate pack_version)
 
 ### Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog 1.0.0].
 - Use document.metadata.title / .judges (etc), not
   metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
   values/in. Legacy name/judge keys are gone.
+- Date metadata claim values are `datetime.date`, not `str`.
+- Claim payloads are structured `MetadataStringValue` /
+  `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
 
 ### Feat
 
@@ -22,12 +25,15 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Document**: reject `from_xml()` for URIs that already exist in MarkLogic (`DocumentAlreadyExistsError`)
 - **Document**: validate identifier and metadata field IDs before upserting document XML during `save()`
 - **Document**: persist identifiers and structured metadata properties after upserting document XML during `save()`
+- **Metadata**: wrap all claim values in structured Metadata\*Value types
+- **Metadata**: per-type pack/unpack with date claims as date
 - **Metadata**: expose DocumentMetadata as typed attribute facades
 
 ### Fix
 
 - Fix `Judgment` and `PressSummary` constructors to pass `api_client` explicitly through `NeutralCitationMixin`
 - Wrap query text with multiple words in a single <mark> tag, rather than each individual text in it's own mark tag
+- **Metadata**: harden claim unpack (strip text, validate pack_version)
 
 ### Refactor
 

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from datetime import date
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
 
 from caselawclient.models.documents.metadata.fields.field import (
-    MetadataCategoryValue,
+    MetadataDateValue,
     MetadataField,
     MetadataFieldValue,
+    MetadataStringValue,
 )
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.fields.unpack_helpers import stripped_element_text
+from caselawclient.xml_helpers import Element
 
 if TYPE_CHECKING:
     from caselawclient.models.documents import Document
@@ -27,32 +31,41 @@ class Metadata(ABC):
     LOGIC_VERSION: ClassVar[int] = 2
     """Bump when this field's body-extraction / materialisation rules change."""
 
+    PACK_VERSION: ClassVar[int] = 1
+    """Bump when this field's packed XML value shape changes."""
+
     def __init__(self, document: "Document") -> None:
         self.document = document
 
     def _resolve_claims(self) -> "ResolvedMetadataField":
         return self.document.metadata_fields.resolve(self.key)
 
-    @staticmethod
-    def _normalise_for_materialisation(value: MetadataFieldValue) -> MetadataFieldValue | None:
-        """Strip whitespace; return ``None`` when the value does not resolve."""
-        if isinstance(value, str):
-            cleaned = value.strip()
-            return cleaned or None
-        if isinstance(value, MetadataCategoryValue):
-            cleaned_name = value.name.strip()
-            if not cleaned_name:
-                return None
-            parent = value.parent.strip() if value.parent else None
-            if parent == "":
-                parent = None
-            return MetadataCategoryValue(name=cleaned_name, parent=parent)
-        return None
+    @classmethod
+    def validate_value(cls, value: MetadataFieldValue) -> None:
+        """Raise ``TypeError`` if ``value`` is not valid for this claim key."""
+        if not isinstance(value, MetadataStringValue):
+            raise TypeError(f"Expected MetadataStringValue for '{cls.key}', got {type(value).__name__}")
+
+    @classmethod
+    def pack_value(cls, value: MetadataFieldValue, into: Element) -> None:
+        """Write ``value`` into a ``<metadata>`` element (text or child elements)."""
+        cls.validate_value(value)
+        into.text = cast(MetadataStringValue, value).value
+
+    @classmethod
+    def unpack_value(cls, metadata_xml: Element, pack_version: int) -> MetadataFieldValue:
+        """Read the Python claim value from a ``<metadata>`` element.
+
+        Implementations must only raise
+        ``InvalidMetadataFieldXMLRepresentationException`` for invalid wire
+        data (wrapping other ``ValueError``s). Strip text nodes before parse.
+        """
+        return MetadataStringValue(stripped_element_text(metadata_xml))
 
     def _materialise_document_values(self, values: Iterable[MetadataFieldValue]) -> None:
         """Add DOCUMENT claims for each resolving value that is not already present."""
         for value in values:
-            normalised = self._normalise_for_materialisation(value)
+            normalised = value.normalised()
             if normalised is None:
                 continue
             if self.document.metadata_fields.has_claim(self.key, normalised, MetadataSource.DOCUMENT):
@@ -74,6 +87,36 @@ class SingleMetadata(Metadata, Generic[T]):
     @property
     @abstractmethod
     def value(self) -> T: ...
+
+    def _string_value(self, body: str, *, when_suppressed: str = "") -> str:
+        """Resolve a string claim, falling back to ``body`` when none exist."""
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return body
+        if resolved.value is None:
+            return when_suppressed
+        self.validate_value(resolved.value)
+        return cast(MetadataStringValue, resolved.value).value
+
+    def _optional_string_value(self, body: str | None) -> str | None:
+        """Like ``_string_value``, but suppressed/empty claims resolve to ``None``."""
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return body
+        if resolved.value is None:
+            return None
+        self.validate_value(resolved.value)
+        return cast(MetadataStringValue, resolved.value).value or None
+
+    def _date_value(self, body: date | None) -> date | None:
+        """Resolve a date claim, falling back to ``body`` when none exist."""
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return body
+        if resolved.value is None:
+            return None
+        self.validate_value(resolved.value)
+        return cast(MetadataDateValue, resolved.value).value
 
 
 class MultipleMetadata(Metadata, Generic[T]):

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -30,7 +30,7 @@ class Metadata(ABC):
     """Bump when this field's body-extraction / materialisation rules change."""
 
     PACK_VERSION: ClassVar[int] = 1
-    """Bump when this field's packed XML value shape changes."""
+    """Bump when pack_value / unpack_value for this type change the XML shape."""
 
     def __init__(self, document: "Document") -> None:
         self.document = document

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -1,10 +1,8 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from datetime import date
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
 
 from caselawclient.models.documents.metadata.fields.field import (
-    MetadataDateValue,
     MetadataField,
     MetadataFieldValue,
     MetadataStringValue,
@@ -107,16 +105,6 @@ class SingleMetadata(Metadata, Generic[T]):
             return None
         self.validate_value(resolved.value)
         return cast(MetadataStringValue, resolved.value).value or None
-
-    def _date_value(self, body: date | None) -> date | None:
-        """Resolve a date claim, falling back to ``body`` when none exist."""
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return body
-        if resolved.value is None:
-            return None
-        self.validate_value(resolved.value)
-        return cast(MetadataDateValue, resolved.value).value
 
 
 class MultipleMetadata(Metadata, Generic[T]):

--- a/src/caselawclient/models/documents/metadata/fields/field.py
+++ b/src/caselawclient/models/documents/metadata/fields/field.py
@@ -1,22 +1,68 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from datetime import UTC, datetime
-from typing import Union
+from datetime import UTC, date, datetime
+from typing import Self, Union
 from uuid import uuid4
 
 from lxml import etree
 
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.xml_helpers import Element
 
-MetadataFieldValue = Union[str, "MetadataCategoryValue"]
+MetadataFieldValue = Union["MetadataStringValue", "MetadataDateValue", "MetadataCategoryValue"]
+
+
+@dataclass(frozen=True)
+class MetadataStringValue:
+    """Plain-text claim value (title, court, judges, etc)."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "value", self.value.strip())
+
+    def normalised(self) -> Self | None:
+        """Return self, or ``None`` when empty after stripping."""
+        return self if self.value else None
+
+
+@dataclass(frozen=True)
+class MetadataDateValue:
+    """Calendar-date claim value (not a timestamp)."""
+
+    value: date
+
+    def __post_init__(self) -> None:
+        if isinstance(self.value, datetime):
+            raise TypeError("Expected datetime.date for MetadataDateValue, got datetime")
+
+    def normalised(self) -> Self | None:
+        return self
 
 
 @dataclass(frozen=True)
 class MetadataCategoryValue:
-    """Structured value for a ``category`` metadata claim."""
+    """Structured value for a ``categories`` metadata claim."""
 
     name: str
     parent: str | None = None
+
+    def __post_init__(self) -> None:
+        name = self.name.strip()
+        parent = self.parent.strip() if self.parent else None
+        if parent == "":
+            parent = None
+        if not name:
+            raise ValueError("category name must be non-empty")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "parent", parent)
+
+    def normalised(self) -> Self | None:
+        return self
 
 
 class MetadataField:
@@ -54,6 +100,15 @@ class MetadataField:
     @property
     def as_etree(self) -> Element:
         """Pack this claim into a ``<metadata>`` element for MarkLogic storage."""
+        # Lazy import avoids a cycle: field → registry → types → base → field.
+        from caselawclient.models.documents.metadata.registry import metadata_class_for_key
+
+        metadata_cls = metadata_class_for_key(self.name)
+        if metadata_cls is None:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                f"Cannot pack metadata field with unknown name '{self.name}'"
+            )
+
         metadata_element = etree.Element(
             "metadata",
             id=self.id,
@@ -61,17 +116,9 @@ class MetadataField:
             source=self.source.value,
             timestamp=self.timestamp.isoformat(),
             rejected=str(self.rejected).lower(),
+            pack_version=str(metadata_cls.PACK_VERSION),
         )
-
-        if isinstance(self.value, MetadataCategoryValue):
-            name_element = etree.SubElement(metadata_element, "name")
-            name_element.text = self.value.name
-            parent_element = etree.SubElement(metadata_element, "parent")
-            if self.value.parent is not None:
-                parent_element.text = self.value.parent
-        else:
-            metadata_element.text = self.value
-
+        metadata_cls.pack_value(self.value, metadata_element)
         return metadata_element
 
     def __repr__(self) -> str:

--- a/src/caselawclient/models/documents/metadata/fields/unpack_helpers.py
+++ b/src/caselawclient/models/documents/metadata/fields/unpack_helpers.py
@@ -1,0 +1,35 @@
+"""Shared helpers for metadata claim XML unpacking.
+
+``unpack_value`` implementations and the claim envelope parser should surface
+invalid wire data as ``InvalidMetadataFieldXMLRepresentationException`` only —
+never leak raw ``ValueError`` from constructors or parsers.
+"""
+
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
+from caselawclient.xml_helpers import Element
+
+
+def stripped_element_text(element: Element | None) -> str:
+    """Return ``element.text`` stripped, or ``""`` when missing/empty."""
+    if element is None or element.text is None:
+        return ""
+    return element.text.strip()
+
+
+def parse_pack_version(pack_version_attr: str | None) -> int:
+    """Parse a ``pack_version`` attribute; missing means version 1."""
+    if pack_version_attr is None:
+        return 1
+    try:
+        pack_version = int(pack_version_attr)
+    except ValueError as exc:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            f"Metadata field XML representation is not valid: unparsable pack_version '{pack_version_attr}'"
+        ) from exc
+    if pack_version < 1:
+        raise InvalidMetadataFieldXMLRepresentationException(
+            f"Metadata field XML representation is not valid: pack_version must be >= 1, got {pack_version}"
+        )
+    return pack_version

--- a/src/caselawclient/models/documents/metadata/fields/unpacker.py
+++ b/src/caselawclient/models/documents/metadata/fields/unpacker.py
@@ -1,11 +1,13 @@
+import warnings
 from datetime import datetime
 
 from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
 from caselawclient.models.documents.metadata.fields.exceptions import (
     InvalidMetadataFieldXMLRepresentationException,
 )
-from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.field import MetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.fields.unpack_helpers import parse_pack_version
 from caselawclient.models.utilities.dates import require_aware_utc
 from caselawclient.xml_helpers import Element
 
@@ -19,13 +21,22 @@ def unpack_all_metadata_fields_from_etree(
         return collection
 
     for metadata_element in metadata_fields_etree.findall("metadata"):
-        collection.add(unpack_a_metadata_field_from_etree(metadata_element))
+        field = unpack_a_metadata_field_from_etree(metadata_element)
+        if field is not None:
+            collection.add(field)
 
     return collection
 
 
-def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField:
-    """Unpack a single ``<metadata>`` element into a ``MetadataField``."""
+def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField | None:
+    """Unpack a single ``<metadata>`` element into a ``MetadataField``.
+
+    Unknown claim ``name`` values warn and return ``None`` so the rest of the
+    collection can still load.
+    """
+    # Lazy import avoids a cycle: unpacker → registry → types → base → field → …
+    from caselawclient.models.documents.metadata.registry import metadata_class_for_key
+
     field_id = metadata_xml.get("id")
     name = metadata_xml.get("name")
     source_value = metadata_xml.get("source")
@@ -48,6 +59,14 @@ def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField:
             "Metadata field XML representation is not valid: timestamp not present or empty"
         )
 
+    metadata_cls = metadata_class_for_key(name)
+    if metadata_cls is None:
+        warnings.warn(
+            f"Skipping metadata field with unknown name '{name}'",
+            stacklevel=2,
+        )
+        return None
+
     try:
         source = MetadataSource(source_value)
     except ValueError as exc:
@@ -65,22 +84,18 @@ def unpack_a_metadata_field_from_etree(metadata_xml: Element) -> MetadataField:
     rejected_attr = metadata_xml.get("rejected")
     rejected = rejected_attr is not None and rejected_attr.lower() == "true"
 
-    name_child = metadata_xml.find("name")
-    if name_child is not None:
-        category_name = name_child.text
-        if not category_name:
-            raise InvalidMetadataFieldXMLRepresentationException(
-                "Metadata field XML representation is not valid: category name not present or empty"
-            )
-        parent_child = metadata_xml.find("parent")
-        parent: str | None
-        if parent_child is None or parent_child.text is None or parent_child.text == "":
-            parent = None
-        else:
-            parent = parent_child.text
-        value: MetadataCategoryValue | str = MetadataCategoryValue(name=category_name, parent=parent)
-    else:
-        value = metadata_xml.text or ""
+    pack_version = parse_pack_version(metadata_xml.get("pack_version"))
+
+    try:
+        value = metadata_cls.unpack_value(metadata_xml, pack_version)
+    except InvalidMetadataFieldXMLRepresentationException:
+        raise
+    except ValueError as exc:
+        # Safety net: value constructors / parsers should already raise
+        # InvalidMetadataFieldXMLRepresentationException, but wrap leaks.
+        raise InvalidMetadataFieldXMLRepresentationException(
+            f"Metadata field XML representation is not valid: {exc}"
+        ) from exc
 
     return MetadataField(
         name=name,

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, fields
+from functools import lru_cache
 
 from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.types.case_number import CaseNumberMetadata
@@ -21,6 +22,16 @@ METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     JurisdictionMetadata,
     NameMetadata,
 )
+
+
+@lru_cache(maxsize=1)
+def metadata_classes_by_key() -> dict[str, type[Metadata]]:
+    return {cls.key: cls for cls in METADATA_FIELD_CLASSES}
+
+
+def metadata_class_for_key(key: str) -> type[Metadata] | None:
+    """Return the metadata type class for a claim ``name``, if registered."""
+    return metadata_classes_by_key().get(key)
 
 
 @dataclass(slots=True)

--- a/src/caselawclient/models/documents/metadata/types/case_number.py
+++ b/src/caselawclient/models/documents/metadata/types/case_number.py
@@ -1,4 +1,5 @@
 from caselawclient.models.documents.metadata.base import SingleMetadata
+from caselawclient.models.documents.metadata.fields.field import MetadataStringValue
 
 
 class CaseNumberMetadata(SingleMetadata[str | None]):
@@ -8,17 +9,10 @@ class CaseNumberMetadata(SingleMetadata[str | None]):
 
     @property
     def value(self) -> str | None:
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return self.document.body.case_number
-        if resolved.value is None:
-            return None
-        if not isinstance(resolved.value, str):
-            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
-        return resolved.value
+        return self._optional_string_value(self.document.body.case_number)
 
     def materialise_body_claims(self) -> None:
         case_number = self.document.body.case_number
         if case_number is None:
             return
-        self._materialise_document_values([case_number])
+        self._materialise_document_values([MetadataStringValue(case_number)])

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -1,6 +1,15 @@
+from typing import cast
+
+from lxml import etree
+
 from caselawclient.models.documents.metadata.base import MultipleMetadata
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
 from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataFieldValue
+from caselawclient.models.documents.metadata.fields.unpack_helpers import stripped_element_text
 from caselawclient.types import DocumentCategory
+from caselawclient.xml_helpers import Element
 
 
 def document_categories_from_field_values(values: list[MetadataFieldValue]) -> list[DocumentCategory]:
@@ -41,8 +50,13 @@ def category_claim_values_from_document_categories(
     """Flatten a category tree into claim values suitable for DOCUMENT materialisation."""
     values: list[MetadataCategoryValue] = []
     for category in categories:
-        values.append(MetadataCategoryValue(name=category.name, parent=parent))
-        values.extend(category_claim_values_from_document_categories(category.subcategories, parent=category.name))
+        child_parent: str | None
+        if category.name.strip():
+            values.append(MetadataCategoryValue(name=category.name, parent=parent))
+            child_parent = category.name
+        else:
+            child_parent = parent
+        values.extend(category_claim_values_from_document_categories(category.subcategories, parent=child_parent))
     return values
 
 
@@ -60,3 +74,35 @@ class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
 
     def materialise_body_claims(self) -> None:
         self._materialise_document_values(category_claim_values_from_document_categories(self.document.body.categories))
+
+    @classmethod
+    def validate_value(cls, value: MetadataFieldValue) -> None:
+        if not isinstance(value, MetadataCategoryValue):
+            raise TypeError(f"Expected MetadataCategoryValue for '{cls.key}', got {type(value).__name__}")
+
+    @classmethod
+    def pack_value(cls, value: MetadataFieldValue, into: Element) -> None:
+        cls.validate_value(value)
+        category = cast(MetadataCategoryValue, value)
+        name_element = etree.SubElement(into, "name")
+        name_element.text = category.name
+        parent_element = etree.SubElement(into, "parent")
+        if category.parent is not None:
+            parent_element.text = category.parent
+
+    @classmethod
+    def unpack_value(cls, metadata_xml: Element, pack_version: int) -> MetadataFieldValue:
+        name_child = metadata_xml.find("name")
+        if name_child is None:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: category name element not present"
+            )
+        category_name = stripped_element_text(name_child)
+        if not category_name:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: category name not present or empty"
+            )
+        parent_child = metadata_xml.find("parent")
+        parent_text = stripped_element_text(parent_child)
+        parent = parent_text or None
+        return MetadataCategoryValue(name=category_name, parent=parent)

--- a/src/caselawclient/models/documents/metadata/types/court.py
+++ b/src/caselawclient/models/documents/metadata/types/court.py
@@ -1,4 +1,5 @@
 from caselawclient.models.documents.metadata.base import SingleMetadata
+from caselawclient.models.documents.metadata.fields.field import MetadataStringValue
 
 
 class CourtMetadata(SingleMetadata[str]):
@@ -8,14 +9,7 @@ class CourtMetadata(SingleMetadata[str]):
 
     @property
     def value(self) -> str:
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return self.document.body.court
-        if resolved.value is None:
-            return ""
-        if not isinstance(resolved.value, str):
-            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
-        return resolved.value
+        return self._string_value(self.document.body.court)
 
     def materialise_body_claims(self) -> None:
-        self._materialise_document_values([self.document.body.court])
+        self._materialise_document_values([MetadataStringValue(self.document.body.court)])

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -1,31 +1,19 @@
 import datetime
-import warnings
+from typing import cast
 
 from caselawclient.models.documents.metadata.base import SingleMetadata
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
+from caselawclient.models.documents.metadata.fields.field import MetadataDateValue, MetadataFieldValue
+from caselawclient.models.documents.metadata.fields.unpack_helpers import stripped_element_text
+from caselawclient.xml_helpers import Element
 
 
 def date_as_string_from_value(value: datetime.date | None) -> str:
     if value is None:
         return ""
     return value.strftime("%Y-%m-%d")
-
-
-def date_from_metadata_field_value(value: object) -> datetime.date | None:
-    if value is None:
-        return None
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.date.fromisoformat(value)
-    except ValueError:
-        # Import locally to avoid a circular dependency with DocumentBody.
-        from caselawclient.models.documents.body import UnparsableDate
-
-        warnings.warn(
-            f"Unparsable date encountered: {value}",
-            UnparsableDate,
-        )
-        return None
 
 
 class DateMetadata(SingleMetadata[datetime.date | None]):
@@ -35,10 +23,7 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
 
     @property
     def value(self) -> datetime.date | None:
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return self.document.body.document_date_as_date
-        return date_from_metadata_field_value(resolved.value)
+        return self._date_value(self.document.body.document_date_as_date)
 
     @property
     def as_string(self) -> str:
@@ -48,7 +33,31 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
         document_date = self.document.body.document_date_as_date
         if document_date is None:
             return
-        self._materialise_document_values([document_date.isoformat()])
+        self._materialise_document_values([MetadataDateValue(document_date)])
+
+    @classmethod
+    def validate_value(cls, value: MetadataFieldValue) -> None:
+        if not isinstance(value, MetadataDateValue):
+            raise TypeError(f"Expected MetadataDateValue for '{cls.key}', got {type(value).__name__}")
+
+    @classmethod
+    def pack_value(cls, value: MetadataFieldValue, into: Element) -> None:
+        cls.validate_value(value)
+        into.text = cast(MetadataDateValue, value).value.isoformat()
+
+    @classmethod
+    def unpack_value(cls, metadata_xml: Element, pack_version: int) -> MetadataFieldValue:
+        text = stripped_element_text(metadata_xml)
+        if not text:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: date value not present or empty"
+            )
+        try:
+            return MetadataDateValue(datetime.date.fromisoformat(text))
+        except ValueError as exc:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                f"Metadata field XML representation is not valid: unparsable date '{text}'"
+            ) from exc
 
     def __str__(self) -> str:
         return self.as_string

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -23,7 +23,13 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
 
     @property
     def value(self) -> datetime.date | None:
-        return self._date_value(self.document.body.document_date_as_date)
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.document_date_as_date
+        if resolved.value is None:
+            return None
+        self.validate_value(resolved.value)
+        return cast(MetadataDateValue, resolved.value).value
 
     @property
     def as_string(self) -> str:

--- a/src/caselawclient/models/documents/metadata/types/judges.py
+++ b/src/caselawclient/models/documents/metadata/types/judges.py
@@ -1,6 +1,6 @@
 from caselawclient.models.documents.metadata.base import MultipleMetadata
 from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldRemovalNotAllowedException
-from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue, MetadataStringValue
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 
 
@@ -13,9 +13,9 @@ def judge_names_from_field_values(values: list[MetadataFieldValue]) -> list[str]
     judges: list[str] = []
 
     for value in values:
-        if not isinstance(value, str):
+        if not isinstance(value, MetadataStringValue):
             continue
-        name = value.strip()
+        name = value.value
         if not name or name in judges:
             continue
         judges.append(name)
@@ -42,12 +42,12 @@ class JudgesMetadata(MultipleMetadata[str]):
         Existing DOCUMENT claims with the same value are left alone (including
         rejected ones). EDITOR/EXTERNAL claims do not block materialisation.
         """
-        self._materialise_document_values(self.document.body.judges)
+        self._materialise_document_values([MetadataStringValue(name) for name in self.document.body.judges])
 
     def add_editor_judge(self, name: str) -> None:
         """Add an EDITOR claim for a judge name, yanking body first if needed."""
-        cleaned = name.strip()
-        if not cleaned:
+        cleaned = MetadataStringValue(name).normalised()
+        if cleaned is None:
             return
 
         self.materialise_body_claims()
@@ -84,8 +84,8 @@ class JudgesMetadata(MultipleMetadata[str]):
 
     def suppress_body_value(self, name: str) -> None:
         """Yank body claims if needed, then reject the DOCUMENT claim matching ``name``."""
-        cleaned = name.strip()
-        if not cleaned:
+        cleaned = MetadataStringValue(name).normalised()
+        if cleaned is None:
             return
 
         self.materialise_body_claims()

--- a/src/caselawclient/models/documents/metadata/types/jurisdiction.py
+++ b/src/caselawclient/models/documents/metadata/types/jurisdiction.py
@@ -1,4 +1,5 @@
 from caselawclient.models.documents.metadata.base import SingleMetadata
+from caselawclient.models.documents.metadata.fields.field import MetadataStringValue
 
 
 class JurisdictionMetadata(SingleMetadata[str]):
@@ -8,14 +9,7 @@ class JurisdictionMetadata(SingleMetadata[str]):
 
     @property
     def value(self) -> str:
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return self.document.body.jurisdiction
-        if resolved.value is None:
-            return ""
-        if not isinstance(resolved.value, str):
-            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
-        return resolved.value
+        return self._string_value(self.document.body.jurisdiction)
 
     def materialise_body_claims(self) -> None:
-        self._materialise_document_values([self.document.body.jurisdiction])
+        self._materialise_document_values([MetadataStringValue(self.document.body.jurisdiction)])

--- a/src/caselawclient/models/documents/metadata/types/name.py
+++ b/src/caselawclient/models/documents/metadata/types/name.py
@@ -1,4 +1,5 @@
 from caselawclient.models.documents.metadata.base import SingleMetadata
+from caselawclient.models.documents.metadata.fields.field import MetadataStringValue
 
 
 class NameMetadata(SingleMetadata[str]):
@@ -8,14 +9,7 @@ class NameMetadata(SingleMetadata[str]):
 
     @property
     def value(self) -> str:
-        resolved = self._resolve_claims()
-        if not resolved.has_any_claims:
-            return self.document.body.name
-        if resolved.value is None:
-            return ""
-        if not isinstance(resolved.value, str):
-            raise TypeError(f"Expected string metadata value for '{self.key}', got {type(resolved.value).__name__}")
-        return resolved.value
+        return self._string_value(self.document.body.name)
 
     def materialise_body_claims(self) -> None:
-        self._materialise_document_values([self.document.body.name])
+        self._materialise_document_values([MetadataStringValue(self.document.body.name)])

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -1,19 +1,28 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 from lxml import etree
 
+from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
 from caselawclient.models.documents.metadata.fields.exceptions import (
     InvalidMetadataFieldXMLRepresentationException,
     MetadataFieldRemovalNotAllowedException,
 )
-from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.field import (
+    MetadataCategoryValue,
+    MetadataDateValue,
+    MetadataField,
+    MetadataFieldValue,
+    MetadataStringValue,
+)
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.fields.unpacker import (
     unpack_a_metadata_field_from_etree,
     unpack_all_metadata_fields_from_etree,
 )
+from caselawclient.models.documents.metadata.registry import METADATA_FIELD_CLASSES
+from caselawclient.xml_helpers import Element
 
 EARLY_TIMESTAMP = datetime(2025, 12, 17, 18, 0, 0, tzinfo=UTC)
 LATE_TIMESTAMP = datetime(2025, 12, 18, 12, 0, 0, tzinfo=UTC)
@@ -25,11 +34,44 @@ class TestMetadataSource:
         assert MetadataSource.EXTERNAL.precedence < MetadataSource.EDITOR.precedence
 
 
+class TestMetadataFieldValues:
+    def test_string_value_strips_and_normalises_empty_to_none(self):
+        assert MetadataStringValue("  Title  ").value == "Title"
+        assert MetadataStringValue("   ").normalised() is None
+
+    def test_category_value_strips_whitespace_parent_and_rejects_empty_name(self):
+        assert MetadataCategoryValue(name=" Child ", parent="  ").parent is None
+        with pytest.raises(ValueError, match="non-empty"):
+            MetadataCategoryValue(name="")
+
+    def test_pack_unknown_name_raises(self):
+        field = MetadataField(
+            name="not_a_real_field",
+            value=MetadataStringValue("X"),
+            source=MetadataSource.EXTERNAL,
+            id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unknown name"):
+            _ = field.as_etree
+
+    def test_pack_categories_rejects_string_value(self):
+        field = MetadataField(
+            name="categories",
+            value=MetadataStringValue("not-a-category"),
+            source=MetadataSource.EXTERNAL,
+            id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        with pytest.raises(TypeError, match="Expected MetadataCategoryValue"):
+            _ = field.as_etree
+
+
 class TestMetadataFieldPacking:
     def test_pack_scalar_value(self):
         field = MetadataField(
             name="title",
-            value="A Judgment",
+            value=MetadataStringValue("A Judgment"),
             source=MetadataSource.DOCUMENT,
             id="2d80bf1d-e3ea-452f-965c-041f4399f2dd",
             timestamp=EARLY_TIMESTAMP,
@@ -42,6 +84,7 @@ class TestMetadataFieldPacking:
         assert element.get("source") == "document"
         assert element.get("timestamp") == EARLY_TIMESTAMP.isoformat()
         assert element.get("rejected") == "false"
+        assert element.get("pack_version") == "1"
         assert element.text == "A Judgment"
 
     def test_pack_category_value(self):
@@ -72,7 +115,7 @@ class TestMetadataFieldPacking:
     def test_pack_rejected(self):
         field = MetadataField(
             name="title",
-            value="Wrong",
+            value=MetadataStringValue("Wrong"),
             source=MetadataSource.DOCUMENT,
             id="f47ac10b-58cc-4372-a567-0e02b2c3d479",
             timestamp=EARLY_TIMESTAMP,
@@ -88,11 +131,12 @@ class TestMetadataFieldUnpacking:
             f'timestamp="{EARLY_TIMESTAMP.isoformat()}" rejected="false">A Judgment</metadata>'
         )
         field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
 
         assert field.id == "2d80bf1d-e3ea-452f-965c-041f4399f2dd"
         assert field.name == "title"
         assert field.source is MetadataSource.DOCUMENT
-        assert field.value == "A Judgment"
+        assert field.value == MetadataStringValue("A Judgment")
         assert field.timestamp == EARLY_TIMESTAMP
         assert field.rejected is False
 
@@ -103,6 +147,7 @@ class TestMetadataFieldUnpacking:
             "<name>Subcategory</name><parent>Category</parent></metadata>"
         )
         field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
 
         assert isinstance(field.value, MetadataCategoryValue)
         assert field.value.name == "Subcategory"
@@ -115,6 +160,7 @@ class TestMetadataFieldUnpacking:
             "<name>Category One</name><parent/></metadata>"
         )
         field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
 
         assert isinstance(field.value, MetadataCategoryValue)
         assert field.value.parent is None
@@ -124,7 +170,9 @@ class TestMetadataFieldUnpacking:
             '<metadata id="f47ac10b-58cc-4372-a567-0e02b2c3d479" name="title" source="document" '
             f'timestamp="{EARLY_TIMESTAMP.isoformat()}" rejected="true">Wrong</metadata>'
         )
-        assert unpack_a_metadata_field_from_etree(xml).rejected is True
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.rejected is True
 
     def test_unpack_missing_id_raises(self):
         xml = etree.fromstring(
@@ -188,6 +236,128 @@ class TestMetadataFieldUnpacking:
         with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="category name"):
             unpack_a_metadata_field_from_etree(xml)
 
+    def test_unpack_missing_category_name_element_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="categories" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}"></metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="category name element"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_legacy_date_yyyy_mm_dd(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="date" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">2023-02-03</metadata>'
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataDateValue(date(2023, 2, 3))
+
+    def test_unpack_empty_date_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="date" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}"></metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="date value"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_unparsable_date_raises(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="date" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">not-a-date</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="unparsable date"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_missing_pack_version_defaults_to_v1(self):
+        xml = etree.fromstring(
+            '<metadata id="2d80bf1d-e3ea-452f-965c-041f4399f2dd" name="title" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">A Judgment</metadata>'
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataStringValue("A Judgment")
+
+    def test_unpack_date_strips_whitespace(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="date" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">\n  2023-02-03\n</metadata>'
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataDateValue(date(2023, 2, 3))
+
+    def test_unpack_category_strips_name_and_parent(self):
+        xml = etree.fromstring(
+            '<metadata id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67" name="categories" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
+            "<name>  Subcategory  </name><parent>  Category  </parent></metadata>"
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataCategoryValue(name="Subcategory", parent="Category")
+
+    def test_unpack_whitespace_only_category_name_raises_invalid_xml(self):
+        xml = etree.fromstring(
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="categories" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}"><name>   </name><parent/></metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="category name"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    @pytest.mark.parametrize("pack_version", ["not-an-int", "0", "-1"])
+    def test_unpack_invalid_pack_version_raises(self, pack_version: str):
+        xml = etree.fromstring(
+            '<metadata id="2d80bf1d-e3ea-452f-965c-041f4399f2dd" name="title" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}" pack_version="{pack_version}">A Judgment</metadata>'
+        )
+        with pytest.raises(InvalidMetadataFieldXMLRepresentationException, match="pack_version"):
+            unpack_a_metadata_field_from_etree(xml)
+
+    def test_unpack_unknown_name_warns_and_skips(self):
+        xml = etree.fromstring(
+            "<metadata_fields>"
+            '<metadata id="2d80bf1d-e3ea-452f-965c-041f4399f2dd" name="title" source="document" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">Keep me</metadata>'
+            '<metadata id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34" name="not_a_real_field" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">Skip me</metadata>'
+            "</metadata_fields>"
+        )
+        with pytest.warns(UserWarning, match="unknown name 'not_a_real_field'"):
+            collection = unpack_all_metadata_fields_from_etree(xml)
+        assert list(collection.keys()) == ["2d80bf1d-e3ea-452f-965c-041f4399f2dd"]
+        assert collection["2d80bf1d-e3ea-452f-965c-041f4399f2dd"].value == MetadataStringValue("Keep me")
+
+    def test_pack_date_emits_iso_text(self):
+        field = MetadataField(
+            name="date",
+            value=MetadataDateValue(date(2023, 2, 3)),
+            source=MetadataSource.DOCUMENT,
+            id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        element = field.as_etree
+        assert element.get("pack_version") == "1"
+        assert element.text == "2023-02-03"
+
+    def test_pack_date_rejects_datetime(self):
+        with pytest.raises(TypeError, match="datetime"):
+            MetadataDateValue(datetime(2023, 2, 3, 12, 0, tzinfo=UTC))
+
+    def test_date_roundtrip(self):
+        original = MetadataFieldsCollection()
+        original.add(
+            MetadataField(
+                name="date",
+                value=MetadataDateValue(date(2023, 2, 3)),
+                source=MetadataSource.DOCUMENT,
+                id="9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        unpacked = unpack_all_metadata_fields_from_etree(original.as_etree)
+        assert unpacked["9b2c8e4f-1a3d-4c5e-8f7a-6b0d9e2c1a34"].value == MetadataDateValue(date(2023, 2, 3))
+
     def test_unpack_none_returns_empty_collection(self):
         assert unpack_all_metadata_fields_from_etree(None) == MetadataFieldsCollection()
 
@@ -196,7 +366,7 @@ class TestMetadataFieldUnpacking:
         original.add(
             MetadataField(
                 name="title",
-                value="Judgment",
+                value=MetadataStringValue("Judgment"),
                 source=MetadataSource.DOCUMENT,
                 id="c0ffee00-dead-beef-cafe-0123456789ab",
                 timestamp=EARLY_TIMESTAMP,
@@ -216,7 +386,7 @@ class TestMetadataFieldUnpacking:
         unpacked = unpack_all_metadata_fields_from_etree(original.as_etree)
 
         assert set(unpacked.keys()) == set(original.keys())
-        assert unpacked["c0ffee00-dead-beef-cafe-0123456789ab"].value == "Judgment"
+        assert unpacked["c0ffee00-dead-beef-cafe-0123456789ab"].value == MetadataStringValue("Judgment")
         assert unpacked["c0ffee00-dead-beef-cafe-0123456789ab"].timestamp == EARLY_TIMESTAMP
         assert unpacked["1e2f3a4b-5c6d-7e8f-9012-3456789abcde"].rejected is True
         category = unpacked["1e2f3a4b-5c6d-7e8f-9012-3456789abcde"].value
@@ -225,13 +395,60 @@ class TestMetadataFieldUnpacking:
         assert category.parent is None
 
 
+class TestMetadataUnpackContract:
+    """Registry-wide guardrails for strip + exception contract on unpack."""
+
+    @staticmethod
+    def _sample_value(metadata_cls: type[Metadata]) -> MetadataFieldValue:
+        if metadata_cls.key == "date":
+            return MetadataDateValue(date(2023, 2, 3))
+        if metadata_cls.key == "categories":
+            return MetadataCategoryValue(name="Child", parent="Parent")
+        return MetadataStringValue("Sample")
+
+    @staticmethod
+    def _pad_value_text(element: Element) -> None:
+        if element.text and element.text.strip():
+            element.text = f"\n  {element.text}\n"
+        for child in element:
+            if child.text and child.text.strip():
+                child.text = f"  {child.text}  "
+
+    @pytest.mark.parametrize("metadata_cls", METADATA_FIELD_CLASSES, ids=lambda cls: cls.key)
+    def test_whitespace_padded_payload_roundtrips(self, metadata_cls):
+        field = MetadataField(
+            name=metadata_cls.key,
+            value=self._sample_value(metadata_cls),
+            source=MetadataSource.EXTERNAL,
+            id="2d80bf1d-e3ea-452f-965c-041f4399f2dd",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        packed = field.as_etree
+        expected = field.value
+        self._pad_value_text(packed)
+
+        unpacked = unpack_a_metadata_field_from_etree(packed)
+        assert unpacked is not None
+        assert unpacked.value == expected
+
+    @pytest.mark.parametrize("metadata_cls", METADATA_FIELD_CLASSES, ids=lambda cls: cls.key)
+    def test_empty_payload_does_not_leak_valueerror(self, metadata_cls):
+        element = etree.Element("metadata")
+        try:
+            metadata_cls.unpack_value(element, 1)
+        except InvalidMetadataFieldXMLRepresentationException:
+            return
+        except ValueError as exc:
+            pytest.fail(f"{metadata_cls.key} leaked ValueError from unpack_value: {exc}")
+
+
 class TestMetadataFieldsResolution:
     def test_single_value_uses_highest_precedence(self):
         collection = MetadataFieldsCollection()
         collection.add(
             MetadataField(
                 name="title",
-                value="From document",
+                value=MetadataStringValue("From document"),
                 source=MetadataSource.DOCUMENT,
                 id="10d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
                 timestamp=EARLY_TIMESTAMP,
@@ -240,7 +457,7 @@ class TestMetadataFieldsResolution:
         collection.add(
             MetadataField(
                 name="title",
-                value="From editor",
+                value=MetadataStringValue("From editor"),
                 source=MetadataSource.EDITOR,
                 id="71e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
                 timestamp=EARLY_TIMESTAMP,
@@ -249,7 +466,7 @@ class TestMetadataFieldsResolution:
         collection.add(
             MetadataField(
                 name="title",
-                value="From external",
+                value=MetadataStringValue("From external"),
                 source=MetadataSource.EXTERNAL,
                 id="45b8c9d0-e1f2-4a3b-4c5d-6e7f8091a2b3",
                 timestamp=EARLY_TIMESTAMP,
@@ -257,7 +474,7 @@ class TestMetadataFieldsResolution:
         )
 
         resolved = collection.resolve("title")
-        assert resolved.value == "From editor"
+        assert resolved.value == MetadataStringValue("From editor")
         assert resolved.winning_source is MetadataSource.EDITOR
 
     def test_same_source_prefers_latest_timestamp(self):
@@ -265,7 +482,7 @@ class TestMetadataFieldsResolution:
         collection.add(
             MetadataField(
                 name="title",
-                value="Older editor title",
+                value=MetadataStringValue("Older editor title"),
                 source=MetadataSource.EDITOR,
                 id="71e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
                 timestamp=EARLY_TIMESTAMP,
@@ -274,14 +491,14 @@ class TestMetadataFieldsResolution:
         collection.add(
             MetadataField(
                 name="title",
-                value="Newer editor title",
+                value=MetadataStringValue("Newer editor title"),
                 source=MetadataSource.EDITOR,
                 id="81e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
                 timestamp=LATE_TIMESTAMP,
             )
         )
 
-        assert collection.resolve("title").value == "Newer editor title"
+        assert collection.resolve("title").value == MetadataStringValue("Newer editor title")
 
     def test_winning_source_is_none_when_empty(self):
         assert MetadataFieldsCollection().resolve("title").winning_source is None
@@ -334,7 +551,7 @@ class TestMetadataFieldsResolution:
         collection.add(
             MetadataField(
                 name="title",
-                value="Wrong",
+                value=MetadataStringValue("Wrong"),
                 source=MetadataSource.DOCUMENT,
                 id="60d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f",
                 timestamp=EARLY_TIMESTAMP,

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -22,6 +22,8 @@ from caselawclient.models.documents.metadata.fields.unpacker import (
     unpack_all_metadata_fields_from_etree,
 )
 from caselawclient.models.documents.metadata.registry import METADATA_FIELD_CLASSES
+from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.name import NameMetadata
 from caselawclient.xml_helpers import Element
 
 EARLY_TIMESTAMP = datetime(2025, 12, 17, 18, 0, 0, tzinfo=UTC)
@@ -84,7 +86,7 @@ class TestMetadataFieldPacking:
         assert element.get("source") == "document"
         assert element.get("timestamp") == EARLY_TIMESTAMP.isoformat()
         assert element.get("rejected") == "false"
-        assert element.get("pack_version") == "1"
+        assert element.get("pack_version") == str(NameMetadata.PACK_VERSION)
         assert element.text == "A Judgment"
 
     def test_pack_category_value(self):
@@ -337,7 +339,7 @@ class TestMetadataFieldUnpacking:
             timestamp=EARLY_TIMESTAMP,
         )
         element = field.as_etree
-        assert element.get("pack_version") == "1"
+        assert element.get("pack_version") == str(DateMetadata.PACK_VERSION)
         assert element.text == "2023-02-03"
 
     def test_pack_date_rejects_datetime(self):

--- a/tests/models/documents/metadata/test_judges_editing.py
+++ b/tests/models/documents/metadata/test_judges_editing.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from caselawclient.factories import DocumentBodyFactory, DocumentFactory
-from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataStringValue
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 
 TIMESTAMP = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
@@ -36,8 +36,8 @@ class TestJudgesMetadataEditing:
         judges.materialise_body_claims()
 
         assert [claim.value for claim in document.metadata_fields.by_name("judges")] == [
-            "Judge A",
-            "Judge B",
+            MetadataStringValue("Judge A"),
+            MetadataStringValue("Judge B"),
         ]
         assert all(claim.source is MetadataSource.DOCUMENT for claim in document.metadata_fields.by_name("judges"))
         assert judges.values == ["Judge A", "Judge B"]
@@ -47,7 +47,7 @@ class TestJudgesMetadataEditing:
         document.metadata_fields.add(
             MetadataField(
                 name="judges",
-                value="Claim Judge",
+                value=MetadataStringValue("Claim Judge"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -56,8 +56,8 @@ class TestJudgesMetadataEditing:
         document.metadata.judges.materialise_body_claims()
         claims = document.metadata_fields.by_name("judges")
         assert {(claim.source, claim.value) for claim in claims} == {
-            (MetadataSource.EXTERNAL, "Claim Judge"),
-            (MetadataSource.DOCUMENT, "Body Judge"),
+            (MetadataSource.EXTERNAL, MetadataStringValue("Claim Judge")),
+            (MetadataSource.DOCUMENT, MetadataStringValue("Body Judge")),
         }
 
     def test_add_editor_judge_yanks_then_adds(self, mock_api_client):
@@ -67,16 +67,20 @@ class TestJudgesMetadataEditing:
         claims = document.metadata_fields.by_name("judges")
         assert len(claims) == 2
         assert claims[0].source is MetadataSource.DOCUMENT
-        assert claims[0].value == "Body Judge"
+        assert claims[0].value == MetadataStringValue("Body Judge")
         assert claims[1].source is MetadataSource.EDITOR
-        assert claims[1].value == "Editor Judge"
+        assert claims[1].value == MetadataStringValue("Editor Judge")
         assert document.metadata.judges.values == ["Body Judge", "Editor Judge"]
 
     def test_suppress_document_claim_rejects(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A", "Judge B"))
         judges = document.metadata.judges
         judges.materialise_body_claims()
-        claim_a = next(claim for claim in document.metadata_fields.by_name("judges") if claim.value == "Judge A")
+        claim_a = next(
+            claim
+            for claim in document.metadata_fields.by_name("judges")
+            if claim.value == MetadataStringValue("Judge A")
+        )
 
         judges.suppress_claim(claim_a.id)
 
@@ -90,7 +94,7 @@ class TestJudgesMetadataEditing:
         document.metadata_fields.add(
             MetadataField(
                 name="judges",
-                value="Editor Judge",
+                value=MetadataStringValue("Editor Judge"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -109,4 +113,15 @@ class TestJudgesMetadataEditing:
         assert judges.values == []
 
         judges.restore_claim(claim.id)
+        assert judges.values == ["Judge A"]
+
+    def test_suppress_body_value_blank_name_is_noop(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client, body=_body_with_judges("Judge A"))
+        judges = document.metadata.judges
+        judges.materialise_body_claims()
+
+        judges.suppress_body_value("   ")
+
+        claim = document.metadata_fields.by_name("judges")[0]
+        assert claim.rejected is False
         assert judges.values == ["Judge A"]

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -6,7 +6,12 @@ import pytest
 
 from caselawclient.factories import DocumentBodyFactory, DocumentFactory
 from caselawclient.models.documents.metadata.base import Metadata
-from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.field import (
+    MetadataCategoryValue,
+    MetadataDateValue,
+    MetadataField,
+    MetadataStringValue,
+)
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -50,7 +55,7 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
-        assert claims[0].value == "Body Title"
+        assert claims[0].value == MetadataStringValue("Body Title")
         assert claims[0].source is MetadataSource.DOCUMENT
 
     def test_materialise_is_idempotent_for_same_document_value(self, mock_api_client):
@@ -74,7 +79,7 @@ class TestMaterialiseBodyClaims:
         document.metadata_fields.add(
             MetadataField(
                 name="title",
-                value="Editor Title",
+                value=MetadataStringValue("Editor Title"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -84,8 +89,8 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert {(c.source, c.value) for c in claims} == {
-            (MetadataSource.EDITOR, "Editor Title"),
-            (MetadataSource.DOCUMENT, "Body Title"),
+            (MetadataSource.EDITOR, MetadataStringValue("Editor Title")),
+            (MetadataSource.DOCUMENT, MetadataStringValue("Body Title")),
         }
 
     def test_skips_empty_body_values(self, mock_api_client):
@@ -108,7 +113,7 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
-        assert claims[0].value == "Body Title"
+        assert claims[0].value == MetadataStringValue("Body Title")
 
     def test_skips_whitespace_only_string(self, mock_api_client):
         document = DocumentFactory.build(
@@ -124,7 +129,7 @@ class TestMaterialiseBodyClaims:
         document.metadata.case_number.materialise_body_claims()
         assert document.metadata_fields.by_name("case_number") == []
 
-    def test_date_materialises_isoformat(self, mock_api_client):
+    def test_date_materialises_as_date(self, mock_api_client):
         document = DocumentFactory.build(
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(document_date_as_string="2023-02-03"),
@@ -133,9 +138,9 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("date")
         assert len(claims) == 1
-        assert claims[0].value == "2023-02-03"
-        assert isinstance(claims[0].value, str)
-        assert date.fromisoformat(claims[0].value) == date(2023, 2, 3)
+        assert claims[0].value == MetadataDateValue(date(2023, 2, 3))
+        assert isinstance(claims[0].value, MetadataDateValue)
+        assert claims[0].value.value == date(2023, 2, 3)
 
     def test_skips_missing_document_date(self, mock_api_client):
         document = DocumentFactory.build(
@@ -157,7 +162,7 @@ class TestMaterialiseBodyClaims:
         )
         rejected = MetadataField(
             name="title",
-            value="Body Title",
+            value=MetadataStringValue("Body Title"),
             source=MetadataSource.DOCUMENT,
             id=_id(),
             timestamp=TIMESTAMP,
@@ -257,8 +262,8 @@ class TestDocumentMaterialiseMetadataClaims:
             LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
             CURRENT_METADATA_MATERIALISATION_VERSION,
         )
-        assert document.metadata_fields.resolve("title").value == "Saved Title"
-        assert document.metadata_fields.resolve("court").value == "Saved Court"
+        assert document.metadata_fields.resolve("title").value == MetadataStringValue("Saved Title")
+        assert document.metadata_fields.resolve("court").value == MetadataStringValue("Saved Court")
 
     def test_needs_metadata_materialisation(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -6,7 +6,12 @@ import pytest
 
 from caselawclient.factories import DocumentBodyFactory, DocumentFactory, JudgmentFactory
 from caselawclient.models.documents.metadata.base import Metadata
-from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.field import (
+    MetadataCategoryValue,
+    MetadataDateValue,
+    MetadataField,
+    MetadataStringValue,
+)
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -50,7 +55,7 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
-        assert claims[0].value == "Body Title"
+        assert claims[0].value == MetadataStringValue("Body Title")
         assert claims[0].source is MetadataSource.DOCUMENT
 
     def test_materialise_is_idempotent_for_same_document_value(self, mock_api_client):
@@ -74,7 +79,7 @@ class TestMaterialiseBodyClaims:
         document.metadata_fields.add(
             MetadataField(
                 name="title",
-                value="Editor Title",
+                value=MetadataStringValue("Editor Title"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -84,8 +89,8 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert {(c.source, c.value) for c in claims} == {
-            (MetadataSource.EDITOR, "Editor Title"),
-            (MetadataSource.DOCUMENT, "Body Title"),
+            (MetadataSource.EDITOR, MetadataStringValue("Editor Title")),
+            (MetadataSource.DOCUMENT, MetadataStringValue("Body Title")),
         }
 
     def test_skips_empty_body_values(self, mock_api_client):
@@ -108,7 +113,7 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("title")
         assert len(claims) == 1
-        assert claims[0].value == "Body Title"
+        assert claims[0].value == MetadataStringValue("Body Title")
 
     def test_skips_whitespace_only_string(self, mock_api_client):
         document = DocumentFactory.build(
@@ -124,7 +129,7 @@ class TestMaterialiseBodyClaims:
         document.metadata.case_number.materialise_body_claims()
         assert document.metadata_fields.by_name("case_number") == []
 
-    def test_date_materialises_isoformat(self, mock_api_client):
+    def test_date_materialises_as_date(self, mock_api_client):
         document = DocumentFactory.build(
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(document_date_as_string="2023-02-03"),
@@ -133,9 +138,9 @@ class TestMaterialiseBodyClaims:
 
         claims = document.metadata_fields.by_name("date")
         assert len(claims) == 1
-        assert claims[0].value == "2023-02-03"
-        assert isinstance(claims[0].value, str)
-        assert date.fromisoformat(claims[0].value) == date(2023, 2, 3)
+        assert claims[0].value == MetadataDateValue(date(2023, 2, 3))
+        assert isinstance(claims[0].value, MetadataDateValue)
+        assert claims[0].value.value == date(2023, 2, 3)
 
     def test_skips_missing_document_date(self, mock_api_client):
         document = DocumentFactory.build(
@@ -157,7 +162,7 @@ class TestMaterialiseBodyClaims:
         )
         rejected = MetadataField(
             name="title",
-            value="Body Title",
+            value=MetadataStringValue("Body Title"),
             source=MetadataSource.DOCUMENT,
             id=_id(),
             timestamp=TIMESTAMP,
@@ -258,8 +263,8 @@ class TestDocumentSaveStructuredMetadataToMarklogic:
             LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
             CURRENT_METADATA_MATERIALISATION_VERSION,
         )
-        assert document.metadata_fields.resolve("title").value == "Saved Title"
-        assert document.metadata_fields.resolve("court").value == "Saved Court"
+        assert document.metadata_fields.resolve("title").value == MetadataStringValue("Saved Title")
+        assert document.metadata_fields.resolve("court").value == MetadataStringValue("Saved Court")
 
     def test_needs_metadata_materialisation(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from uuid import uuid4
 
 import pytest
@@ -6,7 +6,12 @@ from lxml import etree
 
 from caselawclient.factories import DocumentFactory
 from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
-from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
+from caselawclient.models.documents.metadata.fields.field import (
+    MetadataCategoryValue,
+    MetadataDateValue,
+    MetadataField,
+    MetadataStringValue,
+)
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
 from caselawclient.types import SuccessFailureMessageTuple
@@ -45,14 +50,14 @@ class TestDocumentMetadataFieldsLoadSave:
         mock_api_client.get_property_as_node.side_effect = get_property_as_node
         document = DocumentFactory.build(api_client=mock_api_client)
 
-        assert document.metadata_fields.resolve("title").value == "From fields"
+        assert document.metadata_fields.resolve("title").value == MetadataStringValue("From fields")
 
     def test_save_metadata_fields_writes_property(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
                 name="title",
-                value="Saved title",
+                value=MetadataStringValue("Saved title"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -65,13 +70,13 @@ class TestDocumentMetadataFieldsLoadSave:
         uri, property_name, tree = mock_api_client.set_property_as_node.call_args.args
         assert uri == document.uri
         assert property_name == "metadata_fields"
-        assert unpack_all_metadata_fields_from_etree(tree).resolve("title").value == "Saved title"
+        assert unpack_all_metadata_fields_from_etree(tree).resolve("title").value == MetadataStringValue("Saved title")
 
     def test_validate_metadata_fields_returns_success_failure_tuple(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         field = MetadataField(
             name="title",
-            value="Saved title",
+            value=MetadataStringValue("Saved title"),
             source=MetadataSource.EDITOR,
             id=_id(),
             timestamp=TIMESTAMP,
@@ -89,7 +94,7 @@ class TestDocumentMetadataFieldsLoadSave:
         document = DocumentFactory.build(api_client=mock_api_client)
         field = MetadataField(
             name="title",
-            value="Saved title",
+            value=MetadataStringValue("Saved title"),
             source=MetadataSource.EDITOR,
             id=_id(),
             timestamp=TIMESTAMP,
@@ -123,7 +128,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="title",
-                value="Fields Name",
+                value=MetadataStringValue("Fields Name"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -142,7 +147,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="title",
-                value="Rejected Name",
+                value=MetadataStringValue("Rejected Name"),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -249,7 +254,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="date",
-                value="2024-06-15",
+                value=MetadataDateValue(date(2024, 6, 15)),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -263,7 +268,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="date",
-                value="2024-06-15",
+                value=MetadataDateValue(date(2024, 6, 15)),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -274,43 +279,48 @@ class TestDocumentMetadataFacadePrefersFields:
         assert document.metadata.date.value is None
         assert document.metadata.date.as_string == ""
 
-    def test_date_unparsable_field_value_is_none(self, mock_api_client):
-        from caselawclient.models.documents.body import UnparsableDate
-
+    def test_date_facade_rejects_non_date_claim_value(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
                 name="date",
-                value="not-a-date",
+                value=MetadataStringValue("2024-06-15"),
                 source=MetadataSource.EXTERNAL,
                 id=_id(),
                 timestamp=TIMESTAMP,
             )
         )
+        with pytest.raises(TypeError, match="Expected MetadataDateValue for 'date'"):
+            _ = document.metadata.date.value
 
-        with pytest.warns(UnparsableDate, match="Unparsable date"):
-            assert document.metadata.date.value is None
-
-    def test_date_empty_string_field_value_is_none(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="date",
-                value="",
-                source=MetadataSource.EXTERNAL,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
+    def test_date_rejects_string_value_on_pack(self, mock_api_client):
+        field = MetadataField(
+            name="date",
+            value=MetadataStringValue("2024-06-15"),
+            source=MetadataSource.EXTERNAL,
+            id=_id(),
+            timestamp=TIMESTAMP,
         )
+        with pytest.raises(TypeError, match="Expected MetadataDateValue for 'date'"):
+            _ = field.as_etree
 
-        assert document.metadata.date.value is None
+    def test_date_rejects_empty_string_on_pack(self, mock_api_client):
+        field = MetadataField(
+            name="date",
+            value=MetadataStringValue(""),
+            source=MetadataSource.EXTERNAL,
+            id=_id(),
+            timestamp=TIMESTAMP,
+        )
+        with pytest.raises(TypeError, match="Expected MetadataDateValue for 'date'"):
+            _ = field.as_etree
 
     def test_case_number_prefers_metadata_fields(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
         document.metadata_fields.add(
             MetadataField(
                 name="case_number",
-                value="ABC-123",
+                value=MetadataStringValue("ABC-123"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -324,7 +334,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="case_number",
-                value="ABC-123",
+                value=MetadataStringValue("ABC-123"),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -336,17 +346,17 @@ class TestDocumentMetadataFacadePrefersFields:
 
     def test_case_number_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="case_number",
-                value=MetadataCategoryValue(name="not-a-case-number"),
-                source=MetadataSource.EDITOR,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
+        field = MetadataField(
+            name="case_number",
+            value=MetadataCategoryValue(name="not-a-case-number"),
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
         )
-
-        with pytest.raises(TypeError, match="Expected string metadata value for 'case_number'"):
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'case_number'"):
+            _ = field.as_etree
+        document.metadata_fields.add(field)
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'case_number'"):
             _ = document.metadata.case_number.value
 
     def test_court_prefers_metadata_fields(self, mock_api_client):
@@ -359,7 +369,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="court",
-                value="Fields Court",
+                value=MetadataStringValue("Fields Court"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -378,7 +388,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="court",
-                value="Rejected Court",
+                value=MetadataStringValue("Rejected Court"),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -390,17 +400,17 @@ class TestDocumentMetadataFacadePrefersFields:
 
     def test_court_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="court",
-                value=MetadataCategoryValue(name="not-a-court"),
-                source=MetadataSource.EDITOR,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
+        field = MetadataField(
+            name="court",
+            value=MetadataCategoryValue(name="not-a-court"),
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
         )
-
-        with pytest.raises(TypeError, match="Expected string metadata value for 'court'"):
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'court'"):
+            _ = field.as_etree
+        document.metadata_fields.add(field)
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'court'"):
             _ = document.metadata.court.value
 
     def test_jurisdiction_prefers_metadata_fields(self, mock_api_client):
@@ -413,7 +423,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="jurisdiction",
-                value="Fields Jurisdiction",
+                value=MetadataStringValue("Fields Jurisdiction"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -432,7 +442,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="jurisdiction",
-                value="Rejected",
+                value=MetadataStringValue("Rejected"),
                 source=MetadataSource.DOCUMENT,
                 id=_id(),
                 timestamp=TIMESTAMP,
@@ -444,32 +454,32 @@ class TestDocumentMetadataFacadePrefersFields:
 
     def test_jurisdiction_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="jurisdiction",
-                value=MetadataCategoryValue(name="not-a-jurisdiction"),
-                source=MetadataSource.EDITOR,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
+        field = MetadataField(
+            name="jurisdiction",
+            value=MetadataCategoryValue(name="not-a-jurisdiction"),
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
         )
-
-        with pytest.raises(TypeError, match="Expected string metadata value for 'jurisdiction'"):
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'jurisdiction'"):
+            _ = field.as_etree
+        document.metadata_fields.add(field)
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'jurisdiction'"):
             _ = document.metadata.jurisdiction.value
 
     def test_title_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="title",
-                value=MetadataCategoryValue(name="not-a-title"),
-                source=MetadataSource.EDITOR,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
+        field = MetadataField(
+            name="title",
+            value=MetadataCategoryValue(name="not-a-title"),
+            source=MetadataSource.EDITOR,
+            id=_id(),
+            timestamp=TIMESTAMP,
         )
-
-        with pytest.raises(TypeError, match="Expected string metadata value for 'title'"):
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'title'"):
+            _ = field.as_etree
+        document.metadata_fields.add(field)
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'title'"):
             _ = document.metadata.title.value
 
     def test_categories_orphan_child_without_parent_claim_is_omitted(self, mock_api_client):
@@ -502,7 +512,7 @@ class TestDocumentMetadataFacadePrefersFields:
         document.metadata_fields.add(
             MetadataField(
                 name="judges",
-                value="Claim Judge",
+                value=MetadataStringValue("Claim Judge"),
                 source=MetadataSource.EDITOR,
                 id=_id(),
                 timestamp=TIMESTAMP,

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -10,7 +10,7 @@ from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.documents.exceptions import DocumentAlreadyExistsError, DocumentNotPersistedError
 from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
-from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataStringValue
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -223,7 +223,7 @@ class TestDocumentSave:
         field_id = str(uuid4())
         document.metadata_fields["wrong-key"] = MetadataField(
             name="title",
-            value="Bad key",
+            value=MetadataStringValue("Bad key"),
             source=MetadataSource.EDITOR,
             id=field_id,
             timestamp=datetime(2024, 1, 1, tzinfo=UTC),
@@ -338,7 +338,7 @@ class TestDocumentSave:
         document = JudgmentFactory.build(api_client=mock_api_client)
         existing_claim = MetadataField(
             name="title",
-            value="Existing editor title",
+            value=MetadataStringValue("Existing editor title"),
             source=MetadataSource.EDITOR,
             id="existing-claim-id",
             timestamp=datetime(2024, 1, 1, tzinfo=UTC),


### PR DESCRIPTION
A bunch of improvements to how we serialise and deserialise metadata values between XML and memory, and some robustness improvements. This also better lays the ground for rich types like the upcoming party metadata, which has both name and role.

- Move claim value XML pack/unpack onto each metadata type, and introduce `PACK_VERSION` as a guard against us changing this in future
- Metadata values now handle normalisation (`normalise_metadata_field_value`)
- We actually validate a value type when constructing `MetadataField`
- **Breaking:** date metadata claim values are `datetime.date` in memory (wire format still `YYYY-MM-DD`)

# Jira

FCLC-2358