### PR TITLE
FCLC-2359: Idempotent MetadataFieldsCollection.add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,19 @@ The format is based on [Keep a Changelog 1.0.0].
 - Date metadata claim values are `datetime.date`, not `str`.
 - Claim payloads are structured `MetadataStringValue` /
   `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
+- `metadata_fields.add` / `__setitem__` are idempotent: matching
+  name/value/source is a noop (including rejected); id collision with a
+  different payload raises; empty values raise. `add` returns whether the
+  claim was added or already present. Duplicate claims are also deduped on
+  unpack. Key/id mismatch raises. `validate_metadata_fields` /
+  key-id validation on save is removed.
 
 ### Feat
 
 - **Metadata**: wrap all claim values in structured Metadata\*Value types
 - **Metadata**: per-type pack/unpack with date claims as date
 - **Metadata**: expose DocumentMetadata as typed attribute facades
+- **Metadata**: idempotent MetadataFieldsCollection.add
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### Refactor
 
+- **Metadata**: require each metadata type to declare its own LOGIC_VERSION
 - **Metadata**: drop MetadataAttributeKey from the registry
 - **Metadata**: centralise METADATA_FIELD_CLASSES in the registry
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog 1.0.0].
 - Date metadata claim values are `datetime.date`, not `str`.
 - Claim payloads are structured `MetadataStringValue` /
   `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
+- `metadata_fields.add` / `__setitem__` are idempotent: matching
+  name/value/source is a noop (including rejected); id collision with a
+  different payload raises; empty values raise. `add` returns whether the
+  claim was added or already present. Duplicate claims are also deduped on
+  unpack. Key/id mismatch raises. `validate_metadata_fields` /
+  key-id validation on save is removed.
 
 ### Feat
 
@@ -23,11 +29,12 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Document**: add `document_from_xml()` helper and `mint_document_uri()`
 - **Document**: guard MarkLogic-backed APIs until `save()` completes (`DocumentNotPersistedError`)
 - **Document**: reject `from_xml()` for URIs that already exist in MarkLogic (`DocumentAlreadyExistsError`)
-- **Document**: validate identifier and metadata field IDs before upserting document XML during `save()`
+- **Document**: validate identifier IDs before upserting document XML during `save()`
 - **Document**: persist identifiers and structured metadata properties after upserting document XML during `save()`
 - **Metadata**: wrap all claim values in structured Metadata\*Value types
 - **Metadata**: per-type pack/unpack with date claims as date
 - **Metadata**: expose DocumentMetadata as typed attribute facades
+- **Metadata**: idempotent MetadataFieldsCollection.add
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ The format is based on [Keep a Changelog 1.0.0].
   `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
 - `metadata_fields.add` / `__setitem__` are idempotent: matching
   name/value/source is a noop (including rejected); id collision with a
-  different payload raises; empty values raise. `add` returns whether the
-  claim was added or already present. Duplicate claims are also deduped on
-  unpack. Key/id mismatch raises. `validate_metadata_fields` /
-  key-id validation on save is removed.
+  different payload raises; unknown claim names and wrong value types
+  raise; empty values raise. `add` returns whether the claim was added
+  or already present. Duplicate claims are also deduped on unpack.
+  Key/id mismatch raises. `validate_metadata_fields` / key-id validation
+  on save is removed.
 
 ### Feat
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -19,7 +19,6 @@ from caselawclient.errors import (
 from caselawclient.identifier_resolution import IdentifierResolutions
 from caselawclient.models.documents import comparison
 from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
-from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
 from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -964,18 +963,9 @@ class Document:
                 "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
             )
 
-    def validate_metadata_fields(self) -> SuccessFailureMessageTuple:
-        return self.metadata_fields.validate_ids_match_keys()
-
     def save_metadata_fields(self) -> None:
-        """Validate metadata fields, and if validation passes save them to MarkLogic."""
-        validations = self.validate_metadata_fields()
-        if validations.success is True:
-            self.api_client.set_property_as_node(self.uri, "metadata_fields", self.metadata_fields.as_etree)
-        else:
-            raise MetadataFieldValidationException(
-                "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
-            )
+        """Save metadata claims to MarkLogic."""
+        self.api_client.set_property_as_node(self.uri, "metadata_fields", self.metadata_fields.as_etree)
 
     _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
         "name": ("title", "value"),

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -19,7 +19,6 @@ from caselawclient.errors import (
 from caselawclient.identifier_resolution import IdentifierResolutions
 from caselawclient.models.documents import comparison
 from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
-from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
 from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
@@ -716,11 +715,8 @@ class Document:
             field.materialise_body_claims()
 
     def _validate_metadata_for_save(self) -> None:
-        validations = self.metadata_fields.validate_ids_match_keys()
-        if validations.success is not True:
-            raise MetadataFieldValidationException(
-                "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
-            )
+        """Hook for save(); claim invariants are enforced by ``add`` / ``__setitem__``."""
+        return
 
     def _validate_identifiers_for_save(self) -> None:
         validations = self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)
@@ -1089,14 +1085,9 @@ class Document:
     def _save_identifiers_to_marklogic(self) -> None:
         self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers.as_etree)
 
-    def validate_metadata_fields(self) -> SuccessFailureMessageTuple:
-        self._require_persisted()
-        return self.metadata_fields.validate_ids_match_keys()
-
     def save_metadata_fields(self) -> None:
-        """Validate metadata fields, and if validation passes save them to MarkLogic."""
+        """Save metadata claims to MarkLogic."""
         self._require_persisted()
-        self._validate_metadata_for_save()
         self._save_metadata_fields()
 
     def _save_metadata_fields(self) -> None:

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -68,8 +68,7 @@ class Metadata(ABC):
             normalised = value.normalised()
             if normalised is None:
                 continue
-            if self.document.metadata_fields.has_claim(self.key, normalised, MetadataSource.DOCUMENT):
-                continue
+            # Idempotent ``add`` noops when an equivalent DOCUMENT claim exists.
             self.document.metadata_fields.add(
                 MetadataField(
                     name=self.key,

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 from caselawclient.models.documents.metadata.fields.field import (
     MetadataField,
@@ -26,11 +26,22 @@ class Metadata(ABC):
     editable: ClassVar[bool] = False
     """Should editors be allowed to manually edit this metadata field?"""
 
-    LOGIC_VERSION: ClassVar[int] = 2
-    """Bump when this field's body-extraction / materialisation rules change."""
+    LOGIC_VERSION: ClassVar[int]
+    """Per-type body-extraction / materialisation generation. Concrete types must set this."""
 
     PACK_VERSION: ClassVar[int] = 1
     """Bump when pack_value / unpack_value for this type change the XML shape."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Intermediate bases (SingleMetadata / MultipleMetadata) have no claim key.
+        if "key" not in cls.__dict__:
+            return
+        for base in cls.__mro__:
+            if base is Metadata:
+                raise TypeError(f"{cls.__name__} must define LOGIC_VERSION")
+            if "LOGIC_VERSION" in base.__dict__:
+                return
 
     def __init__(self, document: "Document") -> None:
         self.document = document

--- a/src/caselawclient/models/documents/metadata/base.py
+++ b/src/caselawclient/models/documents/metadata/base.py
@@ -66,8 +66,7 @@ class Metadata(ABC):
             normalised = value.normalised()
             if normalised is None:
                 continue
-            if self.document.metadata_fields.has_claim(self.key, normalised, MetadataSource.DOCUMENT):
-                continue
+            # Idempotent ``add`` noops when an equivalent DOCUMENT claim exists.
             self.document.metadata_fields.add(
                 MetadataField(
                     name=self.key,

--- a/src/caselawclient/models/documents/metadata/fields/collection.py
+++ b/src/caselawclient/models/documents/metadata/fields/collection.py
@@ -1,20 +1,65 @@
+from enum import Enum
+
 from lxml import etree
 
 from caselawclient.models.documents.metadata.fields.exceptions import (
+    MetadataFieldEmptyValueException,
+    MetadataFieldIdCollisionException,
+    MetadataFieldKeyMismatchException,
     MetadataFieldRemovalNotAllowedException,
 )
 from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
 from caselawclient.models.documents.metadata.fields.resolution import ResolvedMetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
-from caselawclient.types import SuccessFailureMessageTuple
 from caselawclient.xml_helpers import Element
+
+
+class MetadataFieldAddResult(Enum):
+    """Outcome of ``MetadataFieldsCollection.add``."""
+
+    ADDED = "added"
+    ALREADY_PRESENT = "already_present"
 
 
 class MetadataFieldsCollection(dict[str, MetadataField]):
     """Collection of metadata claims keyed by claim id."""
 
-    def add(self, field: MetadataField) -> None:
-        self[field.id] = field
+    def add(self, field: MetadataField) -> MetadataFieldAddResult:
+        """Insert ``field``, or noop if an equivalent claim already exists.
+
+        Equivalence is ``name`` + ``value`` + ``source`` (``rejected`` is ignored,
+        so matching a rejected claim does not revive it). Empty values raise.
+        A reused id with a different payload raises
+        ``MetadataFieldIdCollisionException``.
+
+        Loading via unpack also goes through ``add``, so duplicate stored claims
+        with the same equivalence key are deduped on load.
+        """
+        if field.value.normalised() is None:
+            raise MetadataFieldEmptyValueException(f"Cannot add metadata claim '{field.name}': value is empty")
+
+        existing_by_id = self.get(field.id)
+        if existing_by_id is not None:
+            if self._same_payload(existing_by_id, field):
+                return MetadataFieldAddResult.ALREADY_PRESENT
+            raise MetadataFieldIdCollisionException(
+                f"Metadata claim id {field.id} already exists with a different payload"
+            )
+
+        if self.has_claim(field.name, field.value, field.source):
+            return MetadataFieldAddResult.ALREADY_PRESENT
+
+        dict.__setitem__(self, field.id, field)
+        return MetadataFieldAddResult.ADDED
+
+    @staticmethod
+    def _same_payload(existing: MetadataField, field: MetadataField) -> bool:
+        return existing.name == field.name and existing.value == field.value and existing.source is field.source
+
+    def __setitem__(self, key: str, field: MetadataField) -> None:
+        if key != field.id:
+            raise MetadataFieldKeyMismatchException(f"Collection key {key!r} does not match claim id {field.id!r}")
+        self.add(field)
 
     def by_name(self, name: str) -> list[MetadataField]:
         return [field for field in self.values() if field.name == name]
@@ -55,12 +100,3 @@ class MetadataFieldsCollection(dict[str, MetadataField]):
         for field in self.values():
             root.append(field.as_etree)
         return root
-
-    def validate_ids_match_keys(self) -> SuccessFailureMessageTuple:
-        for key, field in self.items():
-            if key != field.id:
-                return SuccessFailureMessageTuple(
-                    False,
-                    [f"Key of {field} in MetadataFieldsCollection is {key} not {field.id}"],
-                )
-        return SuccessFailureMessageTuple(True, [])

--- a/src/caselawclient/models/documents/metadata/fields/collection.py
+++ b/src/caselawclient/models/documents/metadata/fields/collection.py
@@ -11,6 +11,7 @@ from caselawclient.models.documents.metadata.fields.exceptions import (
 from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataFieldValue
 from caselawclient.models.documents.metadata.fields.resolution import ResolvedMetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
+from caselawclient.models.documents.metadata.registry import metadata_class_for_key
 from caselawclient.xml_helpers import Element
 
 
@@ -28,13 +29,19 @@ class MetadataFieldsCollection(dict[str, MetadataField]):
         """Insert ``field``, or noop if an equivalent claim already exists.
 
         Equivalence is ``name`` + ``value`` + ``source`` (``rejected`` is ignored,
-        so matching a rejected claim does not revive it). Empty values raise.
+        so matching a rejected claim does not revive it). Unknown claim names and
+        wrong value types raise ``TypeError``. Empty values raise.
         A reused id with a different payload raises
         ``MetadataFieldIdCollisionException``.
 
         Loading via unpack also goes through ``add``, so duplicate stored claims
         with the same equivalence key are deduped on load.
         """
+        metadata_cls = metadata_class_for_key(field.name)
+        if metadata_cls is None:
+            raise TypeError(f"Unknown metadata claim name '{field.name}'")
+        metadata_cls.validate_value(field.value)
+
         if field.value.normalised() is None:
             raise MetadataFieldEmptyValueException(f"Cannot add metadata claim '{field.name}': value is empty")
 

--- a/src/caselawclient/models/documents/metadata/fields/exceptions.py
+++ b/src/caselawclient/models/documents/metadata/fields/exceptions.py
@@ -2,9 +2,21 @@ class InvalidMetadataFieldXMLRepresentationException(Exception):
     """Raised when a metadata field cannot be unpacked from XML."""
 
 
-class MetadataFieldRemovalNotAllowedException(Exception):
+class MetadataFieldException(Exception):
+    """Base for metadata claim collection / mutation errors."""
+
+
+class MetadataFieldRemovalNotAllowedException(MetadataFieldException):
     """Raised when attempting to hard-remove a non-editor metadata claim."""
 
 
-class MetadataFieldValidationException(Exception):
-    """Raised when metadata fields fail validation before save."""
+class MetadataFieldIdCollisionException(MetadataFieldException):
+    """Raised when adding a claim whose id is already used by a different payload."""
+
+
+class MetadataFieldEmptyValueException(MetadataFieldException):
+    """Raised when adding a claim whose value is empty / non-resolving."""
+
+
+class MetadataFieldKeyMismatchException(MetadataFieldException):
+    """Raised when a collection key does not match the claim's id."""

--- a/src/caselawclient/models/documents/metadata/types/case_number.py
+++ b/src/caselawclient/models/documents/metadata/types/case_number.py
@@ -6,6 +6,7 @@ class CaseNumberMetadata(SingleMetadata[str | None]):
     key = "case_number"
     title = "Case Number"
     description = "The case number of the document."
+    LOGIC_VERSION = 2
 
     @property
     def value(self) -> str | None:

--- a/src/caselawclient/models/documents/metadata/types/categories.py
+++ b/src/caselawclient/models/documents/metadata/types/categories.py
@@ -64,6 +64,7 @@ class CategoriesMetadata(MultipleMetadata[DocumentCategory]):
     key = "categories"
     title = "Categories"
     description = "The categories assigned to the document."
+    LOGIC_VERSION = 2
 
     @property
     def values(self) -> list[DocumentCategory]:

--- a/src/caselawclient/models/documents/metadata/types/court.py
+++ b/src/caselawclient/models/documents/metadata/types/court.py
@@ -6,6 +6,7 @@ class CourtMetadata(SingleMetadata[str]):
     key = "court"
     title = "Court"
     description = "The court that issued the document."
+    LOGIC_VERSION = 2
 
     @property
     def value(self) -> str:

--- a/src/caselawclient/models/documents/metadata/types/date.py
+++ b/src/caselawclient/models/documents/metadata/types/date.py
@@ -20,6 +20,7 @@ class DateMetadata(SingleMetadata[datetime.date | None]):
     key = "date"
     title = "Date"
     description = "The date of the document."
+    LOGIC_VERSION = 2
 
     @property
     def value(self) -> datetime.date | None:

--- a/src/caselawclient/models/documents/metadata/types/judges.py
+++ b/src/caselawclient/models/documents/metadata/types/judges.py
@@ -28,6 +28,7 @@ class JudgesMetadata(MultipleMetadata[str]):
     title = "Judges"
     description = "A list of the names of the judges (or equivalent for the body) involved in any particular case."
     editable = True
+    LOGIC_VERSION = 2
 
     @property
     def values(self) -> list[str]:

--- a/src/caselawclient/models/documents/metadata/types/jurisdiction.py
+++ b/src/caselawclient/models/documents/metadata/types/jurisdiction.py
@@ -6,6 +6,7 @@ class JurisdictionMetadata(SingleMetadata[str]):
     key = "jurisdiction"
     title = "Jurisdiction"
     description = "The jurisdiction of the document."
+    LOGIC_VERSION = 2
 
     @property
     def value(self) -> str:

--- a/src/caselawclient/models/documents/metadata/types/name.py
+++ b/src/caselawclient/models/documents/metadata/types/name.py
@@ -6,6 +6,7 @@ class NameMetadata(SingleMetadata[str]):
     key = "title"
     title = "Title"
     description = "The title of the document."
+    LOGIC_VERSION = 2
 
     @property
     def value(self) -> str:

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -4,9 +4,16 @@ import pytest
 from lxml import etree
 
 from caselawclient.models.documents.metadata.base import Metadata
-from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
+from caselawclient.models.documents.metadata.fields.collection import (
+    MetadataFieldAddResult,
+    MetadataFieldsCollection,
+)
 from caselawclient.models.documents.metadata.fields.exceptions import (
     InvalidMetadataFieldXMLRepresentationException,
+    MetadataFieldEmptyValueException,
+    MetadataFieldException,
+    MetadataFieldIdCollisionException,
+    MetadataFieldKeyMismatchException,
     MetadataFieldRemovalNotAllowedException,
 )
 from caselawclient.models.documents.metadata.fields.field import (
@@ -613,3 +620,257 @@ class TestMetadataFieldsMutation:
             collection.remove(field.id)
 
         assert field.id in collection
+
+
+class TestMetadataFieldsIdempotentAdd:
+    def test_add_same_payload_different_ids_is_noop(self):
+        collection = MetadataFieldsCollection()
+        first = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        second = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            timestamp=LATE_TIMESTAMP,
+        )
+        assert collection.add(first) is MetadataFieldAddResult.ADDED
+        assert collection.add(second) is MetadataFieldAddResult.ALREADY_PRESENT
+
+        assert list(collection.keys()) == [first.id]
+        assert collection[first.id].timestamp == EARLY_TIMESTAMP
+
+    def test_add_same_id_same_payload_is_noop(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        assert collection.add(field) is MetadataFieldAddResult.ADDED
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Same"),
+                    source=MetadataSource.EXTERNAL,
+                    id=field.id,
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert collection[field.id].timestamp == EARLY_TIMESTAMP
+
+    def test_add_same_id_different_payload_raises(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("One"),
+                source=MetadataSource.EXTERNAL,
+                id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        with pytest.raises(MetadataFieldIdCollisionException, match="already exists"):
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Two"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+
+    def test_add_matching_rejected_claim_is_noop(self):
+        collection = MetadataFieldsCollection()
+        rejected = MetadataField(
+            name="title",
+            value=MetadataStringValue("Kept"),
+            source=MetadataSource.DOCUMENT,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+            rejected=True,
+        )
+        collection.add(rejected)
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Kept"),
+                    source=MetadataSource.DOCUMENT,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert list(collection.keys()) == [rejected.id]
+        assert collection[rejected.id].rejected is True
+
+    def test_add_same_id_does_not_flip_rejected(self):
+        collection = MetadataFieldsCollection()
+        field_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("Kept"),
+                source=MetadataSource.DOCUMENT,
+                id=field_id,
+                timestamp=EARLY_TIMESTAMP,
+                rejected=True,
+            )
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Kept"),
+                    source=MetadataSource.DOCUMENT,
+                    id=field_id,
+                    timestamp=LATE_TIMESTAMP,
+                    rejected=False,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert collection[field_id].rejected is True
+
+    def test_add_equivalent_string_value_is_noop(self):
+        collection = MetadataFieldsCollection()
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Title"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("  Title  "),
+                    source=MetadataSource.EXTERNAL,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert list(collection.keys()) == ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
+
+    def test_add_empty_string_value_raises(self):
+        collection = MetadataFieldsCollection()
+        with pytest.raises(MetadataFieldEmptyValueException, match="empty"):
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("   "),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+
+    def test_different_sources_same_value_are_both_kept(self):
+        collection = MetadataFieldsCollection()
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Shared"),
+                    source=MetadataSource.DOCUMENT,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Shared"),
+                    source=MetadataSource.EXTERNAL,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+
+        assert set(collection.keys()) == {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        }
+        assert collection.resolve("title").value == MetadataStringValue("Shared")
+        assert collection.resolve("title").winning_source is MetadataSource.EXTERNAL
+
+    def test_setitem_routes_through_add(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("Via setitem"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        collection[field.id] = field
+        assert collection[field.id].value == MetadataStringValue("Via setitem")
+
+    def test_setitem_key_mismatch_raises(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("X"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        with pytest.raises(MetadataFieldKeyMismatchException, match="does not match claim id"):
+            collection["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"] = field
+
+    def test_setitem_colliding_different_payload_raises(self):
+        collection = MetadataFieldsCollection()
+        field_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("One"),
+                source=MetadataSource.EXTERNAL,
+                id=field_id,
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        with pytest.raises(MetadataFieldIdCollisionException):
+            collection[field_id] = MetadataField(
+                name="title",
+                value=MetadataStringValue("Two"),
+                source=MetadataSource.EXTERNAL,
+                id=field_id,
+                timestamp=LATE_TIMESTAMP,
+            )
+
+    def test_add_exceptions_share_base_type(self):
+        assert issubclass(MetadataFieldEmptyValueException, MetadataFieldException)
+        assert issubclass(MetadataFieldIdCollisionException, MetadataFieldException)
+        assert issubclass(MetadataFieldKeyMismatchException, MetadataFieldException)
+        assert issubclass(MetadataFieldRemovalNotAllowedException, MetadataFieldException)

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -792,6 +792,32 @@ class TestMetadataFieldsIdempotentAdd:
                 )
             )
 
+    def test_add_wrong_value_type_raises(self):
+        collection = MetadataFieldsCollection()
+        with pytest.raises(TypeError, match="Expected MetadataStringValue for 'title'"):
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataCategoryValue(name="Not a title"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+
+    def test_add_unknown_claim_name_raises(self):
+        collection = MetadataFieldsCollection()
+        with pytest.raises(TypeError, match="Unknown metadata claim name"):
+            collection.add(
+                MetadataField(
+                    name="not_a_real_field",
+                    value=MetadataStringValue("X"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+
     def test_different_sources_same_value_are_both_kept(self):
         collection = MetadataFieldsCollection()
         assert (

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -4,9 +4,16 @@ import pytest
 from lxml import etree
 
 from caselawclient.models.documents.metadata.base import Metadata
-from caselawclient.models.documents.metadata.fields.collection import MetadataFieldsCollection
+from caselawclient.models.documents.metadata.fields.collection import (
+    MetadataFieldAddResult,
+    MetadataFieldsCollection,
+)
 from caselawclient.models.documents.metadata.fields.exceptions import (
     InvalidMetadataFieldXMLRepresentationException,
+    MetadataFieldEmptyValueException,
+    MetadataFieldException,
+    MetadataFieldIdCollisionException,
+    MetadataFieldKeyMismatchException,
     MetadataFieldRemovalNotAllowedException,
 )
 from caselawclient.models.documents.metadata.fields.field import (
@@ -615,3 +622,257 @@ class TestMetadataFieldsMutation:
             collection.remove(field.id)
 
         assert field.id in collection
+
+
+class TestMetadataFieldsIdempotentAdd:
+    def test_add_same_payload_different_ids_is_noop(self):
+        collection = MetadataFieldsCollection()
+        first = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        second = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            timestamp=LATE_TIMESTAMP,
+        )
+        assert collection.add(first) is MetadataFieldAddResult.ADDED
+        assert collection.add(second) is MetadataFieldAddResult.ALREADY_PRESENT
+
+        assert list(collection.keys()) == [first.id]
+        assert collection[first.id].timestamp == EARLY_TIMESTAMP
+
+    def test_add_same_id_same_payload_is_noop(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("Same"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        assert collection.add(field) is MetadataFieldAddResult.ADDED
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Same"),
+                    source=MetadataSource.EXTERNAL,
+                    id=field.id,
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert collection[field.id].timestamp == EARLY_TIMESTAMP
+
+    def test_add_same_id_different_payload_raises(self):
+        collection = MetadataFieldsCollection()
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("One"),
+                source=MetadataSource.EXTERNAL,
+                id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        with pytest.raises(MetadataFieldIdCollisionException, match="already exists"):
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Two"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+
+    def test_add_matching_rejected_claim_is_noop(self):
+        collection = MetadataFieldsCollection()
+        rejected = MetadataField(
+            name="title",
+            value=MetadataStringValue("Kept"),
+            source=MetadataSource.DOCUMENT,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+            rejected=True,
+        )
+        collection.add(rejected)
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Kept"),
+                    source=MetadataSource.DOCUMENT,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert list(collection.keys()) == [rejected.id]
+        assert collection[rejected.id].rejected is True
+
+    def test_add_same_id_does_not_flip_rejected(self):
+        collection = MetadataFieldsCollection()
+        field_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("Kept"),
+                source=MetadataSource.DOCUMENT,
+                id=field_id,
+                timestamp=EARLY_TIMESTAMP,
+                rejected=True,
+            )
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Kept"),
+                    source=MetadataSource.DOCUMENT,
+                    id=field_id,
+                    timestamp=LATE_TIMESTAMP,
+                    rejected=False,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert collection[field_id].rejected is True
+
+    def test_add_equivalent_string_value_is_noop(self):
+        collection = MetadataFieldsCollection()
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Title"),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("  Title  "),
+                    source=MetadataSource.EXTERNAL,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert list(collection.keys()) == ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]
+
+    def test_add_empty_string_value_raises(self):
+        collection = MetadataFieldsCollection()
+        with pytest.raises(MetadataFieldEmptyValueException, match="empty"):
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("   "),
+                    source=MetadataSource.EXTERNAL,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+
+    def test_different_sources_same_value_are_both_kept(self):
+        collection = MetadataFieldsCollection()
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Shared"),
+                    source=MetadataSource.DOCUMENT,
+                    id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    timestamp=EARLY_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            collection.add(
+                MetadataField(
+                    name="title",
+                    value=MetadataStringValue("Shared"),
+                    source=MetadataSource.EXTERNAL,
+                    id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    timestamp=LATE_TIMESTAMP,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+
+        assert set(collection.keys()) == {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        }
+        assert collection.resolve("title").value == MetadataStringValue("Shared")
+        assert collection.resolve("title").winning_source is MetadataSource.EXTERNAL
+
+    def test_setitem_routes_through_add(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("Via setitem"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        collection[field.id] = field
+        assert collection[field.id].value == MetadataStringValue("Via setitem")
+
+    def test_setitem_key_mismatch_raises(self):
+        collection = MetadataFieldsCollection()
+        field = MetadataField(
+            name="title",
+            value=MetadataStringValue("X"),
+            source=MetadataSource.EXTERNAL,
+            id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        with pytest.raises(MetadataFieldKeyMismatchException, match="does not match claim id"):
+            collection["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"] = field
+
+    def test_setitem_colliding_different_payload_raises(self):
+        collection = MetadataFieldsCollection()
+        field_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        collection.add(
+            MetadataField(
+                name="title",
+                value=MetadataStringValue("One"),
+                source=MetadataSource.EXTERNAL,
+                id=field_id,
+                timestamp=EARLY_TIMESTAMP,
+            )
+        )
+        with pytest.raises(MetadataFieldIdCollisionException):
+            collection[field_id] = MetadataField(
+                name="title",
+                value=MetadataStringValue("Two"),
+                source=MetadataSource.EXTERNAL,
+                id=field_id,
+                timestamp=LATE_TIMESTAMP,
+            )
+
+    def test_add_exceptions_share_base_type(self):
+        assert issubclass(MetadataFieldEmptyValueException, MetadataFieldException)
+        assert issubclass(MetadataFieldIdCollisionException, MetadataFieldException)
+        assert issubclass(MetadataFieldKeyMismatchException, MetadataFieldException)
+        assert issubclass(MetadataFieldRemovalNotAllowedException, MetadataFieldException)

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -9,6 +9,7 @@ class _TestSingleMetadata(SingleMetadata[str]):
     key = "test_single"
     title = "Test Single"
     description = "A test single metadata item."
+    LOGIC_VERSION = 1
 
     @property
     def value(self) -> str:
@@ -19,6 +20,7 @@ class _TestMultipleMetadata(MultipleMetadata[str]):
     key = "test_multiple"
     title = "Test Multiple"
     description = "A test multiple metadata item."
+    LOGIC_VERSION = 1
 
     @property
     def values(self) -> list[str]:
@@ -59,6 +61,18 @@ class TestMetadataBase:
         metadata = _EditableMetadata(Mock())
 
         assert metadata.editable is True
+
+    def test_concrete_metadata_must_define_logic_version(self):
+        with pytest.raises(TypeError, match="must define LOGIC_VERSION"):
+
+            class _MissingLogicVersion(SingleMetadata[str]):
+                key = "missing_logic"
+                title = "Missing"
+                description = "Should fail."
+
+                @property
+                def value(self) -> str:
+                    return "x"
 
 
 class TestNameMetadata:

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -5,7 +5,6 @@ import pytest
 from lxml import etree
 
 from caselawclient.factories import DocumentFactory
-from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
 from caselawclient.models.documents.metadata.fields.field import (
     MetadataCategoryValue,
     MetadataDateValue,
@@ -14,7 +13,6 @@ from caselawclient.models.documents.metadata.fields.field import (
 )
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.fields.unpacker import unpack_all_metadata_fields_from_etree
-from caselawclient.types import SuccessFailureMessageTuple
 
 TIMESTAMP = datetime(2025, 12, 17, 18, 0, 0, tzinfo=UTC)
 
@@ -71,40 +69,6 @@ class TestDocumentMetadataFieldsLoadSave:
         assert uri == document.uri
         assert property_name == "metadata_fields"
         assert unpack_all_metadata_fields_from_etree(tree).resolve("title").value == MetadataStringValue("Saved title")
-
-    def test_validate_metadata_fields_returns_success_failure_tuple(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-        field = MetadataField(
-            name="title",
-            value=MetadataStringValue("Saved title"),
-            source=MetadataSource.EDITOR,
-            id=_id(),
-            timestamp=TIMESTAMP,
-        )
-        document.metadata_fields["wrong-key"] = field
-
-        result = document.validate_metadata_fields()
-
-        assert result == SuccessFailureMessageTuple(
-            False,
-            [f"Key of {field} in MetadataFieldsCollection is wrong-key not {field.id}"],
-        )
-
-    def test_save_metadata_fields_rejects_mismatched_keys(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
-        field = MetadataField(
-            name="title",
-            value=MetadataStringValue("Saved title"),
-            source=MetadataSource.EDITOR,
-            id=_id(),
-            timestamp=TIMESTAMP,
-        )
-        document.metadata_fields["wrong-key"] = field
-
-        with pytest.raises(MetadataFieldValidationException, match="wrong-key"):
-            document.save_metadata_fields()
-
-        mock_api_client.set_property_as_node.assert_not_called()
 
 
 class TestDocumentMetadataFacadePrefersFields:

--- a/tests/models/documents/test_document_metadata_fields.py
+++ b/tests/models/documents/test_document_metadata_fields.py
@@ -245,17 +245,16 @@ class TestDocumentMetadataFacadePrefersFields:
 
     def test_date_facade_rejects_non_date_claim_value(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
-        document.metadata_fields.add(
-            MetadataField(
-                name="date",
-                value=MetadataStringValue("2024-06-15"),
-                source=MetadataSource.EXTERNAL,
-                id=_id(),
-                timestamp=TIMESTAMP,
-            )
-        )
         with pytest.raises(TypeError, match="Expected MetadataDateValue for 'date'"):
-            _ = document.metadata.date.value
+            document.metadata_fields.add(
+                MetadataField(
+                    name="date",
+                    value=MetadataStringValue("2024-06-15"),
+                    source=MetadataSource.EXTERNAL,
+                    id=_id(),
+                    timestamp=TIMESTAMP,
+                )
+            )
 
     def test_date_rejects_string_value_on_pack(self, mock_api_client):
         field = MetadataField(
@@ -319,9 +318,8 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'case_number'"):
             _ = field.as_etree
-        document.metadata_fields.add(field)
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'case_number'"):
-            _ = document.metadata.case_number.value
+            document.metadata_fields.add(field)
 
     def test_court_prefers_metadata_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -373,9 +371,8 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'court'"):
             _ = field.as_etree
-        document.metadata_fields.add(field)
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'court'"):
-            _ = document.metadata.court.value
+            document.metadata_fields.add(field)
 
     def test_jurisdiction_prefers_metadata_fields(self, mock_api_client):
         from caselawclient.factories import DocumentBodyFactory
@@ -427,9 +424,8 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'jurisdiction'"):
             _ = field.as_etree
-        document.metadata_fields.add(field)
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'jurisdiction'"):
-            _ = document.metadata.jurisdiction.value
+            document.metadata_fields.add(field)
 
     def test_title_non_string_value_raises(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)
@@ -442,9 +438,8 @@ class TestDocumentMetadataFacadePrefersFields:
         )
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'title'"):
             _ = field.as_etree
-        document.metadata_fields.add(field)
         with pytest.raises(TypeError, match="Expected MetadataStringValue for 'title'"):
-            _ = document.metadata.title.value
+            document.metadata_fields.add(field)
 
     def test_categories_orphan_child_without_parent_claim_is_omitted(self, mock_api_client):
         document = DocumentFactory.build(api_client=mock_api_client)

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -9,7 +9,7 @@ import pytest
 from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
 from caselawclient.models.documents.exceptions import DocumentAlreadyExistsError, DocumentNotPersistedError
-from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
+from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldKeyMismatchException
 from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataStringValue
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
@@ -218,24 +218,19 @@ class TestDocumentSave:
         with pytest.raises(DocumentAlreadyExistsError, match="already exists"):
             document.save(message="Initial insert")
 
-    def test_save_rejects_mismatched_metadata_field_keys_before_insert(self, mock_api_client):
+    def test_metadata_fields_reject_mismatched_keys_on_assignment(self, mock_api_client):
         document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
         field_id = str(uuid4())
-        document.metadata_fields["wrong-key"] = MetadataField(
-            name="title",
-            value=MetadataStringValue("Bad key"),
-            source=MetadataSource.EDITOR,
-            id=field_id,
-            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
-        )
 
-        with (
-            patch.object(document.api_client, "insert_document_xml") as mock_insert,
-            pytest.raises(MetadataFieldValidationException, match="wrong-key"),
-        ):
-            document.save(message="Initial insert")
+        with pytest.raises(MetadataFieldKeyMismatchException, match="wrong-key"):
+            document.metadata_fields["wrong-key"] = MetadataField(
+                name="title",
+                value=MetadataStringValue("Bad key"),
+                source=MetadataSource.EDITOR,
+                id=field_id,
+                timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+            )
 
-        mock_insert.assert_not_called()
         assert document.is_persisted is False
 
     def test_is_persisted_false_after_from_xml(self, mock_api_client):


### PR DESCRIPTION
- Idempotent `metadata_fields.add`: matching name/value/source is already present (including rejected; no revive); id collision / empty value / key–id mismatch raise
- Returns `MetadataFieldAddResult.ADDED` or `ALREADY_PRESENT`
- Collection errors subclass `MetadataFieldException`
- `__setitem__` routes through `add`; unpack dedupes via the same path
- Removed dead `validate_metadata_fields` / key–id save validation

## Jira

FCLC-2359