### PR TITLE
[FCLC-1677] Filter non-web image formats from HTML transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- omit non-web image formats (WMF/EMF etc.) from HTML transforms so WeasyPrint/Pillow do not crash on Linux; allow MDN common web image types
+
 ## v49.1.0 (2026-08-10)
 
 ### Feat

--- a/src/caselawclient/models/documents/transforms/html.xsl
+++ b/src/caselawclient/models/documents/transforms/html.xsl
@@ -734,10 +734,14 @@
 </xsl:template>
 
 <xsl:template match="img">
-	<img loading="lazy">
-		<xsl:apply-templates select="@*" />
-		<xsl:apply-templates />
-	</img>
+	<!-- Only emit MDN common web image formats (omit WMF/EMF etc.).
+	     https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types#common_image_file_types -->
+	<xsl:if test="matches(@src, '\.(apng|avif|gif|jpe?g|jfif|pjpeg|pjp|png|svg|webp)$', 'i')">
+		<img loading="lazy">
+			<xsl:apply-templates select="@*" />
+			<xsl:apply-templates />
+		</img>
+	</xsl:if>
 </xsl:template>
 <xsl:template match="img/@src">
 	<xsl:attribute name="src">

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -458,6 +458,34 @@ class TestDocumentBody:
 
         assert prettified_transformed_html == prettified_target_html
 
+    def test_content_html_omits_non_web_image_formats(self):
+        """WMF/EMF cannot be rendered by browsers or by Pillow on Linux (WeasyPrint)."""
+        body = DocumentBodyFactory.build("""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment name="decision">
+                    <meta/>
+                    <header>
+                        <p><img src="crest.png" style="width:10pt;height:10pt"/></p>
+                        <p><img src="photo.avif"/></p>
+                        <p><img src="diagram.wmf" style="width:10pt;height:10pt"/></p>
+                        <p><img src="chart.EMF"/></p>
+                        <p>Visible text</p>
+                    </header>
+                    <judgmentBody>
+                        <decision><p/></decision>
+                    </judgmentBody>
+                </judgment>
+            </akomaNtoso>
+        """)
+
+        html = body.content_html("https://assets.example/d-a1b2c3")
+        assert html
+        assert "crest.png" in html
+        assert "photo.avif" in html
+        assert ".wmf" not in html.lower()
+        assert ".emf" not in html.lower()
+
     def test_actual_content_header(self):
         body = DocumentBodyFactory.build("""
             <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">


### PR DESCRIPTION
Some documents include WMF files, which can't be rendered by browsers, or by Pillow on Linux (which is used by Weasyprint to render fallback PDFs).

This PR modifies our XML to HTML XSLT transformation so that it filters out image formats which aren't web-friendly (whitelisting rather than blacklisting). These will now be silently dropped from output, rather than displaying as a broken image or causing a HTTP 500 during PDF rendering.

## Jira

FCLC-1677