### PR TITLE
FCLC-2385: Add parties, headnote_summary, and web_archiving_link metadata types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog 1.0.0].
   values/in. Legacy name/judge keys are gone.
 - Date metadata claim values are `datetime.date`, not `str`.
 - Claim payloads are structured `MetadataStringValue` /
-  `MetadataDateValue` / `MetadataCategoryValue`, not bare `str` / `date`.
+  `MetadataDateValue` / `MetadataCategoryValue` / `MetadataPartyValue`,
+  not bare `str` / `date`.
 - `metadata_fields.add` / `__setitem__` are idempotent: matching
   name/value/source is a noop (including rejected); id collision with a
   different payload raises; unknown claim names and wrong value types
@@ -36,6 +37,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Metadata**: per-type pack/unpack with date claims as date
 - **Metadata**: expose DocumentMetadata as typed attribute facades
 - **Metadata**: idempotent MetadataFieldsCollection.add
+- **Metadata**: add parties claims with MetadataPartyValue; materialise `uk:party` from the body XML
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Metadata**: expose DocumentMetadata as typed attribute facades
 - **Metadata**: idempotent MetadataFieldsCollection.add
 - **Metadata**: add parties claims with MetadataPartyValue; materialise `uk:party` from the body XML
+- **Metadata**: add headnote_summary claims
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - **Metadata**: idempotent MetadataFieldsCollection.add
 - **Metadata**: add parties claims with MetadataPartyValue; materialise `uk:party` from the body XML
 - **Metadata**: add headnote_summary claims
+- **Metadata**: add web_archiving_link claims
 
 ### Fix
 

--- a/src/caselawclient/models/documents/body.py
+++ b/src/caselawclient/models/documents/body.py
@@ -7,6 +7,7 @@ from ds_caselaw_utils.types import CourtCode
 from saxonche import PySaxonProcessor
 from typing_extensions import deprecated
 
+from caselawclient.models.documents.metadata.fields.field import MetadataPartyValue
 from caselawclient.models.documents.metadata.types.date import date_as_string_from_value
 from caselawclient.models.utilities.dates import parse_string_date_as_utc
 from caselawclient.types import DocumentCategory
@@ -26,6 +27,7 @@ CATEGORIES_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:category"
 CASE_NUMBER_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:caseNumber/text()"
 DATE_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:identification/akn:FRBRWork/akn:FRBRdate/@date"
 JUDGES_XPATH = "/akn:akomaNtoso/akn:*/akn:header//akn:judge"
+PARTIES_XPATH = "/akn:akomaNtoso/akn:*/akn:meta/akn:proprietary/uk:party"
 
 
 def categories_from_nodes(nodes: list[Element]) -> list[DocumentCategory]:
@@ -78,6 +80,29 @@ def judges_from_nodes(nodes: list[Element]) -> list[str]:
     return judges
 
 
+def parties_from_nodes(nodes: list[Element]) -> list[MetadataPartyValue]:
+    """Extract unique parties from Akoma Ntoso ``uk:party`` nodes.
+
+    Parties are returned in first-seen document order. Empty or whitespace-only
+    names are skipped; duplicate name+role pairs are de-duplicated. Nested inline
+    markup inside a party node is flattened via ``itertext``. Role is taken from
+    the ``role`` attribute when present.
+    """
+    parties: list[MetadataPartyValue] = []
+
+    for node in nodes:
+        name = "".join(node.itertext()).strip()
+        if not name:
+            continue
+        role = node.get("role")
+        party = MetadataPartyValue(name=name, role=role)
+        if party in parties:
+            continue
+        parties.append(party)
+
+    return parties
+
+
 class DocumentBody:
     """
     A class for abstracting out interactions with the body of a document.
@@ -126,6 +151,10 @@ class DocumentBody:
     @cached_property
     def judges(self) -> list[str]:
         return judges_from_nodes(self.get_xpath_nodes(JUDGES_XPATH))
+
+    @cached_property
+    def parties(self) -> list[MetadataPartyValue]:
+        return parties_from_nodes(self.get_xpath_nodes(PARTIES_XPATH))
 
     @property
     def court_and_jurisdiction_identifier_string(self) -> CourtCode:

--- a/src/caselawclient/models/documents/metadata/fields/field.py
+++ b/src/caselawclient/models/documents/metadata/fields/field.py
@@ -13,7 +13,12 @@ from caselawclient.models.documents.metadata.fields.exceptions import (
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
 from caselawclient.xml_helpers import Element
 
-MetadataFieldValue = Union["MetadataStringValue", "MetadataDateValue", "MetadataCategoryValue"]
+MetadataFieldValue = Union[
+    "MetadataStringValue",
+    "MetadataDateValue",
+    "MetadataCategoryValue",
+    "MetadataPartyValue",
+]
 
 
 @dataclass(frozen=True)
@@ -60,6 +65,27 @@ class MetadataCategoryValue:
             raise ValueError("category name must be non-empty")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "parent", parent)
+
+    def normalised(self) -> Self | None:
+        return self
+
+
+@dataclass(frozen=True)
+class MetadataPartyValue:
+    """Structured value for a ``parties`` metadata claim."""
+
+    name: str
+    role: str | None = None
+
+    def __post_init__(self) -> None:
+        name = self.name.strip()
+        role = self.role.strip() if self.role else None
+        if role == "":
+            role = None
+        if not name:
+            raise ValueError("party name must be non-empty")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "role", role)
 
     def normalised(self) -> Self | None:
         return self

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -14,6 +14,7 @@ from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
 from caselawclient.models.documents.metadata.types.parties import PartiesMetadata
+from caselawclient.models.documents.metadata.types.web_archiving_link import WebArchivingLinkMetadata
 
 METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     CaseNumberMetadata,
@@ -25,6 +26,7 @@ METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     JurisdictionMetadata,
     NameMetadata,
     PartiesMetadata,
+    WebArchivingLinkMetadata,
 )
 
 
@@ -55,6 +57,7 @@ class DocumentMetadata:
     judges: JudgesMetadata
     parties: PartiesMetadata
     headnote_summary: HeadnoteSummaryMetadata
+    web_archiving_link: WebArchivingLinkMetadata
 
     def __iter__(self) -> Iterator[Metadata]:
         for field in fields(self):

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -9,6 +9,7 @@ from caselawclient.models.documents.metadata.types.case_number import CaseNumber
 from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
 from caselawclient.models.documents.metadata.types.court import CourtMetadata
 from caselawclient.models.documents.metadata.types.date import DateMetadata
+from caselawclient.models.documents.metadata.types.headnote_summary import HeadnoteSummaryMetadata
 from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
@@ -19,6 +20,7 @@ METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     CategoriesMetadata,
     CourtMetadata,
     DateMetadata,
+    HeadnoteSummaryMetadata,
     JudgesMetadata,
     JurisdictionMetadata,
     NameMetadata,
@@ -52,6 +54,7 @@ class DocumentMetadata:
     categories: CategoriesMetadata
     judges: JudgesMetadata
     parties: PartiesMetadata
+    headnote_summary: HeadnoteSummaryMetadata
 
     def __iter__(self) -> Iterator[Metadata]:
         for field in fields(self):

--- a/src/caselawclient/models/documents/metadata/registry.py
+++ b/src/caselawclient/models/documents/metadata/registry.py
@@ -12,6 +12,7 @@ from caselawclient.models.documents.metadata.types.date import DateMetadata
 from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
 from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
 from caselawclient.models.documents.metadata.types.name import NameMetadata
+from caselawclient.models.documents.metadata.types.parties import PartiesMetadata
 
 METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     CaseNumberMetadata,
@@ -21,6 +22,7 @@ METADATA_FIELD_CLASSES: tuple[type[Metadata], ...] = (
     JudgesMetadata,
     JurisdictionMetadata,
     NameMetadata,
+    PartiesMetadata,
 )
 
 
@@ -49,6 +51,7 @@ class DocumentMetadata:
     case_number: CaseNumberMetadata
     categories: CategoriesMetadata
     judges: JudgesMetadata
+    parties: PartiesMetadata
 
     def __iter__(self) -> Iterator[Metadata]:
         for field in fields(self):

--- a/src/caselawclient/models/documents/metadata/types/headnote_summary.py
+++ b/src/caselawclient/models/documents/metadata/types/headnote_summary.py
@@ -1,0 +1,17 @@
+from caselawclient.models.documents.metadata.base import SingleMetadata
+
+
+class HeadnoteSummaryMetadata(SingleMetadata[str | None]):
+    key = "headnote_summary"
+    title = "Headnote Summary"
+    description = "A short summary of the headnote for the document."
+    editable = True
+    LOGIC_VERSION = 1
+
+    @property
+    def value(self) -> str | None:
+        return self._optional_string_value(None)
+
+    def materialise_body_claims(self) -> None:
+        """No body equivalent yet; claims come from EXTERNAL/EDITOR sources."""
+        return

--- a/src/caselawclient/models/documents/metadata/types/parties.py
+++ b/src/caselawclient/models/documents/metadata/types/parties.py
@@ -1,0 +1,78 @@
+from typing import cast
+
+from lxml import etree
+
+from caselawclient.models.documents.metadata.base import MultipleMetadata
+from caselawclient.models.documents.metadata.fields.exceptions import (
+    InvalidMetadataFieldXMLRepresentationException,
+)
+from caselawclient.models.documents.metadata.fields.field import MetadataFieldValue, MetadataPartyValue
+from caselawclient.models.documents.metadata.fields.unpack_helpers import stripped_element_text
+from caselawclient.xml_helpers import Element
+
+
+def party_values_from_field_values(values: list[MetadataFieldValue]) -> list[MetadataPartyValue]:
+    """Extract party claim values, de-duplicating with first-seen order winning.
+
+    Non-party claim values are ignored. The same party claimed by multiple
+    sources appears once in the facade list; claims themselves are unchanged.
+    """
+    parties: list[MetadataPartyValue] = []
+    for value in values:
+        if not isinstance(value, MetadataPartyValue):
+            continue
+        if value in parties:
+            continue
+        parties.append(value)
+    return parties
+
+
+class PartiesMetadata(MultipleMetadata[MetadataPartyValue]):
+    key = "parties"
+    title = "Parties"
+    description = "The parties involved in the case, each with an optional role."
+    editable = True
+    LOGIC_VERSION = 1
+
+    @property
+    def values(self) -> list[MetadataPartyValue]:
+        resolved = self._resolve_claims()
+        if not resolved.has_any_claims:
+            return self.document.body.parties
+        return party_values_from_field_values(resolved.values)
+
+    def materialise_body_claims(self) -> None:
+        """Yank body ``uk:party`` nodes into DOCUMENT claims (additive, idempotent)."""
+        self._materialise_document_values(self.document.body.parties)
+
+    @classmethod
+    def validate_value(cls, value: MetadataFieldValue) -> None:
+        if not isinstance(value, MetadataPartyValue):
+            raise TypeError(f"Expected MetadataPartyValue for '{cls.key}', got {type(value).__name__}")
+
+    @classmethod
+    def pack_value(cls, value: MetadataFieldValue, into: Element) -> None:
+        cls.validate_value(value)
+        party = cast(MetadataPartyValue, value)
+        name_element = etree.SubElement(into, "name")
+        name_element.text = party.name
+        if party.role is not None:
+            role_element = etree.SubElement(into, "role")
+            role_element.text = party.role
+
+    @classmethod
+    def unpack_value(cls, metadata_xml: Element, pack_version: int) -> MetadataFieldValue:
+        name_child = metadata_xml.find("name")
+        if name_child is None:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: party name element not present"
+            )
+        party_name = stripped_element_text(name_child)
+        if not party_name:
+            raise InvalidMetadataFieldXMLRepresentationException(
+                "Metadata field XML representation is not valid: party name not present or empty"
+            )
+        role_child = metadata_xml.find("role")
+        role_text = stripped_element_text(role_child)
+        role = role_text or None
+        return MetadataPartyValue(name=party_name, role=role)

--- a/src/caselawclient/models/documents/metadata/types/web_archiving_link.py
+++ b/src/caselawclient/models/documents/metadata/types/web_archiving_link.py
@@ -1,0 +1,17 @@
+from caselawclient.models.documents.metadata.base import SingleMetadata
+
+
+class WebArchivingLinkMetadata(SingleMetadata[str | None]):
+    key = "web_archiving_link"
+    title = "Web Archiving Link"
+    description = "A URL for a web-archived copy of the document or related material."
+    editable = True
+    LOGIC_VERSION = 1
+
+    @property
+    def value(self) -> str | None:
+        return self._optional_string_value(None)
+
+    def materialise_body_claims(self) -> None:
+        """No body equivalent yet; claims come from EXTERNAL/EDITOR sources."""
+        return

--- a/tests/models/documents/metadata/fields/test_metadata_fields.py
+++ b/tests/models/documents/metadata/fields/test_metadata_fields.py
@@ -21,6 +21,7 @@ from caselawclient.models.documents.metadata.fields.field import (
     MetadataDateValue,
     MetadataField,
     MetadataFieldValue,
+    MetadataPartyValue,
     MetadataStringValue,
 )
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
@@ -52,6 +53,14 @@ class TestMetadataFieldValues:
         assert MetadataCategoryValue(name=" Child ", parent="  ").parent is None
         with pytest.raises(ValueError, match="non-empty"):
             MetadataCategoryValue(name="")
+
+    def test_party_value_strips_role_and_rejects_empty_name(self):
+        assert MetadataPartyValue(name=" Acme ", role="  appellant  ") == MetadataPartyValue(
+            name="Acme", role="appellant"
+        )
+        assert MetadataPartyValue(name="Acme", role="  ").role is None
+        with pytest.raises(ValueError, match="non-empty"):
+            MetadataPartyValue(name="")
 
     def test_pack_unknown_name_raises(self):
         field = MetadataField(
@@ -108,6 +117,29 @@ class TestMetadataFieldPacking:
 
         assert element.findtext("name") == "Subcategory"
         assert element.findtext("parent") == "Category"
+
+    def test_pack_party_with_role(self):
+        field = MetadataField(
+            name="parties",
+            value=MetadataPartyValue(name="Acme Ltd", role="appellant"),
+            source=MetadataSource.EXTERNAL,
+            id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        element = field.as_etree
+
+        assert element.findtext("name") == "Acme Ltd"
+        assert element.findtext("role") == "appellant"
+
+    def test_pack_party_without_role_omits_role_element(self):
+        field = MetadataField(
+            name="parties",
+            value=MetadataPartyValue(name="Acme Ltd"),
+            source=MetadataSource.EXTERNAL,
+            id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            timestamp=EARLY_TIMESTAMP,
+        )
+        assert field.as_etree.find("role") is None
 
     def test_pack_category_with_null_parent(self):
         field = MetadataField(
@@ -173,6 +205,26 @@ class TestMetadataFieldUnpacking:
 
         assert isinstance(field.value, MetadataCategoryValue)
         assert field.value.parent is None
+
+    def test_unpack_party_with_role(self):
+        xml = etree.fromstring(
+            '<metadata id="7c4e8a91-3b2f-4d6e-9a1c-5e8f0b2d4a67" name="parties" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
+            "<name>Acme Ltd</name><role>appellant</role></metadata>"
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataPartyValue(name="Acme Ltd", role="appellant")
+
+    def test_unpack_party_without_role(self):
+        xml = etree.fromstring(
+            '<metadata id="a1b2c3d4-e5f6-7890-abcd-ef1234567890" name="parties" source="external" '
+            f'timestamp="{EARLY_TIMESTAMP.isoformat()}">'
+            "<name>Acme Ltd</name></metadata>"
+        )
+        field = unpack_a_metadata_field_from_etree(xml)
+        assert field is not None
+        assert field.value == MetadataPartyValue(name="Acme Ltd", role=None)
 
     def test_unpack_rejected(self):
         xml = etree.fromstring(
@@ -413,6 +465,8 @@ class TestMetadataUnpackContract:
             return MetadataDateValue(date(2023, 2, 3))
         if metadata_cls.key == "categories":
             return MetadataCategoryValue(name="Child", parent="Parent")
+        if metadata_cls.key == "parties":
+            return MetadataPartyValue(name="Acme Ltd", role="appellant")
         return MetadataStringValue("Sample")
 
     @staticmethod

--- a/tests/models/documents/metadata/test_metadata_materialisation.py
+++ b/tests/models/documents/metadata/test_metadata_materialisation.py
@@ -10,6 +10,7 @@ from caselawclient.models.documents.metadata.fields.field import (
     MetadataCategoryValue,
     MetadataDateValue,
     MetadataField,
+    MetadataPartyValue,
     MetadataStringValue,
 )
 from caselawclient.models.documents.metadata.fields.source import MetadataSource
@@ -242,6 +243,43 @@ class TestMaterialiseBodyClaims:
             if isinstance(claim.value, MetadataCategoryValue)
         }
         assert values == {("Child", None)}
+
+    def test_parties_materialise_body_claims(self, mock_api_client):
+        parties_xml = DocumentBodyFactory.build(
+            """
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                        xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <identification><FRBRWork>
+                            <FRBRname value="Name"/>
+                            <FRBRdate date="2023-02-03"/>
+                        </FRBRWork></identification>
+                        <proprietary>
+                            <uk:court>Court</uk:court>
+                            <uk:party role="Claimant">Jerry</uk:party>
+                            <uk:party role="Defendant">Tom</uk:party>
+                        </proprietary>
+                    </meta>
+                    <header><p/></header>
+                    <judgmentBody><decision><p/></decision></judgmentBody>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=parties_xml)
+        document.metadata.parties.materialise_body_claims()
+        document.metadata.parties.materialise_body_claims()
+
+        values = [
+            claim.value
+            for claim in document.metadata_fields.by_name("parties")
+            if isinstance(claim.value, MetadataPartyValue)
+        ]
+        assert values == [
+            MetadataPartyValue(name="Jerry", role="Claimant"),
+            MetadataPartyValue(name="Tom", role="Defendant"),
+        ]
 
 
 class TestDocumentSaveStructuredMetadataToMarklogic:

--- a/tests/models/documents/test_document_body.py
+++ b/tests/models/documents/test_document_body.py
@@ -11,6 +11,7 @@ from caselawclient.models.documents import (
 from caselawclient.models.documents.body import (
     UnparsableDate,
 )
+from caselawclient.models.documents.metadata.fields.field import MetadataPartyValue
 from caselawclient.types import DocumentCategory
 
 
@@ -213,6 +214,91 @@ class TestDocumentBody:
         )
 
         assert body.judges == ["Lord Justice Smith", "Mrs Justice Jones & Co"]
+
+    @pytest.mark.parametrize(
+        "opening_tag, closing_tag",
+        [
+            ("judgment", "judgment"),
+            ('doc name="pressSummary"', "doc"),
+        ],
+    )
+    def test_parties(self, opening_tag, closing_tag):
+        body = DocumentBody(
+            f"""
+            <akomaNtoso xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn"
+                xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <{opening_tag}>
+                    <meta>
+                        <proprietary>
+                            <uk:party role="Claimant">Jerry</uk:party>
+                            <uk:party role="Defendant">Tom</uk:party>
+                            <uk:party role="Claimant">Jerry</uk:party>
+                            <uk:party>   </uk:party>
+                            <uk:party>Unnamed Role</uk:party>
+                        </proprietary>
+                    </meta>
+                </{closing_tag}>
+            </akomaNtoso>
+        """.encode()
+        )
+
+        assert body.parties == [
+            MetadataPartyValue(name="Jerry", role="Claimant"),
+            MetadataPartyValue(name="Tom", role="Defendant"),
+            MetadataPartyValue(name="Unnamed Role"),
+        ]
+
+    def test_parties_empty_when_absent(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment>
+                    <meta><proprietary/></meta>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.parties == []
+
+    def test_parties_ignores_parties_outside_proprietary(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:party role="Claimant">Meta Party</uk:party>
+                        </proprietary>
+                    </meta>
+                    <header>
+                        <p><uk:party role="Defendant">Header Party</uk:party></p>
+                    </header>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.parties == [MetadataPartyValue(name="Meta Party", role="Claimant")]
+
+    def test_parties_flattens_nested_inline_markup(self):
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:party role="Claimant">Acme <span>Ltd</span></uk:party>
+                        </proprietary>
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """
+        )
+
+        assert body.parties == [MetadataPartyValue(name="Acme Ltd", role="Claimant")]
 
     @pytest.mark.parametrize(
         "opening_tag, closing_tag",

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -388,6 +388,51 @@ class TestPartiesMetadata:
         assert claims[0].value == MetadataPartyValue(name="Jerry", role="Claimant")
 
 
+class TestHeadnoteSummaryMetadata:
+    def test_headnote_summary_is_optional_string_key(self):
+        from caselawclient.models.documents.metadata.types.headnote_summary import HeadnoteSummaryMetadata
+
+        assert issubclass(HeadnoteSummaryMetadata, SingleMetadata)
+        assert HeadnoteSummaryMetadata.key == "headnote_summary"
+        assert HeadnoteSummaryMetadata.editable is True
+
+    def test_headnote_summary_none_when_no_claims(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert document.metadata.headnote_summary.value is None
+
+    def test_headnote_summary_prefers_claim_value(self, mock_api_client):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataStringValue
+        from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="headnote_summary",
+                value=MetadataStringValue("  Short headnote  "),
+                source=MetadataSource.EXTERNAL,
+                id=str(uuid4()),
+                timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+        )
+
+        assert document.metadata.headnote_summary.value == "Short headnote"
+
+    def test_headnote_summary_materialise_body_claims_is_noop(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata.headnote_summary.materialise_body_claims()
+
+        assert document.metadata_fields.by_name("headnote_summary") == []
+
+
 class TestDocumentMetadata:
     def test_factory_built_document_metadata_exposes_typed_facades(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -396,6 +441,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.categories import CategoriesMetadata
         from caselawclient.models.documents.metadata.types.court import CourtMetadata
         from caselawclient.models.documents.metadata.types.date import DateMetadata
+        from caselawclient.models.documents.metadata.types.headnote_summary import HeadnoteSummaryMetadata
         from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
         from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
         from caselawclient.models.documents.metadata.types.name import NameMetadata
@@ -412,6 +458,7 @@ class TestDocumentMetadata:
         assert isinstance(document.metadata.categories, CategoriesMetadata)
         assert isinstance(document.metadata.judges, JudgesMetadata)
         assert isinstance(document.metadata.parties, PartiesMetadata)
+        assert isinstance(document.metadata.headnote_summary, HeadnoteSummaryMetadata)
         assert document.metadata.title.value == "Judgment v Judgement"
         assert document.metadata.court.value == "Court of Testing"
 

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -225,6 +225,169 @@ class TestJudgesMetadata:
         assert document.metadata.judges.values == document.body.judges
 
 
+class TestPartiesMetadata:
+    def test_parties_metadata_is_multiple_with_parties_key(self):
+        from caselawclient.models.documents.metadata.types.parties import PartiesMetadata
+
+        assert issubclass(PartiesMetadata, MultipleMetadata)
+        assert PartiesMetadata.key == "parties"
+        assert PartiesMetadata.editable is True
+
+    def test_parties_empty_when_no_claims_and_no_body_parties(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert document.metadata.parties.values == []
+        assert document.metadata.parties.values == document.body.parties
+
+    def test_parties_metadata_values_match_document_body(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.body import DocumentBody
+        from caselawclient.models.documents.metadata.fields.field import MetadataPartyValue
+
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:party role="Claimant">Jerry</uk:party>
+                            <uk:party role="Defendant">Tom</uk:party>
+                        </proprietary>
+                    </meta>
+                    <header><p/></header>
+                    <judgmentBody><decision><p/></decision></judgmentBody>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=body)
+        assert document.metadata.parties.values == [
+            MetadataPartyValue(name="Jerry", role="Claimant"),
+            MetadataPartyValue(name="Tom", role="Defendant"),
+        ]
+        assert document.metadata.parties.values == document.body.parties
+
+    def test_parties_values_from_active_claims_across_sources(self, mock_api_client):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.fields.collection import MetadataFieldAddResult
+        from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataPartyValue
+        from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        timestamp = datetime(2025, 1, 1, tzinfo=UTC)
+        document_party = MetadataPartyValue(name="Doc Party", role="respondent")
+        external_party = MetadataPartyValue(name="Ext Party", role="appellant")
+
+        assert (
+            document.metadata_fields.add(
+                MetadataField(
+                    name="parties",
+                    value=document_party,
+                    source=MetadataSource.DOCUMENT,
+                    id=str(uuid4()),
+                    timestamp=timestamp,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            document.metadata_fields.add(
+                MetadataField(
+                    name="parties",
+                    value=external_party,
+                    source=MetadataSource.EXTERNAL,
+                    id=str(uuid4()),
+                    timestamp=timestamp,
+                )
+            )
+            is MetadataFieldAddResult.ADDED
+        )
+        assert (
+            document.metadata_fields.add(
+                MetadataField(
+                    name="parties",
+                    value=external_party,
+                    source=MetadataSource.EXTERNAL,
+                    id=str(uuid4()),
+                    timestamp=timestamp,
+                )
+            )
+            is MetadataFieldAddResult.ALREADY_PRESENT
+        )
+
+        assert document.metadata.parties.values == [document_party, external_party]
+
+    def test_parties_facade_dedupes_same_party_across_sources(self, mock_api_client):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataPartyValue
+        from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        timestamp = datetime(2025, 1, 1, tzinfo=UTC)
+        shared = MetadataPartyValue(name="Acme Ltd", role="appellant")
+
+        document.metadata_fields.add(
+            MetadataField(
+                name="parties",
+                value=shared,
+                source=MetadataSource.DOCUMENT,
+                id=str(uuid4()),
+                timestamp=timestamp,
+            )
+        )
+        document.metadata_fields.add(
+            MetadataField(
+                name="parties",
+                value=shared,
+                source=MetadataSource.EXTERNAL,
+                id=str(uuid4()),
+                timestamp=timestamp,
+            )
+        )
+
+        assert len(document.metadata_fields.by_name("parties")) == 2
+        assert document.metadata.parties.values == [shared]
+
+    def test_parties_materialise_body_claims_yanks_body_parties(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.body import DocumentBody
+        from caselawclient.models.documents.metadata.fields.field import MetadataPartyValue
+        from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+        body = DocumentBody(
+            b"""
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+                xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                <judgment>
+                    <meta>
+                        <proprietary>
+                            <uk:party role="Claimant">Jerry</uk:party>
+                        </proprietary>
+                    </meta>
+                    <header><p/></header>
+                    <judgmentBody><decision><p/></decision></judgmentBody>
+                </judgment>
+            </akomaNtoso>
+            """
+        )
+        document = DocumentFactory.build(api_client=mock_api_client, body=body)
+        document.metadata.parties.materialise_body_claims()
+
+        claims = document.metadata_fields.by_name("parties")
+        assert len(claims) == 1
+        assert claims[0].source is MetadataSource.DOCUMENT
+        assert claims[0].value == MetadataPartyValue(name="Jerry", role="Claimant")
+
+
 class TestDocumentMetadata:
     def test_factory_built_document_metadata_exposes_typed_facades(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -236,6 +399,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.judges import JudgesMetadata
         from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
         from caselawclient.models.documents.metadata.types.name import NameMetadata
+        from caselawclient.models.documents.metadata.types.parties import PartiesMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
@@ -247,6 +411,7 @@ class TestDocumentMetadata:
         assert isinstance(document.metadata.case_number, CaseNumberMetadata)
         assert isinstance(document.metadata.categories, CategoriesMetadata)
         assert isinstance(document.metadata.judges, JudgesMetadata)
+        assert isinstance(document.metadata.parties, PartiesMetadata)
         assert document.metadata.title.value == "Judgment v Judgement"
         assert document.metadata.court.value == "Court of Testing"
 

--- a/tests/models/documents/test_document_metadata.py
+++ b/tests/models/documents/test_document_metadata.py
@@ -433,6 +433,51 @@ class TestHeadnoteSummaryMetadata:
         assert document.metadata_fields.by_name("headnote_summary") == []
 
 
+class TestWebArchivingLinkMetadata:
+    def test_web_archiving_link_is_optional_string_key(self):
+        from caselawclient.models.documents.metadata.types.web_archiving_link import WebArchivingLinkMetadata
+
+        assert issubclass(WebArchivingLinkMetadata, SingleMetadata)
+        assert WebArchivingLinkMetadata.key == "web_archiving_link"
+        assert WebArchivingLinkMetadata.editable is True
+
+    def test_web_archiving_link_none_when_no_claims(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+
+        assert document.metadata.web_archiving_link.value is None
+
+    def test_web_archiving_link_prefers_claim_value(self, mock_api_client):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from caselawclient.factories import DocumentFactory
+        from caselawclient.models.documents.metadata.fields.field import MetadataField, MetadataStringValue
+        from caselawclient.models.documents.metadata.fields.source import MetadataSource
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata_fields.add(
+            MetadataField(
+                name="web_archiving_link",
+                value=MetadataStringValue("  https://web.archive.org/example  "),
+                source=MetadataSource.EXTERNAL,
+                id=str(uuid4()),
+                timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+        )
+
+        assert document.metadata.web_archiving_link.value == "https://web.archive.org/example"
+
+    def test_web_archiving_link_materialise_body_claims_is_noop(self, mock_api_client):
+        from caselawclient.factories import DocumentFactory
+
+        document = DocumentFactory.build(api_client=mock_api_client)
+        document.metadata.web_archiving_link.materialise_body_claims()
+
+        assert document.metadata_fields.by_name("web_archiving_link") == []
+
+
 class TestDocumentMetadata:
     def test_factory_built_document_metadata_exposes_typed_facades(self, mock_api_client):
         from caselawclient.factories import DocumentFactory
@@ -446,6 +491,7 @@ class TestDocumentMetadata:
         from caselawclient.models.documents.metadata.types.jurisdiction import JurisdictionMetadata
         from caselawclient.models.documents.metadata.types.name import NameMetadata
         from caselawclient.models.documents.metadata.types.parties import PartiesMetadata
+        from caselawclient.models.documents.metadata.types.web_archiving_link import WebArchivingLinkMetadata
 
         document = DocumentFactory.build(api_client=mock_api_client)
 
@@ -459,6 +505,7 @@ class TestDocumentMetadata:
         assert isinstance(document.metadata.judges, JudgesMetadata)
         assert isinstance(document.metadata.parties, PartiesMetadata)
         assert isinstance(document.metadata.headnote_summary, HeadnoteSummaryMetadata)
+        assert isinstance(document.metadata.web_archiving_link, WebArchivingLinkMetadata)
         assert document.metadata.title.value == "Judgment v Judgement"
         assert document.metadata.court.value == "Court of Testing"
 


### PR DESCRIPTION
Adds the three first-class metadata keys the ingester needs so callers can build typed `MetadataField`s (DOCUMENT/EXTERNAL/EDITOR) and persist them without this client parsing JSON.

- `parties` with `MetadataPartyValue` (`<name>` / optional `<role>`)
- `headnote_summary` and `web_archiving_link` as optional string claims
- Registered facades on `document.metadata`; no body materialise yet; no `party` client alias (ingester maps JSON names)

## Jira

FCLC-2385