### PR TITLE
bump: version 49.1.1 → 50.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog 1.0.0].
 
-## Unreleased
+## v50.0.0 (2026-09-10)
 
 ### BREAKING CHANGE
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ds-caselaw-marklogic-api-client"
-version = "49.1.1"
+version = "50.0.0"
 description = "An API client for interacting with the underlying data in Find Caselaw."
 authors = ["The National Archives"]
 homepage = "https://github.com/nationalarchives/ds-caselaw-custom-api-client"


### PR DESCRIPTION
### BREAKING CHANGE

- `Document.save()` on a URI that does not yet exist in MarkLogic now inserts the document instead of failing on update
- Use document.metadata.title / .judges (etc), not
  metadata["title"]. DocumentMetadata is not a dict and has no get/keys/
  values/in. Legacy name/judge keys are gone.
- Date metadata claim values are `datetime.date`, not `str`.
- Claim payloads are structured `MetadataStringValue` /
  `MetadataDateValue` / `MetadataCategoryValue` / `MetadataPartyValue`,
  not bare `str` / `date`.
- `metadata_fields.add` / `__setitem__` are idempotent: matching
  name/value/source is a noop (including rejected); id collision with a
  different payload raises; unknown claim names and wrong value types
  raise; empty values raise. `add` returns whether the claim was added
  or already present. Duplicate claims are also deduped on unpack.
  Key/id mismatch raises. `validate_metadata_fields` / key-id validation
  on save is removed.

### Feat

- **Document**: add `Document.from_xml()` for in-memory construction from parser XML without MarkLogic
- **Document**: upsert `save()` with `version_type` and `automated` parameters
- **Document**: allow `Document.save()` to pass an optional version annotation `payload`
- **Document**: add `document_from_xml()` helper and `mint_document_uri()`
- **Document**: guard MarkLogic-backed APIs until `save()` completes (`DocumentNotPersistedError`)
- **Document**: reject `from_xml()` for URIs that already exist in MarkLogic (`DocumentAlreadyExistsError`)
- **Document**: validate identifier IDs before upserting document XML during `save()`
- **Document**: persist identifiers and structured metadata properties after upserting document XML during `save()`
- **Metadata**: wrap all claim values in structured Metadata\*Value types
- **Metadata**: per-type pack/unpack with date claims as date
- **Metadata**: expose DocumentMetadata as typed attribute facades
- **Metadata**: idempotent MetadataFieldsCollection.add
- **Metadata**: add parties claims with MetadataPartyValue; materialise `uk:party` from the body XML
- **Metadata**: add headnote_summary claims
- **Metadata**: add web_archiving_link claims

### Fix

- Fix `Judgment` and `PressSummary` constructors to pass `api_client` explicitly through `NeutralCitationMixin`
- Wrap query text with multiple words in a single `<mark>` tag, rather than each individual text in it's own mark tag
- **Metadata**: harden claim unpack (strip text, validate pack_version)

### Refactor

- **Metadata**: require each metadata type to declare its own LOGIC_VERSION
- **Metadata**: drop MetadataAttributeKey from the registry
- **Metadata**: centralise METADATA_FIELD_CLASSES in the registry