### PR TITLE
bump: version 49.1.0 → 49.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v49.1.1 (2026-08-13)
 
 ### Fix
 
-- omit non-web image formats (WMF/EMF etc.) from HTML transforms so WeasyPrint/Pillow do not crash on Linux; allow MDN common web image types
+- **HTML**: omit non-web image formats from judgment transforms
 
 ## v49.1.0 (2026-08-10)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "49.1.0"
+version = "49.1.1"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### Fix

- **HTML**: omit non-web image formats from judgment transforms