### PR TITLE
[FCLC-2391] allow save() to pass a version annotation payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - **Document**: add `Document.from_xml()` for in-memory construction from parser XML without MarkLogic
 - **Document**: upsert `save()` with `version_type` and `automated` parameters
+- **Document**: allow `Document.save()` to pass an optional version annotation `payload`
 - **Document**: add `document_from_xml()` helper and `mint_document_uri()`
 - **Document**: guard MarkLogic-backed APIs until `save()` completes (`DocumentNotPersistedError`)
 - **Document**: reject `from_xml()` for URIs that already exist in MarkLogic (`DocumentAlreadyExistsError`)

--- a/src/caselawclient/models/documents/__init__.py
+++ b/src/caselawclient/models/documents/__init__.py
@@ -658,6 +658,7 @@ class Document:
         *,
         version_type: VersionType = VersionType.EDIT,
         automated: bool = False,
+        payload: dict[str, Any] | None = None,
     ) -> None:
         """
         Save the document's XML representation back to MarkLogic as a new version.
@@ -667,6 +668,8 @@ class Document:
         document XML, then saves identifier and metadata properties to MarkLogic.
 
         :param message: Human-readable message describing the changes made.
+        :param payload: Optional structured data stored on the version annotation (for example TRE
+            metadata used later by restore flows).
         """
         if type(self) is Document:
             raise TypeError("Use a concrete document class such as Judgment, PressSummary, or ParserLog to save.")
@@ -675,6 +678,7 @@ class Document:
             version_type=version_type,
             automated=automated,
             message=message,
+            payload=payload,
         )
 
         self._convert_body_claims_to_structured_metadata()

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -30,99 +30,54 @@ def document_does_not_exist_in_marklogic(mock_api_client):
 class TestDocumentSave:
     """Tests for the Document.save() method."""
 
-    def test_save_calls_update_document_xml(self):
-        """Test that save() calls update_document_xml exactly once."""
+    def test_save_calls_update_document_xml(self, mock_api_client):
         uri = DocumentURIString("test/2023/101")
-        document = JudgmentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri, api_client=mock_api_client)
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "_convert_body_claims_to_structured_metadata"),
-            patch.object(document, "_validate_metadata_for_save"),
-            patch.object(document, "_validate_identifiers_for_save"),
-            patch.object(document, "_save_identifiers_to_marklogic"),
-            patch.object(document, "_save_structured_metadata_to_marklogic") as mock_save_metadata,
-        ):
-            document.save(message="Changed document")
+        document.save(message="Changed document")
 
-            mock_update.assert_called_once()
-            mock_save_metadata.assert_called_once()
+        mock_api_client.update_document_xml.assert_called_once()
+        mock_api_client.set_property.assert_called()
 
-    def test_save_creates_edit_annotation(self):
-        """Test that save() creates an EDIT annotation with automated=False."""
+    def test_save_creates_edit_annotation(self, mock_api_client):
         uri = DocumentURIString("test/2023/123")
-        document = JudgmentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri, api_client=mock_api_client)
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "_convert_body_claims_to_structured_metadata"),
-            patch.object(document, "_validate_metadata_for_save"),
-            patch.object(document, "_validate_identifiers_for_save"),
-            patch.object(document, "_save_identifiers_to_marklogic"),
-            patch.object(document, "_save_structured_metadata_to_marklogic"),
-        ):
-            document.save(message="Changed document")
+        document.save(message="Changed document")
 
-            call_args = mock_update.call_args
-            annotation = call_args[0][2]
-            assert isinstance(annotation, VersionAnnotation)
-            assert annotation.version_type == VersionType.EDIT
-            assert annotation.automated is False
+        annotation = mock_api_client.update_document_xml.call_args[0][2]
+        assert isinstance(annotation, VersionAnnotation)
+        assert annotation.version_type == VersionType.EDIT
+        assert annotation.automated is False
 
-    def test_save_passes_uri_and_xml_to_api(self):
-        """Test that save() passes the correct URI and XML to the API."""
+    def test_save_passes_uri_and_xml_to_api(self, mock_api_client):
         uri = DocumentURIString("test/2023/456")
-        document = JudgmentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri, api_client=mock_api_client)
         expected_xml = document.body.content_as_xml_tree
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "_convert_body_claims_to_structured_metadata"),
-            patch.object(document, "_validate_metadata_for_save"),
-            patch.object(document, "_validate_identifiers_for_save"),
-            patch.object(document, "_save_identifiers_to_marklogic"),
-            patch.object(document, "_save_structured_metadata_to_marklogic"),
-        ):
-            document.save(message="Changed document")
+        document.save(message="Changed document")
 
-            call_args = mock_update.call_args
-            assert call_args[0][0] == uri
-            assert call_args[0][1] is expected_xml
+        call_args = mock_api_client.update_document_xml.call_args
+        assert call_args[0][0] == uri
+        assert call_args[0][1] is expected_xml
 
-    def test_save_with_message_includes_message_in_annotation(self):
-        """Test that save() includes the message in the annotation."""
+    def test_save_with_message_includes_message_in_annotation(self, mock_api_client):
         uri = DocumentURIString("test/2023/789")
-        document = JudgmentFactory.build(uri=uri)
+        document = JudgmentFactory.build(uri=uri, api_client=mock_api_client)
         test_message = "Fixed typo in court name"
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "_convert_body_claims_to_structured_metadata"),
-            patch.object(document, "_validate_metadata_for_save"),
-            patch.object(document, "_validate_identifiers_for_save"),
-            patch.object(document, "_save_identifiers_to_marklogic"),
-            patch.object(document, "_save_structured_metadata_to_marklogic"),
-        ):
-            document.save(message=test_message)
+        document.save(message=test_message)
 
-            call_args = mock_update.call_args
-            annotation = call_args[0][2]
-            assert annotation.message == test_message
+        annotation = mock_api_client.update_document_xml.call_args[0][2]
+        assert annotation.message == test_message
 
     def test_save_validates_and_converts_before_xml_update(self, mock_api_client):
         document = JudgmentFactory.build(api_client=mock_api_client)
         call_order: list[str] = []
 
-        def track_xml(*_args, **_kwargs):
-            call_order.append("xml")
+        mock_api_client.update_document_xml.side_effect = lambda *_args, **_kwargs: call_order.append("xml")
 
         with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml", side_effect=track_xml),
             patch.object(
                 document,
                 "_convert_body_claims_to_structured_metadata",
@@ -163,11 +118,7 @@ class TestDocumentSave:
     def test_save_writes_identifiers_and_structured_metadata_to_marklogic(self, mock_api_client):
         document = JudgmentFactory.build(api_client=mock_api_client)
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml"),
-        ):
-            document.save(message="Changed document")
+        document.save(message="Changed document")
 
         mock_api_client.set_property_as_node.assert_any_call(document.uri, "identifiers", ANY)
         mock_api_client.set_property_as_node.assert_any_call(document.uri, "metadata_fields", ANY)
@@ -186,25 +137,21 @@ class TestDocumentSave:
                 "perform_all_validations",
                 return_value=SuccessFailureMessageTuple(False, ["Identifier validation failed"]),
             ),
-            patch.object(document.api_client, "insert_document_xml") as mock_insert,
             pytest.raises(IdentifierValidationException, match="Identifier validation failed"),
         ):
             document.save(message="Initial insert")
 
-        mock_insert.assert_not_called()
+        mock_api_client.insert_document_xml.assert_not_called()
         assert document.is_persisted is False
 
     def test_save_insert_path_for_ephemeral_document(self, mock_api_client):
         body = DocumentBodyFactory.build()
         document = Judgment.from_xml(body, mock_api_client, uri=DocumentURIString("d-new-doc"))
-        mock_api_client.document_exists.return_value = False
 
-        with patch.object(document.api_client, "insert_document_xml") as mock_insert:
-            document.save(message="Initial insert")
+        document.save(message="Initial insert")
 
-        mock_insert.assert_called_once()
-        call_args = mock_insert.call_args
-        assert call_args[0][2] is Judgment
+        mock_api_client.insert_document_xml.assert_called_once()
+        assert mock_api_client.insert_document_xml.call_args[0][2] is Judgment
         assert document.is_persisted is True
 
     def test_save_raises_when_unpersisted_and_uri_already_exists(self, mock_api_client):
@@ -240,10 +187,8 @@ class TestDocumentSave:
 
     def test_is_persisted_true_after_save(self, mock_api_client):
         document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
-        mock_api_client.document_exists.return_value = False
 
-        with patch.object(document.api_client, "insert_document_xml"):
-            document.save(message="Initial insert")
+        document.save(message="Initial insert")
 
         assert document.is_persisted is True
 
@@ -266,22 +211,13 @@ class TestDocumentSave:
     def test_save_passes_custom_version_type_and_automated(self, mock_api_client):
         document = JudgmentFactory.build(api_client=mock_api_client)
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document, "_convert_body_claims_to_structured_metadata"),
-            patch.object(document, "_validate_metadata_for_save"),
-            patch.object(document, "_validate_identifiers_for_save"),
-            patch.object(document, "_save_identifiers_to_marklogic"),
-            patch.object(document, "_save_structured_metadata_to_marklogic"),
-        ):
-            document.save(
-                message="Re-parsed",
-                version_type=VersionType.SUBMISSION,
-                automated=True,
-            )
+        document.save(
+            message="Re-parsed",
+            version_type=VersionType.SUBMISSION,
+            automated=True,
+        )
 
-        annotation = mock_update.call_args[0][2]
+        annotation = mock_api_client.update_document_xml.call_args[0][2]
         assert annotation.version_type == VersionType.SUBMISSION
         assert annotation.automated is True
 
@@ -313,10 +249,8 @@ class TestDocumentSave:
 
     def test_partial_save_failure_leaves_document_persisted_after_insert(self, mock_api_client):
         document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
-        mock_api_client.document_exists.return_value = False
 
         with (
-            patch.object(document.api_client, "insert_document_xml"),
             patch.object(
                 document,
                 "_save_structured_metadata_to_marklogic",
@@ -330,10 +264,8 @@ class TestDocumentSave:
 
     def test_save_retry_after_metadata_persist_failure_uses_update_path(self, mock_api_client):
         document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
-        mock_api_client.document_exists.return_value = False
 
         with (
-            patch.object(document.api_client, "insert_document_xml"),
             patch.object(
                 document,
                 "_save_structured_metadata_to_marklogic",
@@ -343,16 +275,10 @@ class TestDocumentSave:
         ):
             document.save(message="Initial insert")
 
-        mock_api_client.document_exists.return_value = True
+        document.save(message="Retry save")
 
-        with (
-            patch.object(document.api_client, "update_document_xml") as mock_update,
-            patch.object(document.api_client, "insert_document_xml") as mock_insert,
-        ):
-            document.save(message="Retry save")
-
-        mock_update.assert_called_once()
-        mock_insert.assert_not_called()
+        mock_api_client.update_document_xml.assert_called_once()
+        mock_api_client.insert_document_xml.assert_called_once()
         assert document.is_persisted is True
 
     def test_reparse_body_swap_retains_existing_metadata_fields(self, mock_api_client):
@@ -368,11 +294,7 @@ class TestDocumentSave:
 
         document.body = DocumentBodyFactory.build(name="Updated title")
 
-        with (
-            patch.object(document.api_client, "document_exists", return_value=True),
-            patch.object(document.api_client, "update_document_xml"),
-        ):
-            document.save(message="Re-parsed body")
+        document.save(message="Re-parsed body")
 
         assert existing_claim in document.metadata_fields.values()
         title_claims = document.metadata_fields.by_name("title")

--- a/tests/models/documents/test_document_save.py
+++ b/tests/models/documents/test_document_save.py
@@ -285,6 +285,32 @@ class TestDocumentSave:
         assert annotation.version_type == VersionType.SUBMISSION
         assert annotation.automated is True
 
+    def test_save_passes_payload_on_update(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
+        payload = {"tre_raw_metadata": {"parameters": {"TRE": {"reference": "TDR-2024-ABC"}}}}
+
+        document.save(message="Updated document", payload=payload)
+
+        annotation = mock_api_client.update_document_xml.call_args[0][2]
+        assert annotation.payload == payload
+
+    def test_save_passes_payload_on_insert(self, mock_api_client):
+        document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
+        payload = {"tre_raw_metadata": {"parameters": {"TRE": {"reference": "TDR-2024-XYZ"}}}}
+
+        document.save(message="New document", payload=payload)
+
+        annotation = mock_api_client.insert_document_xml.call_args[0][3]
+        assert annotation.payload == payload
+
+    def test_save_without_payload_leaves_annotation_payload_none(self, mock_api_client):
+        document = JudgmentFactory.build(api_client=mock_api_client)
+
+        document.save(message="Changed document")
+
+        annotation = mock_api_client.update_document_xml.call_args[0][2]
+        assert annotation.payload is None
+
     def test_partial_save_failure_leaves_document_persisted_after_insert(self, mock_api_client):
         document = Judgment.from_xml(DocumentBodyFactory.build(), mock_api_client)
         mock_api_client.document_exists.return_value = False


### PR DESCRIPTION
`Document.save()` already accepts `version_type` and `automated`, but it never forwarded a version annotation payload. Ingester (and restore) rely on that payload for `tre_raw_metadata`.

This adds an optional keyword-only `payload=` argument and passes it through to `VersionAnnotation`. When omitted, behaviour is unchanged.