### PR TITLE
FCLC-2261 | use highlight function to correctly wrap whole search que…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
+## Unreleased
+
+### Fix
+
+- Wrap query text with multiple words in a single <mark> tag, rather than each individual text in it's own mark tag
+
 ## v49.1.1 (2026-08-13)
 
 ### Fix

--- a/src/caselawclient/xquery/get_judgment.xqy
+++ b/src/caselawclient/xquery/get_judgment.xqy
@@ -49,8 +49,8 @@ let $transformed := if($search_query) then
         $delete_meta_marks_xslt,
         cts:highlight(
           $raw_xml,
-          helper:make-q-query($search_query),
-          <uk:mark>{$cts:text}</uk:mark>
+          helper:make-highlight-query($search_query),
+          if ($cts:text ne "") then <uk:mark>{$cts:text}</uk:mark> else ()
         )
       )
     else


### PR DESCRIPTION
…ry in mark tag

This uses a function in the marklogic repo to format the query text so that we then keep the whole query within the mark, rather than splitting each separate word into a separate mark.

Related PR here: https://github.com/nationalarchives/ds-caselaw-marklogic/pull/724

## Jira

https://national-archives.atlassian.net/browse/FCLC-2261

FCL-

## Checklist

- [ ] I have written tests to cover the new behaviour
- [ ] I have created/updated method docstrings (if necessary)
- [ ] I have considered if this is a breaking change
