### PR TITLE
FCLC-2355: Initialise document objects from XML and upsert save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,25 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ### BREAKING CHANGE
 
+- `Document.save()` on a URI that does not yet exist in MarkLogic now inserts the document instead of failing on update
 - Use document.metadata.title / .judges (etc), not
   metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
   values/in. Legacy name/judge keys are gone.
 
 ### Feat
 
+- **Document**: add `Document.from_xml()` for in-memory construction from parser XML without MarkLogic
+- **Document**: upsert `save()` with `version_type` and `automated` parameters
+- **Document**: add `document_from_xml()` helper and `mint_document_uri()`
+- **Document**: guard MarkLogic-backed APIs until `save()` completes (`DocumentNotPersistedError`)
+- **Document**: reject `from_xml()` for URIs that already exist in MarkLogic (`DocumentAlreadyExistsError`)
+- **Document**: validate identifier and metadata field IDs before upserting document XML during `save()`
+- **Document**: persist identifiers and structured metadata properties after upserting document XML during `save()`
 - **Metadata**: expose DocumentMetadata as typed attribute facades
 
 ### Fix
 
+- Fix `Judgment` and `PressSummary` constructors to pass `api_client` explicitly through `NeutralCitationMixin`
 - Wrap query text with multiple words in a single <mark> tag, rather than each individual text in it's own mark tag
 
 ### Refactor

--- a/src/caselawclient/Client.py
+++ b/src/caselawclient/Client.py
@@ -598,6 +598,10 @@ class MarklogicApiClient:
         """
         Insert a new XML document into MarkLogic.
 
+        .. deprecated::
+            Prefer ``Document.from_xml(...).save(...)`` for document lifecycle workflows.
+            This method remains available for internal use by ``Document.save()``.
+
         :param document_uri: The URI to insert the document at
         :param document_xml: The XML of the document to insert
         :param document_type: The type class of the document
@@ -631,6 +635,10 @@ class MarklogicApiClient:
         Updates an existing XML document in MarkLogic with a new version.
 
         This uses `dls:document-checkout-update-checkin` to perform this in a single operation.
+
+        .. deprecated::
+            Prefer ``Document.save(...)`` for document lifecycle workflows.
+            This method remains available for internal use by ``Document.save()``.
 
         :param document_uri: The URI of the document to update
         :param document_xml: The new XML content of the document

--- a/src/caselawclient/client_helpers/__init__.py
+++ b/src/caselawclient/client_helpers/__init__.py
@@ -1,11 +1,18 @@
+from typing import TYPE_CHECKING, cast
+
 from lxml import etree
 
+from caselawclient.models.documents.body import DocumentBody
+from caselawclient.types import DocumentURIString
 from caselawclient.xml_helpers import DEFAULT_NAMESPACES
 
 from ..models.documents import Document
 from ..models.judgments import Judgment
 from ..models.parser_logs import ParserLog
 from ..models.press_summaries import PressSummary
+
+if TYPE_CHECKING:
+    from caselawclient.Client import MarklogicApiClient
 
 
 class CannotDetermineDocumentType(Exception):
@@ -33,3 +40,13 @@ def get_document_type_class(xml: bytes) -> type[Document]:
     raise CannotDetermineDocumentType(
         "Unable to determine the Document type by its XML",
     )
+
+
+def document_from_xml(
+    body: DocumentBody,
+    api_client: "MarklogicApiClient",
+    uri: DocumentURIString | None = None,
+) -> Judgment | PressSummary | ParserLog:
+    """Construct a concrete document from XML, detecting the document type automatically."""
+    cls = get_document_type_class(body.content_as_xml.encode("utf-8"))
+    return cast("Judgment | PressSummary | ParserLog", cls.from_xml(body, api_client, uri=uri))

--- a/src/caselawclient/factories.py
+++ b/src/caselawclient/factories.py
@@ -116,15 +116,18 @@ class DocumentFactory:
 
         if not api_client:
             api_client = Mock(spec=MarklogicApiClient)
-            api_client.get_judgment_xml_bytestring.return_value = build_document_body_xml().encode(encoding="utf-8")
             api_client.get_property_as_node.return_value = None
 
-        document = cls.TargetClass(uri, api_client=api_client)
-        document.body = kwargs.pop("body") if "body" in kwargs else DocumentBodyFactory.build()
+        body = kwargs.pop("body") if "body" in kwargs else DocumentBodyFactory.build()
+        document = cls.TargetClass._assemble_from_body(body, api_client, uri=uri)  # noqa: SLF001
+        document._initialise_metadata_fields()  # noqa: SLF001
+        document._persisted = True  # noqa: SLF001
 
         if identifiers is None:
+            document.identifiers = IdentifiersCollection()
             document.identifiers.add(FindCaseLawIdentifier(value="tn4t35ts"))
         else:
+            document.identifiers = IdentifiersCollection()
             for identifier in identifiers:
                 document.identifiers.add(identifier)
 

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 import warnings
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Self
 
 from ds_caselaw_utils import courts
 from ds_caselaw_utils.courts import CourtNotFoundException
@@ -32,9 +32,11 @@ from caselawclient.models.documents.metadata.registry import (
 )
 from caselawclient.models.documents.versions import AnnotationDataDict, VersionAnnotation, VersionType
 from caselawclient.models.identifiers import Identifier
+from caselawclient.models.identifiers.collection import IdentifiersCollection
 from caselawclient.models.identifiers.exceptions import IdentifierValidationException
 from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier, FindCaseLawIdentifierSchema
 from caselawclient.models.identifiers.unpacker import unpack_all_identifiers_from_etree
+from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 from caselawclient.models.utilities import VersionsDict, extract_version, render_versions
 from caselawclient.models.utilities.aws import (
     ParserInstructionsDict,
@@ -49,7 +51,7 @@ from caselawclient.models.utilities.aws import (
     restore_assets_from_consignment_archive,
     unpublish_documents,
 )
-from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple, TDRMetadataDict
+from caselawclient.types import DocumentURIString, SuccessFailureMessageTuple, TDRMetadataDict, mint_document_uri
 
 from .body import DocumentBody
 from .exceptions import (
@@ -57,6 +59,8 @@ from .exceptions import (
     CannotPublishUnpublishableDocument,
     CannotRestoreDocumentWithoutConsignmentReference,
     CannotRestorePublishedDocument,
+    DocumentAlreadyExistsError,
+    DocumentNotPersistedError,
     DocumentNotSafeForDeletion,
 )
 from .statuses import DOCUMENT_STATUS_HOLD, DOCUMENT_STATUS_IN_PROGRESS, DOCUMENT_STATUS_NEW, DOCUMENT_STATUS_PUBLISHED
@@ -167,6 +171,52 @@ class Document:
         self._initialise_identifiers()
         self._initialise_metadata_fields()
         self._initialise_metadata()
+        self._persisted = True
+
+    @property
+    def is_persisted(self) -> bool:
+        return self._persisted
+
+    def _require_persisted(self) -> None:
+        if not self._persisted:
+            raise DocumentNotPersistedError(
+                f"Document {self.uri} is not persisted in MarkLogic; call save() before using MarkLogic-backed APIs."
+            )
+
+    @classmethod
+    def _assemble_from_body(
+        cls,
+        body: DocumentBody,
+        api_client: "MarklogicApiClient",
+        uri: DocumentURIString | None = None,
+    ) -> Self:
+        doc = cls.__new__(cls)
+        doc.uri = uri if uri is not None else mint_document_uri()
+        doc.api_client = api_client
+        doc.body = body
+        doc.identifiers = IdentifiersCollection()
+        doc.metadata_fields = MetadataFieldsCollection()
+        doc._initialise_metadata()  # noqa: SLF001
+        doc._persisted = False  # noqa: SLF001
+        if isinstance(doc, NeutralCitationMixin):
+            doc._initialise_neutral_citation_validation(cls.document_noun)  # noqa: SLF001
+        return doc
+
+    @classmethod
+    def from_xml(
+        cls,
+        body: DocumentBody,
+        api_client: "MarklogicApiClient",
+        uri: DocumentURIString | None = None,
+    ) -> Self:
+        if cls is Document:
+            raise TypeError("Use Judgment.from_xml, PressSummary.from_xml, ParserLog.from_xml, or document_from_xml().")
+        resolved_uri = uri if uri is not None else mint_document_uri()
+        if api_client.document_exists(resolved_uri):
+            raise DocumentAlreadyExistsError(
+                f"Document {resolved_uri} already exists; load it with {cls.__name__}(uri, api_client) instead."
+            )
+        return cls._assemble_from_body(body, api_client, uri=resolved_uri)
 
     def __repr__(self) -> str:
         name = self.metadata.title.value or "un-named"
@@ -180,6 +230,7 @@ class Document:
 
     def docx_exists(self) -> bool:
         """There is a docx in S3 private bucket for this Document"""
+        self._require_persisted()
         return check_docx_exists(self.uri)
 
     def _initialise_document_body(self, search_query: str | None = None) -> None:
@@ -249,10 +300,12 @@ class Document:
 
     @cached_property
     def is_published(self) -> bool:
+        self._require_persisted()
         return self.api_client.get_published(self.uri)
 
     @cached_property
     def is_held(self) -> bool:
+        self._require_persisted()
         return self.api_client.get_property(self.uri, "editor-hold") == "true"
 
     @cached_property
@@ -261,18 +314,22 @@ class Document:
 
     @cached_property
     def checkout_message(self) -> str | None:
+        self._require_persisted()
         return self.api_client.get_judgment_checkout_status_message(self.uri)
 
     @cached_property
     def source_name(self) -> str:
+        self._require_persisted()
         return self.api_client.get_property(self.uri, "source-name")
 
     @cached_property
     def source_email(self) -> str:
+        self._require_persisted()
         return self.api_client.get_property(self.uri, "source-email")
 
     @cached_property
     def consignment_reference(self) -> str:
+        self._require_persisted()
         return self.api_client.get_property(self.uri, "transfer-consignment-reference")
 
     @property
@@ -287,10 +344,12 @@ class Document:
 
     @cached_property
     def assigned_to(self) -> str:
+        self._require_persisted()
         return self.api_client.get_property(self.uri, "assigned-to")
 
     @cached_property
     def versions(self) -> list[VersionsDict]:
+        self._require_persisted()
         versions_response = self.api_client.list_judgment_versions(self.uri)
 
         try:
@@ -309,6 +368,7 @@ class Document:
         Note that this is only valid on the managed document -- a `DLS-DOCUMENTVERSION` error will occur if the document
         this is called on is itself a version.
         """
+        self._require_persisted()
         if self.is_version:
             raise NotSupportedOnVersion(
                 f"Cannot get versions of a version for {self.uri}",
@@ -379,6 +439,7 @@ class Document:
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
         such cannot be published.
         """
+        self._require_persisted()
         if not self.is_publishable:
             raise CannotPublishUnpublishableDocument(
                 f"{self.document_noun.capitalize()} {self.uri} cannot be published due to the following issues: "
@@ -399,6 +460,7 @@ class Document:
                 reference is available to locate the document's S3 assets, so a
                 complete restore cannot be performed.
         """
+        self._require_persisted()
         if self.is_published:
             raise CannotRestorePublishedDocument(
                 f"{self.document_noun.capitalize()} {self.uri} cannot be restored because it is currently published.",
@@ -418,6 +480,7 @@ class Document:
 
         :return: The datetime value in the database for "first published".
         """
+        self._require_persisted()
         return self.api_client.get_datetime_property(self.uri, "first_published_datetime")
 
     @cached_property
@@ -429,6 +492,7 @@ class Document:
 
         :return: The datetime value to be displayed to end users for "first published".
         """
+        self._require_persisted()
 
         if self.first_published_datetime == datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc):
             return None
@@ -442,6 +506,7 @@ class Document:
 
         :return: The datetime value in the database for "latest published".
         """
+        self._require_persisted()
         return self.api_client.get_datetime_property(self.uri, "latest_published_datetime")
 
     @cached_property
@@ -453,6 +518,7 @@ class Document:
 
         :return: A boolean indicating if the document has ever been published.
         """
+        self._require_persisted()
         return self.is_published or self.first_published_datetime is not None
 
     @cached_property
@@ -465,10 +531,12 @@ class Document:
 
     @cached_property
     def annotation(self) -> str:
+        self._require_persisted()
         return self.api_client.get_version_annotation(self.uri)
 
     @cached_property
     def structured_annotation(self) -> AnnotationDataDict:
+        self._require_persisted()
         annotation_data_dict_loader = TypeAdapter(AnnotationDataDict)
 
         return annotation_data_dict_loader.validate_json(self.annotation)
@@ -476,6 +544,7 @@ class Document:
     @cached_property
     def has_unique_content_hash(self) -> bool:
         """Check if the content hash of this document is unique compared to all other documents in MarkLogic."""
+        self._require_persisted()
         return self.api_client.has_unique_content_hash(self.uri)
 
     @cached_property
@@ -486,10 +555,12 @@ class Document:
 
     @cached_property
     def version_created_datetime(self) -> datetime.datetime:
+        self._require_persisted()
         return self.api_client.get_version_created_datetime(self.uri)
 
     @property
     def status(self) -> str:
+        self._require_persisted()
         if self.is_published:
             return DOCUMENT_STATUS_PUBLISHED
 
@@ -505,6 +576,7 @@ class Document:
         """
         Request enrichment of the document, but do no checks
         """
+        self._require_persisted()
         now = datetime.datetime.now(datetime.timezone.utc)
         self.api_client.set_property(
             self.uri,
@@ -526,6 +598,7 @@ class Document:
         """
         Request enrichment of a document, if it's sensible to do so.
         """
+        self._require_persisted()
         if not (even_if_recent) and self.enriched_recently:
             logger.info("Enrichment not requested as document was enriched recently")
             return False
@@ -562,10 +635,12 @@ class Document:
         """
         Does the document validate against the most recent schema?
         """
+        self._require_persisted()
         return self.api_client.validate_document(self.uri)
 
     def assign_fclid_if_missing(self) -> FindCaseLawIdentifier | None:
         """If the document does not have an FCLID already, mint a new one and save it."""
+        self._require_persisted()
         if len(self.identifiers.of_type(FindCaseLawIdentifier)) == 0:
             logger.info("Document has no FCLID, minting a new one")
             document_fclid = FindCaseLawIdentifierSchema.mint(self.api_client)
@@ -578,45 +653,84 @@ class Document:
         logger.info("Document already has an FCLID")
         return None
 
-    def save(self, message: str) -> None:
+    def save(
+        self,
+        message: str,
+        *,
+        version_type: VersionType = VersionType.EDIT,
+        automated: bool = False,
+    ) -> None:
         """
         Save the document's XML representation back to MarkLogic as a new version.
 
-        Creates a new version with type EDIT, recording the changes made to the document.
-        Also materialises body-derived DOCUMENT metadata claims and persists them.
+        Inserts when this object is not yet persisted; otherwise updates the existing MarkLogic document.
+        Validates identifiers and metadata, converts body claims to structured metadata, upserts the
+        document XML, then saves identifier and metadata properties to MarkLogic.
 
         :param message: Human-readable message describing the changes made.
         """
-        # Create annotation for this version
+        if type(self) is Document:
+            raise TypeError("Use a concrete document class such as Judgment, PressSummary, or ParserLog to save.")
+
         annotation = VersionAnnotation(
-            version_type=VersionType.EDIT,
-            automated=False,
+            version_type=version_type,
+            automated=automated,
             message=message,
         )
 
-        # Update the document XML in MarkLogic
-        self.api_client.update_document_xml(
-            self.uri,
-            self.body.content_as_xml_tree,
-            annotation,
-        )
-        self.materialise_metadata_claims()
+        self._convert_body_claims_to_structured_metadata()
+        self._validate_metadata_for_save()
+        self._validate_identifiers_for_save()
+
+        if not self._persisted:
+            if self.document_exists():
+                raise DocumentAlreadyExistsError(
+                    f"Document {self.uri} already exists; load it with {type(self).__name__}(uri, api_client) instead."
+                )
+            self.api_client.insert_document_xml(
+                self.uri,
+                self.body.content_as_xml_tree,
+                type(self),
+                annotation,
+            )
+            self._persisted = True
+        else:
+            self.api_client.update_document_xml(
+                self.uri,
+                self.body.content_as_xml_tree,
+                annotation,
+            )
+
+        self._save_identifiers_to_marklogic()
+        self._save_structured_metadata_to_marklogic()
 
     @property
     def needs_metadata_materialisation(self) -> bool:
         """True if this document's stored materialisation version is missing or outdated."""
+        self._require_persisted()
         stored = self.api_client.get_property(self.uri, LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY)
         return document_needs_metadata_materialisation(stored or None)
 
-    def materialise_metadata_claims(self) -> None:
-        """Materialise body-derived DOCUMENT claims, persist metadata_fields, and stamp version.
-
-        Idempotent: existing DOCUMENT claims with the same value are not overwritten.
-        Safe to call from maintenance backfills as well as from ``save()``.
-        """
+    def _convert_body_claims_to_structured_metadata(self) -> None:
         for field in self.metadata:
             field.materialise_body_claims()
-        self.save_metadata_fields()
+
+    def _validate_metadata_for_save(self) -> None:
+        validations = self.metadata_fields.validate_ids_match_keys()
+        if validations.success is not True:
+            raise MetadataFieldValidationException(
+                "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
+            )
+
+    def _validate_identifiers_for_save(self) -> None:
+        validations = self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)
+        if validations.success is not True:
+            raise IdentifierValidationException(
+                "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
+            )
+
+    def _save_structured_metadata_to_marklogic(self) -> None:
+        self._save_metadata_fields()
         self.api_client.set_property(
             self.uri,
             LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
@@ -630,6 +744,7 @@ class Document:
         :raises CannotPublishUnpublishableDocument: This document has not passed the checks in `is_publishable`, and as
         such cannot be published.
         """
+        self._require_persisted()
         logger.debug("Assert that document is publishable")
         self.assert_is_publishable()
 
@@ -663,6 +778,7 @@ class Document:
         logger.info("Document publication complete")
 
     def unpublish(self) -> None:
+        self._require_persisted()
         self.api_client.break_checkout(self.uri)
         unpublish_documents(self.uri)
         self.api_client.set_published(self.uri, False)
@@ -672,9 +788,11 @@ class Document:
         )
 
     def hold(self) -> None:
+        self._require_persisted()
         self.api_client.set_property(self.uri, "editor-hold", "true")
 
     def unhold(self) -> None:
+        self._require_persisted()
         self.api_client.set_property(self.uri, "editor-hold", "false")
 
     @cached_property
@@ -684,6 +802,7 @@ class Document:
 
         :return: If the document is safe to be deleted
         """
+        self._require_persisted()
 
         return not self.is_published
 
@@ -691,6 +810,7 @@ class Document:
         """
         Deletes this document from MarkLogic and any resources from AWS.
         """
+        self._require_persisted()
 
         if self.safe_to_delete:
             self.api_client.delete_judgment(self.uri)
@@ -822,6 +942,7 @@ class Document:
                 consignment reference is available to locate the document's S3
                 assets.
         """
+        self._require_persisted()
         restore_version_document = self._get_version(version_number)
 
         if restore_version_document is None:
@@ -886,10 +1007,12 @@ class Document:
         self._initialise_document_body()
 
     def move(self, new_citation: NeutralCitationString) -> None:
+        self._require_persisted()
         self.api_client.update_document_uri(self.uri, new_citation)
 
     def force_reparse(self) -> None:
         "Send an SNS notification that triggers reparsing, also sending all editor-modifiable metadata and URI"
+        self._require_persisted()
 
         now = datetime.datetime.now(datetime.timezone.utc)
         self.api_client.set_property(self.uri, "last_sent_to_parser", now.isoformat())
@@ -928,6 +1051,7 @@ class Document:
         )
 
     def reparse(self) -> bool:
+        self._require_persisted()
         # note that we set 'last_sent_to_parser' even if we can't send it to the parser
         # it means 'last tried to reparse' much more consistently.
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -942,6 +1066,7 @@ class Document:
         """
         Is it sensible to reparse this document?
         """
+        self._require_persisted()
         return self.docx_exists() and not self.body.has_external_data
 
     @cached_property
@@ -952,30 +1077,30 @@ class Document:
         return self.body.has_content
 
     def validate_identifiers(self) -> SuccessFailureMessageTuple:
+        self._require_persisted()
         return self.identifiers.perform_all_validations(document_type=type(self), api_client=self.api_client)
 
     def save_identifiers(self) -> None:
         """Validate the identifiers, and if the validation passes save them to MarkLogic"""
-        validations = self.validate_identifiers()
-        if validations.success is True:
-            self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers.as_etree)
-        else:
-            raise IdentifierValidationException(
-                "Unable to save identifiers; validation constraints not met: " + ", ".join(validations.messages)
-            )
+        self._require_persisted()
+        self._validate_identifiers_for_save()
+        self._save_identifiers_to_marklogic()
+
+    def _save_identifiers_to_marklogic(self) -> None:
+        self.api_client.set_property_as_node(self.uri, "identifiers", self.identifiers.as_etree)
 
     def validate_metadata_fields(self) -> SuccessFailureMessageTuple:
+        self._require_persisted()
         return self.metadata_fields.validate_ids_match_keys()
 
     def save_metadata_fields(self) -> None:
         """Validate metadata fields, and if validation passes save them to MarkLogic."""
-        validations = self.validate_metadata_fields()
-        if validations.success is True:
-            self.api_client.set_property_as_node(self.uri, "metadata_fields", self.metadata_fields.as_etree)
-        else:
-            raise MetadataFieldValidationException(
-                "Unable to save metadata fields; validation constraints not met: " + ", ".join(validations.messages)
-            )
+        self._require_persisted()
+        self._validate_metadata_for_save()
+        self._save_metadata_fields()
+
+    def _save_metadata_fields(self) -> None:
+        self.api_client.set_property_as_node(self.uri, "metadata_fields", self.metadata_fields.as_etree)
 
     _METADATA_DEPRECATED_ATTRS: ClassVar[dict[str, tuple[str, str]]] = {
         "name": ("title", "value"),
@@ -1004,6 +1129,7 @@ class Document:
 
     def linked_document_resolutions(self, namespaces: list[str], only_published: bool = True) -> IdentifierResolutions:
         """Get document resolutions which share the same neutral citation as this document."""
+        self._require_persisted()
         if not hasattr(self, "neutral_citation") or not self.neutral_citation:
             return IdentifierResolutions([])
 
@@ -1021,6 +1147,7 @@ class Document:
         )
 
     def linked_documents(self, namespaces: list[str], only_published: bool = True) -> list["Document"]:
+        self._require_persisted()
         resolutions = self.linked_document_resolutions(namespaces=namespaces, only_published=only_published)
         return [
             Document(resolution.document_uri.as_document_uri(), api_client=self.api_client)

--- a/src/caselawclient/models/documents/exceptions.py
+++ b/src/caselawclient/models/documents/exceptions.py
@@ -20,3 +20,11 @@ class CannotEnrichUnenrichableDocument(Exception):
 
 class DocumentNotSafeForDeletion(Exception):
     """A document which is not safe for deletion cannot be deleted."""
+
+
+class DocumentNotPersistedError(Exception):
+    """A document constructed with from_xml must be saved before MarkLogic-backed operations are available."""
+
+
+class DocumentAlreadyExistsError(Exception):
+    """A document URI passed to from_xml already exists in MarkLogic."""

--- a/src/caselawclient/models/judgments.py
+++ b/src/caselawclient/models/judgments.py
@@ -1,6 +1,6 @@
 import importlib
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ds_caselaw_utils.types import NeutralCitationString
 
@@ -9,6 +9,7 @@ from caselawclient.identifier_resolution import IdentifierResolutions
 from caselawclient.models.neutral_citation_mixin import NeutralCitationMixin
 
 if TYPE_CHECKING:
+    from caselawclient.Client import MarklogicApiClient
     from caselawclient.models.press_summaries import PressSummary
 
 from caselawclient.types import DocumentURIString
@@ -26,8 +27,10 @@ class Judgment(NeutralCitationMixin, Document):
     type_collection_name = "judgment"
     _default_reparse_document_type = "judgment"
 
-    def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
-        super().__init__(self.document_noun, uri, *args, **kwargs)
+    def __init__(
+        self, uri: DocumentURIString, api_client: "MarklogicApiClient", search_query: str | None = None
+    ) -> None:
+        super().__init__(self.document_noun, uri, api_client, search_query=search_query)
 
     @cached_property
     def neutral_citation(self) -> NeutralCitationString | None:
@@ -41,6 +44,7 @@ class Judgment(NeutralCitationMixin, Document):
         """
         Attempt to fetch a linked press summary, and return it, if it exists
         """
+        self._require_persisted()
         try:
             uri = DocumentURIString(self.uri + "/press-summary/1")
             if not TYPE_CHECKING:  # This isn't nice, but will be cleaned up when we refactor how related documents work

--- a/src/caselawclient/models/neutral_citation_mixin.py
+++ b/src/caselawclient/models/neutral_citation_mixin.py
@@ -22,6 +22,10 @@ class NeutralCitationMixin(ABC):
     """
 
     def __init__(self, document_noun: str, *args: Any, **kwargs: Any) -> None:
+        self._initialise_neutral_citation_validation(document_noun)
+        super().__init__(*args, **kwargs)
+
+    def _initialise_neutral_citation_validation(self, document_noun: str) -> None:
         self.attributes_to_validate: list[tuple[str, bool, str]] = self.attributes_to_validate + [
             (
                 "has_valid_ncn",
@@ -29,8 +33,6 @@ class NeutralCitationMixin(ABC):
                 f"The neutral citation number of this {document_noun} is not valid",
             ),
         ]
-
-        super().__init__(*args, **kwargs)
 
     @cached_property
     @abstractmethod

--- a/src/caselawclient/models/press_summaries.py
+++ b/src/caselawclient/models/press_summaries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ds_caselaw_utils.types import NeutralCitationString
 
@@ -14,6 +14,7 @@ from caselawclient.types import DocumentURIString
 from .documents import Document
 
 if TYPE_CHECKING:
+    from caselawclient.Client import MarklogicApiClient
     from caselawclient.models.judgments import Judgment
 
 
@@ -27,8 +28,8 @@ class PressSummary(NeutralCitationMixin, Document):
     type_collection_name = "press-summary"
     _default_reparse_document_type = "pressSummary"
 
-    def __init__(self, uri: DocumentURIString, *args: Any, **kwargs: Any) -> None:
-        super().__init__(self.document_noun, uri, *args, **kwargs)
+    def __init__(self, uri: DocumentURIString, api_client: MarklogicApiClient, search_query: str | None = None) -> None:
+        super().__init__(self.document_noun, uri, api_client, search_query=search_query)
 
     @cached_property
     def neutral_citation(self) -> NeutralCitationString | None:
@@ -44,6 +45,7 @@ class PressSummary(NeutralCitationMixin, Document):
         """
         Attempt to fetch a linked judgement, and return it, if it exists
         """
+        self._require_persisted()
         try:
             uri = DocumentURIString(self.uri.removesuffix("/press-summary/1"))
             if not TYPE_CHECKING:  # This isn't nice, but will be cleaned up when we refactor how related documents work

--- a/src/caselawclient/types.py
+++ b/src/caselawclient/types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Self, TypedDict
+from uuid import uuid4
 
 from lxml import etree
 
@@ -63,6 +64,10 @@ class DocumentURIString(str):
 
     def as_marklogic(self) -> MarkLogicDocumentURIString:
         return MarkLogicDocumentURIString(f"/{self}.xml")
+
+
+def mint_document_uri() -> DocumentURIString:
+    return DocumentURIString(f"d-{uuid4()}")
 
 
 class DocumentIdentifierSlug(str):

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -1,10 +1,10 @@
 from datetime import UTC, date, datetime
-from unittest.mock import PropertyMock, patch
+from unittest.mock import ANY, PropertyMock, patch
 from uuid import uuid4
 
 import pytest
 
-from caselawclient.factories import DocumentBodyFactory, DocumentFactory
+from caselawclient.factories import DocumentBodyFactory, DocumentFactory, JudgmentFactory
 from caselawclient.models.documents.metadata.base import Metadata
 from caselawclient.models.documents.metadata.fields.field import MetadataCategoryValue, MetadataField
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
@@ -239,19 +239,20 @@ class TestMaterialiseBodyClaims:
         assert values == {("Child", None)}
 
 
-class TestDocumentMaterialiseMetadataClaims:
-    def test_materialise_persists_fields_and_version(self, mock_api_client):
-        document = DocumentFactory.build(
+class TestDocumentSaveStructuredMetadataToMarklogic:
+    def test_save_persists_structured_metadata_fields_and_version(self, mock_api_client):
+        document = JudgmentFactory.build(
             api_client=mock_api_client,
             body=DocumentBodyFactory.build(name="Saved Title", court="Saved Court"),
         )
 
-        document.materialise_metadata_claims()
+        with (
+            patch.object(document.api_client, "document_exists", return_value=True),
+            patch.object(document.api_client, "update_document_xml"),
+        ):
+            document.save(message="Persist metadata")
 
-        mock_api_client.set_property_as_node.assert_called_once()
-        uri, property_name, _tree = mock_api_client.set_property_as_node.call_args.args
-        assert uri == document.uri
-        assert property_name == "metadata_fields"
+        mock_api_client.set_property_as_node.assert_any_call(document.uri, "metadata_fields", ANY)
         mock_api_client.set_property.assert_any_call(
             document.uri,
             LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,

--- a/tests/models/documents/test_document_from_xml.py
+++ b/tests/models/documents/test_document_from_xml.py
@@ -1,0 +1,173 @@
+"""Tests for Document.from_xml() and document_from_xml()."""
+
+from unittest.mock import patch
+
+import pytest
+
+from caselawclient.client_helpers import document_from_xml
+from caselawclient.factories import DocumentBodyFactory, DocumentFactory, JudgmentFactory
+from caselawclient.models.documents import Document, DocumentURIString
+from caselawclient.models.documents.body import DocumentBody
+from caselawclient.models.documents.exceptions import DocumentAlreadyExistsError, DocumentNotPersistedError
+from caselawclient.models.judgments import Judgment
+from caselawclient.models.parser_logs import ParserLog
+from caselawclient.models.press_summaries import PressSummary
+
+
+@pytest.fixture(autouse=True)
+def document_does_not_exist_in_marklogic(mock_api_client):
+    mock_api_client.document_exists.return_value = False
+
+
+class TestDocumentFromXml:
+    def test_from_xml_checks_document_does_not_exist(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+
+        with patch.object(mock_api_client, "get_judgment_xml_bytestring") as mock_get_xml:
+            document = Judgment.from_xml(body, mock_api_client)
+
+        mock_api_client.document_exists.assert_called_once()
+        mock_get_xml.assert_not_called()
+        assert document.is_persisted is False
+
+    def test_from_xml_raises_when_uri_already_exists(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        uri = DocumentURIString("test/2023/123")
+        mock_api_client.document_exists.return_value = True
+
+        with pytest.raises(DocumentAlreadyExistsError, match="already exists"):
+            Judgment.from_xml(body, mock_api_client, uri=uri)
+
+    def test_from_xml_mints_uri_when_omitted(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        document = Judgment.from_xml(body, mock_api_client)
+
+        assert str(document.uri).startswith("d-")
+        assert len(str(document.uri)) > 2
+
+    def test_from_xml_uses_provided_uri(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        uri = DocumentURIString("d-abc123")
+
+        document = Judgment.from_xml(body, mock_api_client, uri=uri)
+
+        assert document.uri == uri
+
+    def test_from_xml_initialises_in_memory_state(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        document = Judgment.from_xml(body, mock_api_client)
+
+        assert document.body is body
+        assert len(document.identifiers) == 0
+        assert len(document.metadata_fields) == 0
+        assert document.metadata.title.value == "Judgment v Judgement"
+
+    def test_from_xml_initialises_ncn_validation(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        validation_names = [name for name, _, _ in document.attributes_to_validate]
+        assert "has_valid_ncn" in validation_names
+
+    def test_linked_document_on_ephemeral_judgment_raises(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        with pytest.raises(DocumentNotPersistedError):
+            _ = document.linked_document
+
+    def test_linked_document_on_ephemeral_press_summary_raises(self, mock_api_client):
+        body = DocumentBody(
+            b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <doc name="pressSummary">
+                <meta><identification><FRBRWork><FRBRname value="Summary"/></FRBRWork></identification></meta>
+                <mainBody><p>Summary text</p></mainBody>
+            </doc>
+            </akomaNtoso>"""
+        )
+        document = PressSummary.from_xml(body, mock_api_client)
+
+        with pytest.raises(DocumentNotPersistedError):
+            _ = document.linked_document
+
+    def test_press_summary_from_xml(self, mock_api_client):
+        xml = b"""<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+            <doc name="pressSummary">
+                <meta><identification><FRBRWork><FRBRname value="Summary"/></FRBRWork></identification></meta>
+                <mainBody><p>Summary text</p></mainBody>
+            </doc>
+            </akomaNtoso>"""
+        body = DocumentBody(xml)
+
+        document = PressSummary.from_xml(body, mock_api_client)
+
+        assert isinstance(document, PressSummary)
+        assert document.is_persisted is False
+
+    def test_parser_log_from_xml(self, mock_api_client):
+        body = DocumentBody(b"<error>parser failed</error>")
+
+        document = ParserLog.from_xml(body, mock_api_client)
+
+        assert isinstance(document, ParserLog)
+        assert document.is_persisted is False
+
+    def test_document_from_xml_helper_returns_parser_log(self, mock_api_client):
+        body = DocumentBody(b"<error>parser failed</error>")
+
+        document = document_from_xml(body, mock_api_client)
+
+        assert isinstance(document, ParserLog)
+
+    def test_document_from_xml_helper_returns_judgment(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+
+        document = document_from_xml(body, mock_api_client)
+
+        assert isinstance(document, Judgment)
+
+    def test_base_document_from_xml_raises(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+
+        with pytest.raises(TypeError, match="document_from_xml"):
+            Document.from_xml(body, mock_api_client)
+
+    def test_base_document_save_raises(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        assemble = Document._assemble_from_body  # noqa: SLF001
+        document = assemble(body, mock_api_client)
+
+        with pytest.raises(TypeError, match="concrete document class"):
+            document.save(message="test")
+
+    def test_publish_on_ephemeral_document_raises(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        with pytest.raises(DocumentNotPersistedError):
+            document.publish()
+
+    def test_document_factory_sets_persisted(self, mock_api_client):
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert document.is_persisted is True
+
+    def test_judgment_factory_sets_persisted(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
+
+        assert document.is_persisted is True
+
+
+class TestParserLogSaveInsert:
+    def test_parser_log_save_inserts_into_parser_log_collection(self, mock_api_client):
+        body = DocumentBody(b"<error>parser failed</error>")
+        document = ParserLog.from_xml(body, mock_api_client, uri=DocumentURIString("d-parser-test"))
+        mock_api_client.document_exists.return_value = False
+
+        with patch.object(document.api_client, "insert_document_xml") as mock_insert:
+            document.save(message="Initial parser log")
+
+        mock_insert.assert_called_once()
+        call_args = mock_insert.call_args
+        assert call_args[0][0] == DocumentURIString("d-parser-test")
+        assert call_args[0][2] is ParserLog
+        assert document.is_persisted is True

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -1,14 +1,30 @@
 """Tests for Document.save() method."""
 
-from unittest.mock import patch
+from datetime import UTC, datetime
+from unittest.mock import ANY, patch
+from uuid import uuid4
 
-from caselawclient.factories import DocumentFactory
+import pytest
+
+from caselawclient.factories import DocumentBodyFactory, JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.exceptions import DocumentAlreadyExistsError, DocumentNotPersistedError
+from caselawclient.models.documents.metadata.fields.exceptions import MetadataFieldValidationException
+from caselawclient.models.documents.metadata.fields.field import MetadataField
+from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.models.documents.metadata.materialisation import (
     CURRENT_METADATA_MATERIALISATION_VERSION,
     LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
 )
 from caselawclient.models.documents.versions import VersionAnnotation, VersionType
+from caselawclient.models.identifiers.exceptions import IdentifierValidationException
+from caselawclient.models.judgments import Judgment
+from caselawclient.types import SuccessFailureMessageTuple
+
+
+@pytest.fixture(autouse=True)
+def document_does_not_exist_in_marklogic(mock_api_client):
+    mock_api_client.document_exists.return_value = False
 
 
 class TestDocumentSave:
@@ -17,29 +33,38 @@ class TestDocumentSave:
     def test_save_calls_update_document_xml(self):
         """Test that save() calls update_document_xml exactly once."""
         uri = DocumentURIString("test/2023/101")
-        document = DocumentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri)
 
         with (
+            patch.object(document.api_client, "document_exists", return_value=True),
             patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "materialise_metadata_claims") as mock_materialise,
+            patch.object(document, "_convert_body_claims_to_structured_metadata"),
+            patch.object(document, "_validate_metadata_for_save"),
+            patch.object(document, "_validate_identifiers_for_save"),
+            patch.object(document, "_save_identifiers_to_marklogic"),
+            patch.object(document, "_save_structured_metadata_to_marklogic") as mock_save_metadata,
         ):
             document.save(message="Changed document")
 
             mock_update.assert_called_once()
-            mock_materialise.assert_called_once()
+            mock_save_metadata.assert_called_once()
 
     def test_save_creates_edit_annotation(self):
         """Test that save() creates an EDIT annotation with automated=False."""
         uri = DocumentURIString("test/2023/123")
-        document = DocumentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri)
 
         with (
+            patch.object(document.api_client, "document_exists", return_value=True),
             patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "materialise_metadata_claims"),
+            patch.object(document, "_convert_body_claims_to_structured_metadata"),
+            patch.object(document, "_validate_metadata_for_save"),
+            patch.object(document, "_validate_identifiers_for_save"),
+            patch.object(document, "_save_identifiers_to_marklogic"),
+            patch.object(document, "_save_structured_metadata_to_marklogic"),
         ):
             document.save(message="Changed document")
 
-            # Verify the annotation was created correctly
             call_args = mock_update.call_args
             annotation = call_args[0][2]
             assert isinstance(annotation, VersionAnnotation)
@@ -49,16 +74,20 @@ class TestDocumentSave:
     def test_save_passes_uri_and_xml_to_api(self):
         """Test that save() passes the correct URI and XML to the API."""
         uri = DocumentURIString("test/2023/456")
-        document = DocumentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri)
         expected_xml = document.body.content_as_xml_tree
 
         with (
+            patch.object(document.api_client, "document_exists", return_value=True),
             patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "materialise_metadata_claims"),
+            patch.object(document, "_convert_body_claims_to_structured_metadata"),
+            patch.object(document, "_validate_metadata_for_save"),
+            patch.object(document, "_validate_identifiers_for_save"),
+            patch.object(document, "_save_identifiers_to_marklogic"),
+            patch.object(document, "_save_structured_metadata_to_marklogic"),
         ):
             document.save(message="Changed document")
 
-            # Verify the correct URI and XML are passed
             call_args = mock_update.call_args
             assert call_args[0][0] == uri
             assert call_args[0][1] is expected_xml
@@ -66,12 +95,17 @@ class TestDocumentSave:
     def test_save_with_message_includes_message_in_annotation(self):
         """Test that save() includes the message in the annotation."""
         uri = DocumentURIString("test/2023/789")
-        document = DocumentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri)
         test_message = "Fixed typo in court name"
 
         with (
+            patch.object(document.api_client, "document_exists", return_value=True),
             patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "materialise_metadata_claims"),
+            patch.object(document, "_convert_body_claims_to_structured_metadata"),
+            patch.object(document, "_validate_metadata_for_save"),
+            patch.object(document, "_validate_identifiers_for_save"),
+            patch.object(document, "_save_identifiers_to_marklogic"),
+            patch.object(document, "_save_structured_metadata_to_marklogic"),
         ):
             document.save(message=test_message)
 
@@ -79,34 +113,247 @@ class TestDocumentSave:
             annotation = call_args[0][2]
             assert annotation.message == test_message
 
-    def test_save_calls_materialise_after_xml_update(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
+    def test_save_validates_and_converts_before_xml_update(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
         call_order: list[str] = []
 
         def track_xml(*_args, **_kwargs):
             call_order.append("xml")
 
-        def track_materialise():
-            call_order.append("materialise")
-
         with (
+            patch.object(document.api_client, "document_exists", return_value=True),
             patch.object(document.api_client, "update_document_xml", side_effect=track_xml),
-            patch.object(document, "materialise_metadata_claims", side_effect=track_materialise) as mock_materialise,
+            patch.object(
+                document,
+                "_convert_body_claims_to_structured_metadata",
+                side_effect=lambda: call_order.append("convert"),
+            ),
+            patch.object(
+                document,
+                "_validate_metadata_for_save",
+                side_effect=lambda: call_order.append("validate_metadata"),
+            ),
+            patch.object(
+                document,
+                "_validate_identifiers_for_save",
+                side_effect=lambda: call_order.append("validate_identifiers"),
+            ),
+            patch.object(
+                document,
+                "_save_identifiers_to_marklogic",
+                side_effect=lambda: call_order.append("save_identifiers"),
+            ),
+            patch.object(
+                document,
+                "_save_structured_metadata_to_marklogic",
+                side_effect=lambda: call_order.append("save_metadata"),
+            ),
         ):
             document.save(message="Changed document")
 
-        assert call_order == ["xml", "materialise"]
-        mock_materialise.assert_called_once()
+        assert call_order == [
+            "convert",
+            "validate_metadata",
+            "validate_identifiers",
+            "xml",
+            "save_identifiers",
+            "save_metadata",
+        ]
 
-    def test_save_materialise_persists_version(self, mock_api_client):
-        document = DocumentFactory.build(api_client=mock_api_client)
+    def test_save_writes_identifiers_and_structured_metadata_to_marklogic(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
 
-        with patch.object(document.api_client, "update_document_xml"):
+        with (
+            patch.object(document.api_client, "document_exists", return_value=True),
+            patch.object(document.api_client, "update_document_xml"),
+        ):
             document.save(message="Changed document")
 
-        mock_api_client.set_property_as_node.assert_called()
+        mock_api_client.set_property_as_node.assert_any_call(document.uri, "identifiers", ANY)
+        mock_api_client.set_property_as_node.assert_any_call(document.uri, "metadata_fields", ANY)
         mock_api_client.set_property.assert_any_call(
             document.uri,
             LATEST_METADATA_MATERIALISATION_VERSION_PROPERTY,
             CURRENT_METADATA_MATERIALISATION_VERSION,
         )
+
+    def test_save_rejects_invalid_identifiers_before_insert(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        with (
+            patch.object(
+                document.identifiers,
+                "perform_all_validations",
+                return_value=SuccessFailureMessageTuple(False, ["Identifier validation failed"]),
+            ),
+            patch.object(document.api_client, "insert_document_xml") as mock_insert,
+            pytest.raises(IdentifierValidationException, match="Identifier validation failed"),
+        ):
+            document.save(message="Initial insert")
+
+        mock_insert.assert_not_called()
+        assert document.is_persisted is False
+
+    def test_save_insert_path_for_ephemeral_document(self, mock_api_client):
+        body = DocumentBodyFactory.build()
+        document = Judgment.from_xml(body, mock_api_client, uri=DocumentURIString("d-new-doc"))
+        mock_api_client.document_exists.return_value = False
+
+        with patch.object(document.api_client, "insert_document_xml") as mock_insert:
+            document.save(message="Initial insert")
+
+        mock_insert.assert_called_once()
+        call_args = mock_insert.call_args
+        assert call_args[0][2] is Judgment
+        assert document.is_persisted is True
+
+    def test_save_raises_when_unpersisted_and_uri_already_exists(self, mock_api_client):
+        document = Judgment.from_xml(
+            DocumentBodyFactory.build(),
+            mock_api_client,
+            uri=DocumentURIString("d-new-doc"),
+        )
+        mock_api_client.document_exists.return_value = True
+
+        with pytest.raises(DocumentAlreadyExistsError, match="already exists"):
+            document.save(message="Initial insert")
+
+    def test_save_rejects_mismatched_metadata_field_keys_before_insert(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+        field_id = str(uuid4())
+        document.metadata_fields["wrong-key"] = MetadataField(
+            name="title",
+            value="Bad key",
+            source=MetadataSource.EDITOR,
+            id=field_id,
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        with (
+            patch.object(document.api_client, "insert_document_xml") as mock_insert,
+            pytest.raises(MetadataFieldValidationException, match="wrong-key"),
+        ):
+            document.save(message="Initial insert")
+
+        mock_insert.assert_not_called()
+        assert document.is_persisted is False
+
+    def test_is_persisted_false_after_from_xml(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        assert document.is_persisted is False
+
+    def test_is_persisted_true_after_save(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+        mock_api_client.document_exists.return_value = False
+
+        with patch.object(document.api_client, "insert_document_xml"):
+            document.save(message="Initial insert")
+
+        assert document.is_persisted is True
+
+    def test_is_persisted_true_on_init(self, mock_api_client):
+        mock_api_client.document_exists.return_value = True
+        mock_api_client.get_judgment_xml_bytestring.return_value = DocumentBodyFactory.build().content_as_xml.encode(
+            "utf-8"
+        )
+
+        document = Judgment(DocumentURIString("test/2023/999"), mock_api_client)
+
+        assert document.is_persisted is True
+
+    def test_publish_on_ephemeral_raises(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+
+        with pytest.raises(DocumentNotPersistedError):
+            document.publish()
+
+    def test_save_passes_custom_version_type_and_automated(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
+
+        with (
+            patch.object(document.api_client, "document_exists", return_value=True),
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document, "_convert_body_claims_to_structured_metadata"),
+            patch.object(document, "_validate_metadata_for_save"),
+            patch.object(document, "_validate_identifiers_for_save"),
+            patch.object(document, "_save_identifiers_to_marklogic"),
+            patch.object(document, "_save_structured_metadata_to_marklogic"),
+        ):
+            document.save(
+                message="Re-parsed",
+                version_type=VersionType.SUBMISSION,
+                automated=True,
+            )
+
+        annotation = mock_update.call_args[0][2]
+        assert annotation.version_type == VersionType.SUBMISSION
+        assert annotation.automated is True
+
+    def test_partial_save_failure_leaves_document_persisted_after_insert(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+        mock_api_client.document_exists.return_value = False
+
+        with (
+            patch.object(document.api_client, "insert_document_xml"),
+            patch.object(
+                document,
+                "_save_structured_metadata_to_marklogic",
+                side_effect=RuntimeError("metadata save failed"),
+            ),
+            pytest.raises(RuntimeError, match="metadata save failed"),
+        ):
+            document.save(message="Initial insert")
+
+        assert document.is_persisted is True
+
+    def test_save_retry_after_metadata_persist_failure_uses_update_path(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+        mock_api_client.document_exists.return_value = False
+
+        with (
+            patch.object(document.api_client, "insert_document_xml"),
+            patch.object(
+                document,
+                "_save_structured_metadata_to_marklogic",
+                side_effect=RuntimeError("metadata save failed"),
+            ),
+            pytest.raises(RuntimeError, match="metadata save failed"),
+        ):
+            document.save(message="Initial insert")
+
+        mock_api_client.document_exists.return_value = True
+
+        with (
+            patch.object(document.api_client, "update_document_xml") as mock_update,
+            patch.object(document.api_client, "insert_document_xml") as mock_insert,
+        ):
+            document.save(message="Retry save")
+
+        mock_update.assert_called_once()
+        mock_insert.assert_not_called()
+        assert document.is_persisted is True
+
+    def test_reparse_body_swap_retains_existing_metadata_fields(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
+        existing_claim = MetadataField(
+            name="title",
+            value="Existing editor title",
+            source=MetadataSource.EDITOR,
+            id="existing-claim-id",
+            timestamp=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        document.metadata_fields.add(existing_claim)
+
+        document.body = DocumentBodyFactory.build(name="Updated title")
+
+        with (
+            patch.object(document.api_client, "document_exists", return_value=True),
+            patch.object(document.api_client, "update_document_xml"),
+        ):
+            document.save(message="Re-parsed body")
+
+        assert existing_claim in document.metadata_fields.values()
+        title_claims = document.metadata_fields.by_name("title")
+        assert any(claim.source is MetadataSource.EDITOR for claim in title_claims)
+        assert any(claim.source is MetadataSource.DOCUMENT for claim in title_claims)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -7,6 +7,7 @@ from caselawclient.types import (
     InvalidMarkLogicDocumentURIException,
     MarkLogicDocumentURIString,
     SuccessTuple,
+    mint_document_uri,
 )
 
 
@@ -63,6 +64,13 @@ class TestDocumentURIString:
 
         assert marklogic_uri == "/test/2025/123.xml"
         assert type(marklogic_uri) is MarkLogicDocumentURIString
+
+
+class TestMintDocumentUri:
+    def test_minted_uri_begins_with_d_prefix(self):
+        uri = mint_document_uri()
+        assert str(uri).startswith("d-")
+        assert type(uri) is DocumentURIString
 
 
 class TestSuccessFailureMessageTuple:


### PR DESCRIPTION
Documents can now be constructed in memory from parser XML without an existing MarkLogic record, then persisted via a single `save()` call. This lays the foundation for simplifying how the Ingester performs updates without it having to replicate a bunch of knowledge about how `Document` objects behave.

- Add `Document.from_xml()` and `document_from_xml()` for in-memory construction; URIs mint as `d-{uuid4}` when not provided.
- Extend `Document.save()` to insert-or-update with `version_type` and `automated` parameters
- Add `is_persisted` and guard MarkLogic-backed calls until `save()` completes (`DocumentNotPersistedError`). This will eventually go away as we move more document behaviours to be in-memory.
- Refactor `DocumentFactory.build` to use the new construction path, so tests are using real `Document`s for more stuff instead of mocking.
- Deprecate `Client.insert_document_xml` / `update_document_xml` for lifecycle workflows in favour of `Document.save()`

**Breaking change:** `save()` on a URI that does not yet exist in MarkLogic now inserts the document instead of failing on update.

## Jira

FCLC-2355